### PR TITLE
chore: update element internal force sign and remove pNewDT and stepTime

### DIFF
--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
@@ -135,15 +135,14 @@ public:
    * @param[out] K Stiffness matrix.
    * @param[in] time Current time.
    * @param[in] dT Time step size.
-   * @param[out] pNewdT Suggested new time step size.
+   * @param[in] dT Time step size.
    */
   virtual void computeYourself( const double* QTotal,
                                 const double* dQ,
                                 double*       Pint,
                                 double*       K,
                                 const double* time,
-                                double        dT,
-                                double&       pNewdT ) = 0;
+                                double        dT ) = 0;
 
   /**
    * @brief Perform element computations for explicit time integration.
@@ -152,7 +151,6 @@ public:
    * @param[out] Pint Internal force vector.
    * @param[in] time Current time.
    * @param[in] dT Time step size.
-   * @param[out] pNewdT Suggested new time step size.
    *
    * @note Default implementation throws an exception.
    */
@@ -160,8 +158,7 @@ public:
                                         const double* dQ,
                                         double*       Pint,
                                         const double* time,
-                                        double        dT,
-                                        double&       pNewdT )
+                                        double        dT )
   {
     throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
   };

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
@@ -135,14 +135,13 @@ public:
    * @param[out] K Stiffness matrix.
    * @param[in] time Current time.
    * @param[in] dT Time step size.
-   * @param[in] dT Time step size.
    */
-  virtual void computeYourself( const double* QTotal,
-                                const double* dQ,
-                                double*       Pint,
-                                double*       K,
-                                const double* time,
-                                double        dT ) = 0;
+  virtual void computeKernels( const double* QTotal,
+                               const double* dQ,
+                               double*       Pint,
+                               double*       K,
+                               double        time,
+                               double        dT ) = 0;
 
   /**
    * @brief Perform element computations for explicit time integration.
@@ -154,11 +153,7 @@ public:
    *
    * @note Default implementation throws an exception.
    */
-  virtual void computeYourselfExplicit( const double* QTotal,
-                                        const double* dQ,
-                                        double*       Pint,
-                                        const double* time,
-                                        double        dT )
+  virtual void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pint, double time, double dT )
   {
     throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
   };
@@ -179,7 +174,7 @@ public:
                                        int                  elementFace,
                                        const double*        load,
                                        const double*        QTotal,
-                                       const double*        time,
+                                       double               time,
                                        double               dT ) = 0;
 
   /**
@@ -195,7 +190,7 @@ public:
                                  double*       K,
                                  const double* load,
                                  const double* QTotal,
-                                 const double* time,
+                                 double        time,
                                  double        dT ) = 0;
 
   /**

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
@@ -117,15 +117,8 @@ public:
    * @param[out] Ke      Stiffness matrix in the ambient space.
    * @param[in]  time    Current time.
    * @param[in]  dT      Time step size.
-   * @param[out] pNewdT  Suggested new time step size.
    */
-  void computeYourself( const double* QTotal,
-                        const double* dQ,
-                        double*       Pe,
-                        double*       Ke,
-                        const double* time,
-                        double        dT,
-                        double&       pNewdT );
+  void computeYourself( const double* QTotal, const double* dQ, double* Pe, double* Ke, const double* time, double dT );
 
   /// @copydoc MarmotElement::setInitialConditions
   void setInitialConditions( StateTypes state, const double* values );

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
@@ -118,7 +118,7 @@ public:
    * @param[in]  time    Current time.
    * @param[in]  dT      Time step size.
    */
-  void computeYourself( const double* QTotal, const double* dQ, double* Pe, double* Ke, const double* time, double dT );
+  void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
   /// @copydoc MarmotElement::setInitialConditions
   void setInitialConditions( StateTypes state, const double* values );
@@ -140,7 +140,7 @@ public:
                                int                  elementFace,
                                const double*        load,
                                const double*        QTotal,
-                               const double*        time,
+                               double               time,
                                double               dT );
 
   /**
@@ -152,12 +152,7 @@ public:
    * @param[in]  time   Current time.
    * @param[in]  dT     Time step size.
    */
-  void computeBodyForce( double*       P,
-                         double*       K,
-                         const double* load,
-                         const double* QTotal,
-                         const double* time,
-                         double        dT );
+  void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
 
   /// @copydoc MarmotElement::getStateView
   StateView getStateView( const std::string& stateName, int quadraturePoint );

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
@@ -149,8 +149,7 @@ void MarmotElementSpatialWrapper::computeYourself( const double* Q,
                                                    double*       Pe_,
                                                    double*       Ke_,
                                                    const double* time,
-                                                   double        dT,
-                                                   double&       pNewDT )
+                                                   double        dT )
 {
   Map< const VectorXd > Q_Unprojected( Q, unprojectedSize );
   Map< const VectorXd > dQ_Unprojected( dQ, unprojectedSize );
@@ -161,16 +160,8 @@ void MarmotElementSpatialWrapper::computeYourself( const double* Q,
   VectorXd Pe_Projected = VectorXd::Zero( projectedSize );
   MatrixXd Ke_Projected = MatrixXd::Zero( projectedSize, projectedSize );
 
-  childElement->computeYourself( Q_Projected.data(),
-                                 dQ_Projected.data(),
-                                 Pe_Projected.data(),
-                                 Ke_Projected.data(),
-                                 time,
-                                 dT,
-                                 pNewDT );
-
-  if ( pNewDT < 1.0 )
-    return;
+  childElement
+    ->computeYourself( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
 
   Map< VectorXd > Pe_Unprojected( Pe_, unprojectedSize );
   Map< MatrixXd > Ke_Unprojected( Ke_, unprojectedSize, unprojectedSize );

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
@@ -144,12 +144,12 @@ void MarmotElementSpatialWrapper::assignNodeCoordinates( const double* coordinat
   childElement->assignNodeCoordinates( projectedCoordinates.data() );
 }
 
-void MarmotElementSpatialWrapper::computeYourself( const double* Q,
-                                                   const double* dQ,
-                                                   double*       Pe_,
-                                                   double*       Ke_,
-                                                   const double* time,
-                                                   double        dT )
+void MarmotElementSpatialWrapper::computeKernels( const double* Q,
+                                                  const double* dQ,
+                                                  double*       Pe_,
+                                                  double*       Ke_,
+                                                  double        time,
+                                                  double        dT )
 {
   Map< const VectorXd > Q_Unprojected( Q, unprojectedSize );
   Map< const VectorXd > dQ_Unprojected( dQ, unprojectedSize );
@@ -161,7 +161,7 @@ void MarmotElementSpatialWrapper::computeYourself( const double* Q,
   MatrixXd Ke_Projected = MatrixXd::Zero( projectedSize, projectedSize );
 
   childElement
-    ->computeYourself( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
+    ->computeKernels( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
 
   Map< VectorXd > Pe_Unprojected( Pe_, unprojectedSize );
   Map< MatrixXd > Ke_Unprojected( Ke_, unprojectedSize, unprojectedSize );
@@ -181,7 +181,7 @@ void MarmotElementSpatialWrapper::computeDistributedLoad( DistributedLoadTypes l
                                                           int                  elementFace,
                                                           const double*        load,
                                                           const double*        QTotal,
-                                                          const double*        time,
+                                                          double               time,
                                                           double               dT )
 {
   VectorXd P_Projected = VectorXd::Zero( projectedSize );
@@ -201,7 +201,7 @@ void MarmotElementSpatialWrapper::computeBodyForce( double*       P_,
                                                     double*       K,
                                                     const double* load,
                                                     const double* QTotal,
-                                                    const double* time,
+                                                    double        time,
                                                     double        dT )
 {
   VectorXd P_Projected = VectorXd::Zero( projectedSize );

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotUtility.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotUtility.h
@@ -32,16 +32,4 @@
  */
 
 namespace Marmot {
-  /**
-   * @brief Signals that the current increment should be discarded.
-   *
-   * Sets @p pNewDT to the requested @p value and prints a warning message.
-   * Intended to be called inside material routines when convergence cannot
-   * be achieved, instructing the host code to restart with a smaller step.
-   *
-   * @param pNewDT   Output parameter: suggested new time-step size.
-   * @param value    Suggested value for the new time-step size.
-   * @param message  Human-readable reason for discarding the increment.
-   */
-  void discardTheIncrement( double& pNewDT, double value, const std::string& message );
 } // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/src/MarmotUtility.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotUtility.cpp
@@ -5,11 +5,4 @@
 
 namespace Marmot {
 
-  void discardTheIncrement( double& pNewDT, double value, const std::string& message )
-  {
-    pNewDT = value;
-    MarmotJournal::warningToMSG( message );
-    return;
-  }
-
 } // namespace Marmot

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -251,7 +251,7 @@ namespace Marmot::Elements {
                                  const int                           elementFace,
                                  const double*                       load,
                                  const double*                       QTotal,
-                                 const double*                       time,
+                                 double                              time,
                                  double                              dT );
 
     /**
@@ -259,12 +259,7 @@ namespace Marmot::Elements {
      * @details Integrates \f$\mathbf{P}_e^{(b)} = \int_{\Omega_e} \mathbf{N}^\mathsf{T} \mathbf{f}\,
      * \mathrm{d}\Omega\f$.
      */
-    void computeBodyForce( double*       P,
-                           double*       K,
-                           const double* load,
-                           const double* QTotal,
-                           const double* time,
-                           double        dT );
+    void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
 
     /**
      * @brief Compute internal force and consistent tangent stiffness.
@@ -282,12 +277,7 @@ namespace Marmot::Elements {
      * @param time Time data forwarded to materials.
      * @param dT Time increment.
      */
-    void computeYourself( const double* QTotal,
-                          const double* dQ,
-                          double*       Pe,
-                          double*       Ke,
-                          const double* time,
-                          double        dT );
+    void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
     /**
      * @brief Compute internal force only (no tangent stiffness).
@@ -302,7 +292,7 @@ namespace Marmot::Elements {
      * @param time Time data forwarded to materials.
      * @param dT Time increment.
      */
-    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
+    void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pe, double time, double dT );
     /**
      * @brief Compute consistent mass matrix using material density.
      * @details \f$\mathbf{M}_e = \sum_{qp} \rho\, \mathbf{N}^\mathsf{T}\mathbf{N}\, J_0 w\f$.
@@ -488,12 +478,12 @@ namespace Marmot::Elements {
   }
 
   template < int nDim, int nNodes >
-  void DisplacementFiniteElement< nDim, nNodes >::computeYourself( const double* QTotal_,
-                                                                   const double* dQ_,
-                                                                   double*       Pe_,
-                                                                   double*       Ke_,
-                                                                   const double* time,
-                                                                   double        dT )
+  void DisplacementFiniteElement< nDim, nNodes >::computeKernels( const double* QTotal_,
+                                                                  const double* dQ_,
+                                                                  double*       Pe_,
+                                                                  double*       Ke_,
+                                                                  double        time,
+                                                                  double        dT )
   {
     using namespace Marmot;
     using namespace ContinuumMechanics::VoigtNotation;
@@ -526,7 +516,7 @@ namespace Marmot::Elements {
         state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
         // set time info
-        timeInfo.time = time[1];
+        timeInfo.time = time;
         timeInfo.dT   = dT;
         qp.material->computeUniaxialStress( state, C[0], dE[0], timeInfo );
         Eigen::VectorXd stress1D( 1 );
@@ -550,7 +540,7 @@ namespace Marmot::Elements {
           state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
           // set time info
-          timeInfo.time = time[1];
+          timeInfo.time = time;
           timeInfo.dT   = dT;
           qp.material->computePlaneStress( state, C, dE, timeInfo );
           qp.managedStateVars->stress = make3DVoigt< ParentGeometryElement::voigtSize >( state.stress );
@@ -575,7 +565,7 @@ namespace Marmot::Elements {
           state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
           // set time info
-          timeInfo.time = time[1];
+          timeInfo.time = time;
           timeInfo.dT   = dT;
           qp.material->computeStress( state, C66, dE6, timeInfo );
           qp.managedStateVars->stress = state.stress;
@@ -600,7 +590,7 @@ namespace Marmot::Elements {
           state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
           // set time info
-          timeInfo.time = time[1];
+          timeInfo.time = time;
           timeInfo.dT   = dT;
           qp.material->computeStress( state, C, dE, timeInfo );
           qp.managedStateVars->stress = state.stress;
@@ -621,11 +611,11 @@ namespace Marmot::Elements {
   }
 
   template < int nDim, int nNodes >
-  void DisplacementFiniteElement< nDim, nNodes >::computeYourselfExplicit( const double* QTotal_,
-                                                                           const double* dQ_,
-                                                                           double*       Pe_,
-                                                                           const double* time,
-                                                                           double        dT )
+  void DisplacementFiniteElement< nDim, nNodes >::computeKernelsExplicit( const double* QTotal_,
+                                                                          const double* dQ_,
+                                                                          double*       Pe_,
+                                                                          double        time,
+                                                                          double        dT )
   {
     using namespace Marmot;
     using namespace ContinuumMechanics::VoigtNotation;
@@ -664,7 +654,7 @@ namespace Marmot::Elements {
           state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
           // set time info
-          timeInfo.time = time[1];
+          timeInfo.time = time;
           timeInfo.dT   = dT;
           Matrix3d C    = Matrix3d::Zero();
           qp.material->computePlaneStress( state, C, dE, timeInfo );
@@ -689,7 +679,7 @@ namespace Marmot::Elements {
           state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
           // set time info
-          timeInfo.time = time[1];
+          timeInfo.time = time;
           timeInfo.dT   = dT;
           qp.material->computeStressExplicit( state, dE6, timeInfo );
           qp.managedStateVars->stress = state.stress;
@@ -713,7 +703,7 @@ namespace Marmot::Elements {
           state.stateVars            = qp.managedStateVars->materialStateVars.data();
 
           // set time info
-          timeInfo.time = time[1];
+          timeInfo.time = time;
           timeInfo.dT   = dT;
           qp.material->computeStressExplicit( state, dE, timeInfo );
           qp.managedStateVars->stress = state.stress;
@@ -773,7 +763,7 @@ namespace Marmot::Elements {
                                                                           const int     elementFace,
                                                                           const double* load,
                                                                           const double* QTotal,
-                                                                          const double* time,
+                                                                          double        time,
                                                                           double        dT )
   {
     Map< RhsSized > fU( P );
@@ -818,7 +808,7 @@ namespace Marmot::Elements {
                                                                     double*       K,
                                                                     const double* load,
                                                                     const double* QTotal,
-                                                                    const double* time,
+                                                                    double        time,
                                                                     double        dT )
   {
     Map< RhsSized >                              Pe( P_ );

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -281,15 +281,13 @@ namespace Marmot::Elements {
      * @param Ke Tangent stiffness matrix (accumulated).
      * @param time Time data forwarded to materials.
      * @param dT Time increment.
-     * @param pNewdT Suggested scaling of dT by the material; if reduced (<1), the routine returns early.
      */
     void computeYourself( const double* QTotal,
                           const double* dQ,
                           double*       Pe,
                           double*       Ke,
                           const double* time,
-                          double        dT,
-                          double&       pNewdT );
+                          double        dT );
 
     /**
      * @brief Compute internal force only (no tangent stiffness).
@@ -298,20 +296,13 @@ namespace Marmot::Elements {
      * \f[
      * \mathbf{P}_e = \sum_{qp} \mathbf{B}^\mathsf{T} \boldsymbol{\sigma}\, J_0 w.
      * \f]
-     * If pNewdT<1, the routine returns early to signal time step reduction.
      * @param QTotal Total displacement vector.
      * @param dQ Incremental displacement.
      * @param Pe Internal force vector (accumulated).
      * @param time Time data forwarded to materials.
      * @param dT Time increment.
-     * @param pNewdT Suggested scaling of dT by the material; if reduced (<1), the routine returns early.
      */
-    void computeYourselfExplicit( const double* QTotal,
-                                  const double* dQ,
-                                  double*       Pe,
-                                  const double* time,
-                                  double        dT,
-                                  double&       pNewdT );
+    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
     /**
      * @brief Compute consistent mass matrix using material density.
      * @details \f$\mathbf{M}_e = \sum_{qp} \rho\, \mathbf{N}^\mathsf{T}\mathbf{N}\, J_0 w\f$.
@@ -502,8 +493,7 @@ namespace Marmot::Elements {
                                                                    double*       Pe_,
                                                                    double*       Ke_,
                                                                    const double* time,
-                                                                   double        dT,
-                                                                   double&       pNewDT )
+                                                                   double        dT )
   {
     using namespace Marmot;
     using namespace ContinuumMechanics::VoigtNotation;
@@ -538,13 +528,7 @@ namespace Marmot::Elements {
         // set time info
         timeInfo.time = time[1];
         timeInfo.dT   = dT;
-        try {
-          qp.material->computeUniaxialStress( state, C[0], dE[0], timeInfo );
-        }
-        catch ( const Marmot::StressUpdateFailed& e ) {
-          pNewDT = 0.5;
-          return;
-        }
+        qp.material->computeUniaxialStress( state, C[0], dE[0], timeInfo );
         Eigen::VectorXd stress1D( 1 );
         stress1D( 0 )               = state.stress;
         qp.managedStateVars->stress = make3DVoigt< ParentGeometryElement::voigtSize >( stress1D );
@@ -568,13 +552,7 @@ namespace Marmot::Elements {
           // set time info
           timeInfo.time = time[1];
           timeInfo.dT   = dT;
-          try {
-            qp.material->computePlaneStress( state, C, dE, timeInfo );
-          }
-          catch ( const Marmot::StressUpdateFailed& e ) {
-            pNewDT = 0.5;
-            return;
-          }
+          qp.material->computePlaneStress( state, C, dE, timeInfo );
           qp.managedStateVars->stress = make3DVoigt< ParentGeometryElement::voigtSize >( state.stress );
           S                           = state.stress;
           elasticEnergyDensity        = state.elasticEnergyDensity;
@@ -599,13 +577,7 @@ namespace Marmot::Elements {
           // set time info
           timeInfo.time = time[1];
           timeInfo.dT   = dT;
-          try {
-            qp.material->computeStress( state, C66, dE6, timeInfo );
-          }
-          catch ( const Marmot::StressUpdateFailed& e ) {
-            pNewDT = 0.5;
-            return;
-          }
+          qp.material->computeStress( state, C66, dE6, timeInfo );
           qp.managedStateVars->stress = state.stress;
 
           S                    = reduce3DVoigt< ParentGeometryElement::voigtSize >( state.stress );
@@ -630,13 +602,7 @@ namespace Marmot::Elements {
           // set time info
           timeInfo.time = time[1];
           timeInfo.dT   = dT;
-          try {
-            qp.material->computeStress( state, C, dE, timeInfo );
-          }
-          catch ( const Marmot::StressUpdateFailed& e ) {
-            pNewDT = 0.5;
-            return;
-          }
+          qp.material->computeStress( state, C, dE, timeInfo );
           qp.managedStateVars->stress = state.stress;
           S                           = state.stress;
           elasticEnergyDensity        = state.elasticEnergyDensity;
@@ -650,7 +616,7 @@ namespace Marmot::Elements {
       qp.managedStateVars->strain += make3DVoigt< ParentGeometryElement::voigtSize >( dE );
 
       Ke += B.transpose() * C * B * qp.J0xW;
-      Pe -= B.transpose() * S * qp.J0xW;
+      Pe += B.transpose() * S * qp.J0xW;
     }
   }
 
@@ -659,8 +625,7 @@ namespace Marmot::Elements {
                                                                            const double* dQ_,
                                                                            double*       Pe_,
                                                                            const double* time,
-                                                                           double        dT,
-                                                                           double&       pNewDT )
+                                                                           double        dT )
   {
     using namespace Marmot;
     using namespace ContinuumMechanics::VoigtNotation;
@@ -702,13 +667,7 @@ namespace Marmot::Elements {
           timeInfo.time = time[1];
           timeInfo.dT   = dT;
           Matrix3d C    = Matrix3d::Zero();
-          try {
-            qp.material->computePlaneStress( state, C, dE, timeInfo );
-          }
-          catch ( const StressUpdateFailed& e ) {
-            pNewDT = 0.5;
-            return;
-          }
+          qp.material->computePlaneStress( state, C, dE, timeInfo );
           qp.managedStateVars->stress = make3DVoigt< ParentGeometryElement::voigtSize >( state.stress );
           S                           = state.stress;
           elasticEnergyDensity        = state.elasticEnergyDensity;
@@ -732,13 +691,7 @@ namespace Marmot::Elements {
           // set time info
           timeInfo.time = time[1];
           timeInfo.dT   = dT;
-          try {
-            qp.material->computeStressExplicit( state, dE6, timeInfo );
-          }
-          catch ( const Marmot::StressUpdateFailed& e ) {
-            pNewDT = 0.5;
-            return;
-          }
+          qp.material->computeStressExplicit( state, dE6, timeInfo );
           qp.managedStateVars->stress = state.stress;
 
           S                    = reduce3DVoigt< ParentGeometryElement::voigtSize >( state.stress );
@@ -762,13 +715,7 @@ namespace Marmot::Elements {
           // set time info
           timeInfo.time = time[1];
           timeInfo.dT   = dT;
-          try {
-            qp.material->computeStressExplicit( state, dE, timeInfo );
-          }
-          catch ( const Marmot::StressUpdateFailed& e ) {
-            pNewDT = 0.5;
-            return;
-          }
+          qp.material->computeStressExplicit( state, dE, timeInfo );
           qp.managedStateVars->stress = state.stress;
           S                           = state.stress;
           elasticEnergyDensity        = state.elasticEnergyDensity;
@@ -781,7 +728,7 @@ namespace Marmot::Elements {
       qp.managedStateVars->totalStrainEnergy   = ( elasticEnergyDensity + dissipation ) * qp.J0xW;
       qp.managedStateVars->strain += make3DVoigt< ParentGeometryElement::voigtSize >( dE );
 
-      Pe -= B.transpose() * S * qp.J0xW;
+      Pe += B.transpose() * S * qp.J0xW;
     }
   }
   template < int nDim, int nNodes >

--- a/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
+++ b/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
@@ -112,10 +112,8 @@ void testStiffnessMatrixCalculationPlaneStress()
 
   double currentTime = 0.0;
   double dt          = 1.0; // Dummy time step (not critical for linear elastic stiffness)
-  double pNewDT      = 1.0; // Placeholder for adaptive time stepping (not used here)
-
   // Compute the stiffness matrix K and internal force vector P
-  element->computeYourself( u.data(), dQ.data(), P.data(), K.data(), &currentTime, dt, pNewDT );
+  element->computeYourself( u.data(), dQ.data(), P.data(), K.data(), &currentTime, dt );
 
   // --- Stiffness Matrix Checks ---
   // The stiffness matrix K should be symmetric for linear elastic materials.

--- a/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
+++ b/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
@@ -113,7 +113,7 @@ void testStiffnessMatrixCalculationPlaneStress()
   double currentTime = 0.0;
   double dt          = 1.0; // Dummy time step (not critical for linear elastic stiffness)
   // Compute the stiffness matrix K and internal force vector P
-  element->computeYourself( u.data(), dQ.data(), P.data(), K.data(), &currentTime, dt );
+  element->computeKernels( u.data(), dQ.data(), P.data(), K.data(), currentTime, dt );
 
   // --- Stiffness Matrix Checks ---
   // The stiffness matrix K should be symmetric for linear elastic materials.

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -307,7 +307,7 @@ namespace Marmot::Elements {
                                  const int                           elementFace,
                                  const double*                       load,
                                  const double*                       QTotal,
-                                 const double*                       time,
+                                 double                              time,
                                  double                              dT );
 
     /** @brief Compute the contributions of body forces to the element residual vector and stiffness matrix
@@ -324,20 +324,13 @@ namespace Marmot::Elements {
      * @param time[in] Pointer to the time at the beginning of the current time step
      * @param dT[in] Length of the current time step
      */
-    void computeBodyForce( double*       P,
-                           double*       K,
-                           const double* load,
-                           const double* QTotal,
-                           const double* time,
-                           double        dT );
+    void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
 
     /** @brief Compute the negative element residual vector (right hand side of global newton) and stiffness matrix
      *
      * For a given displacement \f$\mathbf{q}^{(n+1)}\f$ at the current time step \f$t^{(n+1)} = t^{(n)} + \Delta\,t\f$,
      * compute the internal work contribution for the negative element residual vector (right hand side of global
-     * newton) \f$-\int_{V_0}\,\mathbf{N}_{A,i}\,\tau_{ij}\,dV_0\f$ and the element stiffness matrix
-     * \f$\int_{V_0}\,\mathbf{N}_{A,i}\,\frac{\partial \tau_{ij}}{\partial
-     * F_{kK}}\,\mathbf{N}_{B,K}\,-\,\mathbf{N}_{A,k\,}\mathbf{N}_{B,i}\,\tau_{ij}\,dV_0\f$.
+     * newton) \f$-\int_{V_0}\,\mathbf{N}_A\,f_j\,dV_0\f$.
      *
      * @param QTotal[in] Pointer to the total element displacement vector at the current time step
      * @param dQ[in] Pointer to the increment of the element displacement vector at the current time step
@@ -346,18 +339,13 @@ namespace Marmot::Elements {
      * @param time[in] Pointer to the time at the beginning of the current time step
      * @param dT[in] Length of the current time step
      */
-    void computeYourself( const double* QTotal,
-                          const double* dQ,
-                          double*       Pe,
-                          double*       Ke,
-                          const double* time,
-                          double        dT );
+    void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
     /** @brief Compute the negative element residual vector (internal force only, no tangent stiffness)
      *
      * For a given displacement \f$\mathbf{q}^{(n+1)}\f$ at the current time step \f$t^{(n+1)} = t^{(n)} + \Delta\,t\f$,
      * compute the internal work contribution for the negative element residual vector (right hand side of global
-     * newton) \f$-\int_{V_0}\,\mathbf{N}_{A,i}\,\tau_{ij}\,dV_0\f$.
+     * newton) \f$-\int_{V_0}\,\mathbf{N}_A\,f_j\,dV_0\f$.
      *
      * @param QTotal[in] Pointer to the total element displacement vector at the current time step
      * @param dQ[in] Pointer to the increment of the element displacement vector at the current time step
@@ -365,7 +353,7 @@ namespace Marmot::Elements {
      * @param time[in] Pointer to the time at the beginning of the current time step
      * @param dT[in] Length of the current time step
      */
-    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
+    void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pe, double time, double dT );
 
     /**
      * @brief Compute consistent mass matrix using material density.
@@ -547,12 +535,12 @@ namespace Marmot::Elements {
   }
 
   template < int nDim, int nNodes >
-  void DisplacementFiniteStrainULElement< nDim, nNodes >::computeYourself( const double* qTotal,
-                                                                           const double* dQ,
-                                                                           double*       rightHandSide,
-                                                                           double*       stiffnessMatrix,
-                                                                           const double* time,
-                                                                           double        dT )
+  void DisplacementFiniteStrainULElement< nDim, nNodes >::computeKernels( const double* qTotal,
+                                                                          const double* dQ,
+                                                                          double*       rightHandSide,
+                                                                          double*       stiffnessMatrix,
+                                                                          double        time,
+                                                                          double        dT )
   {
     using namespace Fastor;
 
@@ -582,7 +570,7 @@ namespace Marmot::Elements {
 
       const Material::Deformation< nDim > deformation = { F_np };
 
-      const Material::TimeIncrement timeIncrement{ time[1], dT };
+      const Material::TimeIncrement timeIncrement{ time, dT };
 
       Material::ConstitutiveResponse< nDim > response( Tensor< double, nDim, nDim >( qp.managedStateVars->stress.data(),
                                                                                      ColumnMajor ),
@@ -682,11 +670,11 @@ namespace Marmot::Elements {
   }
 
   template < int nDim, int nNodes >
-  void DisplacementFiniteStrainULElement< nDim, nNodes >::computeYourselfExplicit( const double* qTotal,
-                                                                                   const double* dQ,
-                                                                                   double*       rightHandSide,
-                                                                                   const double* time,
-                                                                                   double        dT )
+  void DisplacementFiniteStrainULElement< nDim, nNodes >::computeKernelsExplicit( const double* qTotal,
+                                                                                  const double* dQ,
+                                                                                  double*       rightHandSide,
+                                                                                  double        time,
+                                                                                  double        dT )
   {
     using namespace Fastor;
 
@@ -713,7 +701,7 @@ namespace Marmot::Elements {
 
       const Material::Deformation< nDim > deformation = { F_np };
 
-      const Material::TimeIncrement timeIncrement{ time[1], dT };
+      const Material::TimeIncrement timeIncrement{ time, dT };
 
       Material::ConstitutiveResponse< nDim > response( Tensor< double, nDim, nDim >( qp.managedStateVars->stress.data(),
                                                                                      ColumnMajor ),
@@ -785,7 +773,7 @@ namespace Marmot::Elements {
     const int                           elementFace,
     const double*                       load,
     const double*                       QTotal_,
-    const double*                       time,
+    double                              time,
     double                              dT )
   {
 
@@ -893,7 +881,7 @@ namespace Marmot::Elements {
                                                                             const double* load,
 
                                                                             const double* qTotal,
-                                                                            const double* time,
+                                                                            double        time,
                                                                             double        dT )
   {
     Eigen::Map< RhsSized >                                     r( rightHandSide );
@@ -1034,23 +1022,18 @@ namespace Marmot::Elements {
 
     using DisplacementFiniteStrainULElement< 2, nNodes >::DisplacementFiniteStrainULElement;
 
-    void computeYourself( const double* QTotal,
-                          const double* dQ,
-                          double*       Pe,
-                          double*       Ke,
-                          const double* time,
-                          double        dT );
+    void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
-    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
+    void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pe, double time, double dT );
   };
 
   template < int nNodes >
-  void AxiSymmetricDisplacementFiniteStrainULElement< nNodes >::computeYourself( const double* qTotal,
-                                                                                 const double* dQ,
-                                                                                 double*       rightHandSide,
-                                                                                 double*       stiffnessMatrix,
-                                                                                 const double* time,
-                                                                                 double        dT )
+  void AxiSymmetricDisplacementFiniteStrainULElement< nNodes >::computeKernels( const double* qTotal,
+                                                                                const double* dQ,
+                                                                                double*       rightHandSide,
+                                                                                double*       stiffnessMatrix,
+                                                                                double        time,
+                                                                                double        dT )
   {
     constexpr int nDim = 2;
 
@@ -1096,7 +1079,7 @@ namespace Marmot::Elements {
         F_np,
       };
 
-      const Material ::TimeIncrement timeIncrement{ time[0], dT };
+      const Material ::TimeIncrement timeIncrement{ time, dT };
 
       Material::ConstitutiveResponse< nDim > response;
       Material::AlgorithmicModuli< nDim >    tangents;
@@ -1194,11 +1177,11 @@ namespace Marmot::Elements {
   }
 
   template < int nNodes >
-  void AxiSymmetricDisplacementFiniteStrainULElement< nNodes >::computeYourselfExplicit( const double* qTotal,
-                                                                                         const double* dQ,
-                                                                                         double*       rightHandSide,
-                                                                                         const double* time,
-                                                                                         double        dT )
+  void AxiSymmetricDisplacementFiniteStrainULElement< nNodes >::computeKernelsExplicit( const double* qTotal,
+                                                                                        const double* dQ,
+                                                                                        double*       rightHandSide,
+                                                                                        double        time,
+                                                                                        double        dT )
   {
     constexpr int nDim = 2;
 
@@ -1240,7 +1223,7 @@ namespace Marmot::Elements {
         F_np,
       };
 
-      const Material ::TimeIncrement timeIncrement{ time[0], dT };
+      const Material ::TimeIncrement timeIncrement{ time, dT };
 
       Material::ConstitutiveResponse< nDim > response;
 

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -345,15 +345,13 @@ namespace Marmot::Elements {
      * @param Ke[in,out] Pointer to the element stiffness matrix
      * @param time[in] Pointer to the time at the beginning of the current time step
      * @param dT[in] Length of the current time step
-     * @param pNewdT[in,out] Suggested length of the next time step
      */
     void computeYourself( const double* QTotal,
                           const double* dQ,
                           double*       Pe,
                           double*       Ke,
                           const double* time,
-                          double        dT,
-                          double&       pNewdT );
+                          double        dT );
 
     /** @brief Compute the negative element residual vector (internal force only, no tangent stiffness)
      *
@@ -366,14 +364,8 @@ namespace Marmot::Elements {
      * @param Pe[in,out] Pointer to the negative element residual vector (right hand side of global newton)
      * @param time[in] Pointer to the time at the beginning of the current time step
      * @param dT[in] Length of the current time step
-     * @param pNewdT[in,out] Suggested length of the next time step
      */
-    void computeYourselfExplicit( const double* QTotal,
-                                  const double* dQ,
-                                  double*       Pe,
-                                  const double* time,
-                                  double        dT,
-                                  double&       pNewdT );
+    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
 
     /**
      * @brief Compute consistent mass matrix using material density.
@@ -560,8 +552,7 @@ namespace Marmot::Elements {
                                                                            double*       rightHandSide,
                                                                            double*       stiffnessMatrix,
                                                                            const double* time,
-                                                                           double        dT,
-                                                                           double&       pNewDT )
+                                                                           double        dT )
   {
     using namespace Fastor;
 
@@ -600,66 +591,60 @@ namespace Marmot::Elements {
                                                        qp.managedStateVars->materialStateVars.data() );
       Material::AlgorithmicModuli< nDim >    tangents = { 0 };
 
-      try {
-        if constexpr ( nDim == 2 ) {
+      if constexpr ( nDim == 2 ) {
 
-          if ( sectionType == SectionType::PlaneStrain ) {
+        if ( sectionType == SectionType::PlaneStrain ) {
 
-            using namespace Marmot;
+          using namespace Marmot;
 
-            Material::ConstitutiveResponse< 3 >
-              response3D( FastorStandardTensors::Tensor3d( qp.managedStateVars->stress.data(), ColumnMajor ),
-                          response.elasticEnergyDensity,
-                          response.dissipation,
-                          response.stateVars );
+          Material::ConstitutiveResponse< 3 >
+            response3D( FastorStandardTensors::Tensor3d( qp.managedStateVars->stress.data(), ColumnMajor ),
+                        response.elasticEnergyDensity,
+                        response.dissipation,
+                        response.stateVars );
 
-            Material::AlgorithmicModuli< 3 > algorithmicModuli3D;
+          Material::AlgorithmicModuli< 3 > algorithmicModuli3D;
 
-            Material::Deformation< 3 > deformation3D{
-              expandTo3D( deformation.F ),
-            };
+          Material::Deformation< 3 > deformation3D{
+            expandTo3D( deformation.F ),
+          };
 
-            deformation3D.F( 2, 2 ) = 1.0;
+          deformation3D.F( 2, 2 ) = 1.0;
 
-            if ( hasEigenDeformation )
-              qp.material->computePlaneStrain( response3D,
-                                               algorithmicModuli3D,
-                                               deformation3D,
-                                               timeIncrement,
-                                               { qp.managedStateVars->F0_XX,
-                                                 qp.managedStateVars->F0_YY,
-                                                 qp.managedStateVars->F0_ZZ } );
-            else
-              qp.material->computePlaneStrain( response3D, algorithmicModuli3D, deformation3D, timeIncrement );
+          if ( hasEigenDeformation )
+            qp.material->computePlaneStrain( response3D,
+                                             algorithmicModuli3D,
+                                             deformation3D,
+                                             timeIncrement,
+                                             { qp.managedStateVars->F0_XX,
+                                               qp.managedStateVars->F0_YY,
+                                               qp.managedStateVars->F0_ZZ } );
+          else
+            qp.material->computePlaneStrain( response3D, algorithmicModuli3D, deformation3D, timeIncrement );
 
-            response.tau                  = reduceTo2D< U, U >( response3D.tau );
-            response.elasticEnergyDensity = response3D.elasticEnergyDensity;
-            response.dissipation          = response3D.dissipation;
-            response.stateVars            = qp.managedStateVars->materialStateVars.data();
+          response.tau                  = reduceTo2D< U, U >( response3D.tau );
+          response.elasticEnergyDensity = response3D.elasticEnergyDensity;
+          response.dissipation          = response3D.dissipation;
+          response.stateVars            = qp.managedStateVars->materialStateVars.data();
 
-            tangents = {
-              reduceTo2D< U, U, U, U >( algorithmicModuli3D.dTau_dF ),
-            };
+          tangents = {
+            reduceTo2D< U, U, U, U >( algorithmicModuli3D.dTau_dF ),
+          };
 
-            qp.managedStateVars->stress = Marmot::mapEigenToFastor( response3D.tau ).reshaped();
-            qp.managedStateVars->F      = Marmot::mapEigenToFastor( deformation3D.F ).reshaped();
-          }
-          else {
-            throw std::runtime_error( "Plane stress update is not implemented yet for finite strain materials." );
-          }
+          qp.managedStateVars->stress = Marmot::mapEigenToFastor( response3D.tau ).reshaped();
+          qp.managedStateVars->F      = Marmot::mapEigenToFastor( deformation3D.F ).reshaped();
         }
         else {
-
-          qp.material->computeStress( response, tangents, deformation, timeIncrement );
-
-          // implicit conversion to col major
-          qp.managedStateVars->stress = Marmot::mapEigenToFastor( response.tau ).reshaped();
-          qp.managedStateVars->F      = Marmot::mapEigenToFastor( deformation.F ).reshaped();
+          throw std::runtime_error( "Plane stress update is not implemented yet for finite strain materials." );
         }
       }
-      catch ( const Marmot::StressUpdateFailed& ) {
-        pNewDT = 0.25;
-        return;
+      else {
+
+        qp.material->computeStress( response, tangents, deformation, timeIncrement );
+
+        // implicit conversion to col major
+        qp.managedStateVars->stress = Marmot::mapEigenToFastor( response.tau ).reshaped();
+        qp.managedStateVars->F      = Marmot::mapEigenToFastor( deformation.F ).reshaped();
       }
       qp.managedStateVars->elasticEnergy     = response.elasticEnergyDensity * qp.J0xW;
       qp.managedStateVars->dissipation       = response.dissipation * qp.J0xW;
@@ -677,7 +662,7 @@ namespace Marmot::Elements {
 
       // r[ node, dim ] (swap to abuse directly colmajor layout)
       // directly operate via TensorMap
-      r_U -= ( +einsum< iA, ij >( dNdx, tau ) ) * J0xW;
+      r_U += ( +einsum< iA, ij >( dNdx, tau ) ) * J0xW;
 
       // K [dim, node, dim, node ]
       k_UU += ( +einsum< iA, ijkB, to_jAkB >( dNdx, dTau_dqU ) ) * J0xW;
@@ -701,8 +686,7 @@ namespace Marmot::Elements {
                                                                                    const double* dQ,
                                                                                    double*       rightHandSide,
                                                                                    const double* time,
-                                                                                   double        dT,
-                                                                                   double&       pNewDT )
+                                                                                   double        dT )
   {
     using namespace Fastor;
 
@@ -736,53 +720,47 @@ namespace Marmot::Elements {
                                                        qp.managedStateVars->elasticEnergy / qp.J0xW,
                                                        qp.managedStateVars->dissipation / qp.J0xW,
                                                        qp.managedStateVars->materialStateVars.data() );
-      try {
-        if constexpr ( nDim == 2 ) {
+      if constexpr ( nDim == 2 ) {
 
-          if ( sectionType == SectionType::PlaneStrain ) {
+        if ( sectionType == SectionType::PlaneStrain ) {
 
-            using namespace Marmot;
+          using namespace Marmot;
 
-            Material::ConstitutiveResponse< 3 >
-              response3D( FastorStandardTensors::Tensor33d( qp.managedStateVars->stress.data(), Fastor::ColumnMajor ),
-                          response.elasticEnergyDensity,
-                          response.dissipation,
-                          qp.managedStateVars->materialStateVars.data() );
+          Material::ConstitutiveResponse< 3 >
+            response3D( FastorStandardTensors::Tensor33d( qp.managedStateVars->stress.data(), Fastor::ColumnMajor ),
+                        response.elasticEnergyDensity,
+                        response.dissipation,
+                        qp.managedStateVars->materialStateVars.data() );
 
-            Material::Deformation< 3 > deformation3D{
-              expandTo3D( deformation.F ),
-            };
+          Material::Deformation< 3 > deformation3D{
+            expandTo3D( deformation.F ),
+          };
 
-            deformation3D.F( 2, 2 ) = 1.0;
+          deformation3D.F( 2, 2 ) = 1.0;
 
-            if ( hasEigenDeformation )
-              qp.material->computePlaneStrainExplicit( response3D,
-                                                       deformation3D,
-                                                       timeIncrement,
-                                                       { qp.managedStateVars->F0_XX,
-                                                         qp.managedStateVars->F0_YY,
-                                                         qp.managedStateVars->F0_ZZ } );
-            else
-              qp.material->computePlaneStrainExplicit( response3D, deformation3D, timeIncrement );
+          if ( hasEigenDeformation )
+            qp.material->computePlaneStrainExplicit( response3D,
+                                                     deformation3D,
+                                                     timeIncrement,
+                                                     { qp.managedStateVars->F0_XX,
+                                                       qp.managedStateVars->F0_YY,
+                                                       qp.managedStateVars->F0_ZZ } );
+          else
+            qp.material->computePlaneStrainExplicit( response3D, deformation3D, timeIncrement );
 
-            response.tau                  = reduceTo2D< U, U >( response3D.tau );
-            response.elasticEnergyDensity = response3D.elasticEnergyDensity;
-            response.dissipation          = response3D.dissipation;
-            response.stateVars            = qp.managedStateVars->materialStateVars.data();
+          response.tau                  = reduceTo2D< U, U >( response3D.tau );
+          response.elasticEnergyDensity = response3D.elasticEnergyDensity;
+          response.dissipation          = response3D.dissipation;
+          response.stateVars            = qp.managedStateVars->materialStateVars.data();
 
-            qp.managedStateVars->stress = Marmot::mapEigenToFastor( response3D.tau ).reshaped();
-          }
-        }
-        else {
-          qp.material->computeStressExplicit( response, deformation, timeIncrement );
-
-          // implicit conversion to col major
-          qp.managedStateVars->stress = Marmot::mapEigenToFastor( response.tau ).reshaped();
+          qp.managedStateVars->stress = Marmot::mapEigenToFastor( response3D.tau ).reshaped();
         }
       }
-      catch ( const Marmot::StressUpdateFailed& ) {
-        pNewDT = 0.25;
-        return;
+      else {
+        qp.material->computeStressExplicit( response, deformation, timeIncrement );
+
+        // implicit conversion to col major
+        qp.managedStateVars->stress = Marmot::mapEigenToFastor( response.tau ).reshaped();
       }
       qp.managedStateVars->elasticEnergy     = response.elasticEnergyDensity * qp.J0xW;
       qp.managedStateVars->dissipation       = response.dissipation * qp.J0xW;
@@ -795,7 +773,7 @@ namespace Marmot::Elements {
 
       // r[ node, dim ] (swap to abuse directly colmajor layout)
       // directly operate via TensorMap
-      r_U -= ( +einsum< iA, ij >( dNdx, tau ) ) * J0xW;
+      r_U += ( +einsum< iA, ij >( dNdx, tau ) ) * J0xW;
     }
   }
 
@@ -1061,15 +1039,9 @@ namespace Marmot::Elements {
                           double*       Pe,
                           double*       Ke,
                           const double* time,
-                          double        dT,
-                          double&       pNewdT );
+                          double        dT );
 
-    void computeYourselfExplicit( const double* QTotal,
-                                  const double* dQ,
-                                  double*       Pe,
-                                  const double* time,
-                                  double        dT,
-                                  double&       pNewdT );
+    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
   };
 
   template < int nNodes >
@@ -1078,8 +1050,7 @@ namespace Marmot::Elements {
                                                                                  double*       rightHandSide,
                                                                                  double*       stiffnessMatrix,
                                                                                  const double* time,
-                                                                                 double        dT,
-                                                                                 double&       pNewDT )
+                                                                                 double        dT )
   {
     constexpr int nDim = 2;
 
@@ -1143,13 +1114,7 @@ namespace Marmot::Elements {
 
       deformation3D.F( 2, 2 ) = 1 + u_np[0] / r;
 
-      try {
-        qp.material->computePlaneStrain( response3D, algorithmicModuli3D, deformation3D, timeIncrement );
-      }
-      catch ( const Marmot::StressUpdateFailed& ) {
-        pNewDT = 0.25;
-        return;
-      }
+      qp.material->computePlaneStrain( response3D, algorithmicModuli3D, deformation3D, timeIncrement );
       response.tau                  = reduceTo2D< U, U >( response3D.tau );
       response.elasticEnergyDensity = response3D.elasticEnergyDensity;
       response.dissipation          = response3D.dissipation;
@@ -1195,7 +1160,7 @@ namespace Marmot::Elements {
 
       // r[ node, dim ] (swap to abuse directly colmajor layout)
       // directly operate via TensorMap
-      r_U -= ( +einsum< iA, ij >( dNdx, tau ) ) * J0xWxRx2Pi;
+      r_U += ( +einsum< iA, ij >( dNdx, tau ) ) * J0xWxRx2Pi;
 
       const double F33          = 1 + u_np[0] / r;
       const double invF33       = 1. / F33;
@@ -1233,8 +1198,7 @@ namespace Marmot::Elements {
                                                                                          const double* dQ,
                                                                                          double*       rightHandSide,
                                                                                          const double* time,
-                                                                                         double        dT,
-                                                                                         double&       pNewDT )
+                                                                                         double        dT )
   {
     constexpr int nDim = 2;
 
@@ -1291,13 +1255,7 @@ namespace Marmot::Elements {
 
       deformation3D.F( 2, 2 ) = 1 + u_np[0] / r;
 
-      try {
-        qp.material->computePlaneStrainExplicit( response3D, deformation3D, timeIncrement );
-      }
-      catch ( const Marmot::StressUpdateFailed& ) {
-        pNewDT = 0.25;
-        return;
-      }
+      qp.material->computePlaneStrainExplicit( response3D, deformation3D, timeIncrement );
       response.tau                  = reduceTo2D< U, U >( response3D.tau );
       response.elasticEnergyDensity = response3D.elasticEnergyDensity;
       response.dissipation          = response3D.dissipation;
@@ -1317,7 +1275,7 @@ namespace Marmot::Elements {
 
       // r[ node, dim ] (swap to abuse directly colmajor layout)
       // directly operate via TensorMap
-      r_U -= ( +einsum< iA, ij >( dNdx, tau ) ) * J0xWxRx2Pi;
+      r_U += ( +einsum< iA, ij >( dNdx, tau ) ) * J0xWxRx2Pi;
 
       const double F33    = 1 + u_np[0] / r;
       const double invF33 = 1. / F33;

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -346,8 +346,7 @@ namespace Marmot::Elements {
                           double*       Pe,
                           double*       Ke,
                           const double* time,
-                          double        dT,
-                          double&       pNewdT );
+                          double        dT );
 
     /**
      * @brief Compute internal force without tangents.
@@ -368,12 +367,7 @@ namespace Marmot::Elements {
      * @param dT Time increment.
      * @param pNewdT Suggested scaling of dT by the material; if reduced (<1), the routine returns early.
      */
-    void computeYourselfExplicit( const double* QTotal,
-                                  const double* dQ,
-                                  double*       Pe,
-                                  const double* time,
-                                  double        dT,
-                                  double&       pNewdT );
+    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
     /**
      * @brief Compute consistent mass matrix using material density.
      * @details \f$\mathbf{M}_e = \sum_{qp} \rho\, \mathbf{N}^\mathsf{T}\mathbf{N}\, J_0 w\f$.
@@ -588,13 +582,7 @@ namespace Marmot::Elements {
 
   template < int nDim, int nNodes, int nNonlocalVariables, int nNonLocalNodes >
   void GeneralGradientEnhancedDisplacementFiniteElement< nDim, nNodes, nNonlocalVariables, nNonLocalNodes >::
-    computeYourself( const double* QTotal_,
-                     const double* dQ_,
-                     double*       Pe_,
-                     double*       Ke_,
-                     const double* time,
-                     double        dT,
-                     double&       pNewDT )
+    computeYourself( const double* QTotal_, const double* dQ_, double* Pe_, double* Ke_, const double* time, double dT )
   {
 
     Map< const RhsSized > QTotal( QTotal_ );
@@ -650,47 +638,80 @@ namespace Marmot::Elements {
       response  res;
       tangents  tan;
       increment inc;
-      try {
-        if constexpr ( nDim == 2 ) {
-          Vector6d dE6             = ContinuumMechanics::VoigtNotation::planeVoigtToVoigt( dE );
+      if constexpr ( nDim == 2 ) {
+        Vector6d dE6             = ContinuumMechanics::VoigtNotation::planeVoigtToVoigt( dE );
+        res.stress               = qp.managedStateVars->stress;
+        res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
+        res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
+        res.stateVars            = qp.managedStateVars->materialStateVars.data();
+        inc                      = { dE6, K, dK, time[1], dT };
+        CSized C                 = CSized::Zero();
+        Voigt  S                 = Voigt::Zero();
+
+        if ( sectionType == SectionType::PlaneStress ) {
+          qp.material->computePlaneStress( res, tan, inc );
+          S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
+          C = ContinuumMechanics::PlaneStress::getPlaneStressTangent( tan.dStressddStrain );
+        }
+        else if ( sectionType == SectionType::PlaneStrain ) {
+          qp.material->computeStress( res, tan, inc );
+          S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
+          C = ContinuumMechanics::PlaneStrain::getPlaneStrainTangent( tan.dStressddStrain );
+        }
+        else {
+          throw std::invalid_argument( "Invalid section type for 2D element, expected PlaneStress or PlaneStrain" );
+        }
+
+        fU += B.transpose() * S * qp.J0xW;
+        kUU += B.transpose() * C * B * qp.J0xW;
+
+        for ( int n = 0; n < nNonlocalVariables; n++ ) {
+          Eigen::Index idx = n * nNonLocalNodes;
+          fK.segment( idx, nNonLocalNodes ) += ( N_K.transpose() * K( n ) +
+                                                 res.c( n ) * dNdX_K.transpose() * dNdX_K *
+                                                   qK.segment( idx, nNonLocalNodes ) -
+                                                 N_K.transpose() * res.KLocal( n ) ) *
+                                               qp.J0xW;
+          const auto dSdK         = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( tan.dStressddK.col( n ) );
+          const auto dK_Local_dDE = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt(
+            tan.dKLocalddStrain.row( n ).transpose() );
+
+          kUK.block( 0, idx, sizeDoFU, nNonLocalNodes ) += B.transpose() * dSdK * N_K * qp.J0xW;
+          kKU.block( idx, 0, nNonLocalNodes, sizeDoFU ) += N_K.transpose() * -dK_Local_dDE.transpose() * B * qp.J0xW;
+          kKK.block( idx, idx, nNonLocalNodes, nNonLocalNodes ) += ( N_K.transpose() * N_K +
+                                                                     res.c( n ) * dNdX_K.transpose() * dNdX_K +
+                                                                     tan.dcddK( n ) * dNdX_K.transpose() * dNdX_K *
+                                                                       qK.segment( idx, nNonLocalNodes ) * N_K -
+                                                                     N_K.transpose() * tan.dKLocalddK( n, n ) * N_K ) *
+                                                                   qp.J0xW;
+        }
+      }
+
+      else if ( nDim == 3 ) {
+        if ( sectionType == Solid ) {
+
           res.stress               = qp.managedStateVars->stress;
           res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
           res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
           res.stateVars            = qp.managedStateVars->materialStateVars.data();
-          inc                      = { dE6, K, dK, time[1], dT };
-          CSized C                 = CSized::Zero();
-          Voigt  S                 = Voigt::Zero();
+          inc                      = { dE, K, dK, time[1], dT };
+          qp.material->computeStress( res, tan, inc );
 
-          if ( sectionType == SectionType::PlaneStress ) {
-            qp.material->computePlaneStress( res, tan, inc );
-            S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
-            C = ContinuumMechanics::PlaneStress::getPlaneStressTangent( tan.dStressddStrain );
-          }
-          else if ( sectionType == SectionType::PlaneStrain ) {
-            qp.material->computeStress( res, tan, inc );
-            S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
-            C = ContinuumMechanics::PlaneStrain::getPlaneStrainTangent( tan.dStressddStrain );
-          }
-          else {
-            throw std::invalid_argument( "Invalid section type for 2D element, expected PlaneStress or PlaneStrain" );
-          }
-
-          fU -= B.transpose() * S * qp.J0xW;
-          kUU += B.transpose() * C * B * qp.J0xW;
+          fU += B.transpose() * res.stress * qp.J0xW;
+          kUU += B.transpose() * tan.dStressddStrain * B * qp.J0xW;
 
           for ( int n = 0; n < nNonlocalVariables; n++ ) {
             Eigen::Index idx = n * nNonLocalNodes;
-            fK.segment( idx, nNonLocalNodes ) -= ( N_K.transpose() * K( n ) +
+            fK.segment( idx, nNonLocalNodes ) += ( N_K.transpose() * K( n ) +
                                                    res.c( n ) * dNdX_K.transpose() * dNdX_K *
                                                      qK.segment( idx, nNonLocalNodes ) -
                                                    N_K.transpose() * res.KLocal( n ) ) *
                                                  qp.J0xW;
-            const auto dSdK         = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( tan.dStressddK.col( n ) );
-            const auto dK_Local_dDE = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt(
-              tan.dKLocalddStrain.row( n ).transpose() );
 
-            kUK.block( 0, idx, sizeDoFU, nNonLocalNodes ) += B.transpose() * dSdK * N_K * qp.J0xW;
-            kKU.block( idx, 0, nNonLocalNodes, sizeDoFU ) += N_K.transpose() * -dK_Local_dDE.transpose() * B * qp.J0xW;
+            kUK.block( 0, idx, sizeDoFU, nNonLocalNodes ) += B.transpose() * tan.dStressddK.col( n ) * N_K * qp.J0xW;
+            kKU.block( idx, 0, nNonLocalNodes, sizeDoFU ) += N_K.transpose() * -tan.dKLocalddStrain.row( n ) * B *
+                                                             qp.J0xW;
+
             kKK.block( idx, idx, nNonLocalNodes, nNonLocalNodes ) += ( N_K.transpose() * N_K +
                                                                        res.c( n ) * dNdX_K.transpose() * dNdX_K +
                                                                        tan.dcddK( n ) * dNdX_K.transpose() * dNdX_K *
@@ -700,48 +721,8 @@ namespace Marmot::Elements {
                                                                      qp.J0xW;
           }
         }
-
-        else if ( nDim == 3 ) {
-          if ( sectionType == Solid ) {
-
-            res.stress               = qp.managedStateVars->stress;
-            res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
-            res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
-            res.stateVars            = qp.managedStateVars->materialStateVars.data();
-            inc                      = { dE, K, dK, time[1], dT };
-            qp.material->computeStress( res, tan, inc );
-
-            fU -= B.transpose() * res.stress * qp.J0xW;
-            kUU += B.transpose() * tan.dStressddStrain * B * qp.J0xW;
-
-            for ( int n = 0; n < nNonlocalVariables; n++ ) {
-              Eigen::Index idx = n * nNonLocalNodes;
-              fK.segment( idx, nNonLocalNodes ) -= ( N_K.transpose() * K( n ) +
-                                                     res.c( n ) * dNdX_K.transpose() * dNdX_K *
-                                                       qK.segment( idx, nNonLocalNodes ) -
-                                                     N_K.transpose() * res.KLocal( n ) ) *
-                                                   qp.J0xW;
-
-              kUK.block( 0, idx, sizeDoFU, nNonLocalNodes ) += B.transpose() * tan.dStressddK.col( n ) * N_K * qp.J0xW;
-              kKU.block( idx, 0, nNonLocalNodes, sizeDoFU ) += N_K.transpose() * -tan.dKLocalddStrain.row( n ) * B *
-                                                               qp.J0xW;
-
-              kKK.block( idx, idx, nNonLocalNodes, nNonLocalNodes ) += ( N_K.transpose() * N_K +
-                                                                         res.c( n ) * dNdX_K.transpose() * dNdX_K +
-                                                                         tan.dcddK( n ) * dNdX_K.transpose() * dNdX_K *
-                                                                           qK.segment( idx, nNonLocalNodes ) * N_K -
-                                                                         N_K.transpose() * tan.dKLocalddK( n, n ) *
-                                                                           N_K ) *
-                                                                       qp.J0xW;
-            }
-          }
-          else
-            throw std::invalid_argument( "Invalid section type for 3D element! Must be Solid" );
-        }
-      }
-      catch ( StressUpdateFailed& e ) {
-        pNewDT = 0.25;
-        return;
+        else
+          throw std::invalid_argument( "Invalid section type for 3D element! Must be Solid" );
       }
       qp.managedStateVars->stress              = res.stress;
       qp.managedStateVars->elasticStrainEnergy = res.elasticEnergyDensity * qp.J0xW;
@@ -753,12 +734,7 @@ namespace Marmot::Elements {
 
   template < int nDim, int nNodes, int nNonlocalVariables, int nNonLocalNodes >
   void GeneralGradientEnhancedDisplacementFiniteElement< nDim, nNodes, nNonlocalVariables, nNonLocalNodes >::
-    computeYourselfExplicit( const double* QTotal_,
-                             const double* dQ_,
-                             double*       Pe_,
-                             const double* time,
-                             double        dT,
-                             double&       pNewDT )
+    computeYourselfExplicit( const double* QTotal_, const double* dQ_, double* Pe_, const double* time, double dT )
   {
 
     Map< const RhsSized > QTotal( QTotal_ );
@@ -803,68 +779,62 @@ namespace Marmot::Elements {
 
       response  res;
       increment inc;
-      try {
-        if constexpr ( nDim == 2 ) {
-          Vector6d dE6             = ContinuumMechanics::VoigtNotation::planeVoigtToVoigt( dE );
+      if constexpr ( nDim == 2 ) {
+        Vector6d dE6             = ContinuumMechanics::VoigtNotation::planeVoigtToVoigt( dE );
+        res.stress               = qp.managedStateVars->stress;
+        res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
+        res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
+        res.stateVars            = qp.managedStateVars->materialStateVars.data();
+        inc                      = { dE6, K, dK, time[1], dT };
+        Voigt S                  = Voigt::Zero();
+
+        if ( sectionType == SectionType::PlaneStress ) {
+          qp.material->computePlaneStressExplicit( res, inc );
+          S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
+        }
+        else if ( sectionType == SectionType::PlaneStrain ) {
+          qp.material->computeStressExplicit( res, inc );
+          S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
+        }
+        else {
+          throw std::invalid_argument( "Invalid section type for 2D element, expected PlaneStress or PlaneStrain" );
+        }
+
+        fU += B.transpose() * S * qp.J0xW;
+
+        for ( int n = 0; n < nNonlocalVariables; n++ ) {
+          Eigen::Index idx = n * nNonLocalNodes;
+          fK.segment( idx, nNonLocalNodes ) += ( N_K.transpose() * K( n ) +
+                                                 res.c( n ) * dNdX_K.transpose() * dNdX_K *
+                                                   qK.segment( idx, nNonLocalNodes ) -
+                                                 N_K.transpose() * res.KLocal( n ) ) *
+                                               qp.J0xW;
+        }
+      }
+
+      else if ( nDim == 3 ) {
+        if ( sectionType == Solid ) {
+
           res.stress               = qp.managedStateVars->stress;
           res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
           res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
           res.stateVars            = qp.managedStateVars->materialStateVars.data();
-          inc                      = { dE6, K, dK, time[1], dT };
-          Voigt S                  = Voigt::Zero();
+          inc                      = { dE, K, dK, time[1], dT };
+          qp.material->computeStressExplicit( res, inc );
 
-          if ( sectionType == SectionType::PlaneStress ) {
-            qp.material->computePlaneStressExplicit( res, inc );
-            S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
-          }
-          else if ( sectionType == SectionType::PlaneStrain ) {
-            qp.material->computeStressExplicit( res, inc );
-            S = ContinuumMechanics::VoigtNotation::voigtToPlaneVoigt( res.stress );
-          }
-          else {
-            throw std::invalid_argument( "Invalid section type for 2D element, expected PlaneStress or PlaneStrain" );
-          }
-
-          fU -= B.transpose() * S * qp.J0xW;
+          fU += B.transpose() * res.stress * qp.J0xW;
 
           for ( int n = 0; n < nNonlocalVariables; n++ ) {
             Eigen::Index idx = n * nNonLocalNodes;
-            fK.segment( idx, nNonLocalNodes ) -= ( N_K.transpose() * K( n ) +
+            fK.segment( idx, nNonLocalNodes ) += ( N_K.transpose() * K( n ) +
                                                    res.c( n ) * dNdX_K.transpose() * dNdX_K *
                                                      qK.segment( idx, nNonLocalNodes ) -
                                                    N_K.transpose() * res.KLocal( n ) ) *
                                                  qp.J0xW;
           }
         }
-
-        else if ( nDim == 3 ) {
-          if ( sectionType == Solid ) {
-
-            res.stress               = qp.managedStateVars->stress;
-            res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
-            res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
-            res.stateVars            = qp.managedStateVars->materialStateVars.data();
-            inc                      = { dE, K, dK, time[1], dT };
-            qp.material->computeStressExplicit( res, inc );
-
-            fU -= B.transpose() * res.stress * qp.J0xW;
-
-            for ( int n = 0; n < nNonlocalVariables; n++ ) {
-              Eigen::Index idx = n * nNonLocalNodes;
-              fK.segment( idx, nNonLocalNodes ) -= ( N_K.transpose() * K( n ) +
-                                                     res.c( n ) * dNdX_K.transpose() * dNdX_K *
-                                                       qK.segment( idx, nNonLocalNodes ) -
-                                                     N_K.transpose() * res.KLocal( n ) ) *
-                                                   qp.J0xW;
-            }
-          }
-          else
-            throw std::invalid_argument( "Invalid section type for 3D element! Must be Solid" );
-        }
-      }
-      catch ( StressUpdateFailed& e ) {
-        pNewDT = 0.25;
-        return;
+        else
+          throw std::invalid_argument( "Invalid section type for 3D element! Must be Solid" );
       }
       qp.managedStateVars->stress = res.stress;
       qp.managedStateVars->strain += make3DVoigt< ParentGeometryElement::voigtSize >( dE );

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -285,7 +285,7 @@ namespace Marmot::Elements {
                                  const int                           elementFace,
                                  const double*                       load,
                                  const double*                       QTotal,
-                                 const double*                       time,
+                                 double                              time,
                                  double                              dT );
 
     /**
@@ -298,7 +298,7 @@ namespace Marmot::Elements {
 
                            const double* load,
                            const double* QTotal,
-                           const double* time,
+                           double        time,
                            double        dT );
 
     /**
@@ -318,18 +318,14 @@ namespace Marmot::Elements {
      * \f]
      * The stiffness submatrices are evaluated using the following expressions:
      * \f[
-     * \mathbf{K}_{uu} = \sum_{qp} \mathbf{B}^\mathsf{T} \frac{\partial \mathbf{\sig}}{\partial \mathbf{\eps}}
-     * \mathbf{B}\, J_0\, w_{qp},\quad
-     * \mathbf{K}_{u\knl} = \sum_{qp} \mathbf{B}^\mathsf{T} \frac{\partial \mathbf{\sig}}{\partial \knl} \mathbf{\Nk}\,
-     * J_0\, w_{qp},\quad
-     * \mathbf{K}_{\knl u} = -\sum_{qp} \mathbf{\Nk}^\mathsf{T} \frac{\partial \kl}{\partial \mathbf{\eps}} \mathbf{B}\,
-     * J_0\, w_{qp},
+     * \mathbf{K}_e = \begin{bmatrix} \mathbf{K}_{uu} & \mathbf{K}_{uk} \\ \mathbf{K}_{ku} & \mathbf{K}_{kk}
+     * \end{bmatrix},\qquad
+     * \mathbf{\fuint} = \sum_{qp} \mathbf{B}^\mathsf{T}\, \sig\, J_0\, w_{qp}\, .
      * \f]
      * \f[
-     * \mathbf{K}_{\knl\knl} = \sum_{qp} \left( \mathbf{\Nk}^\mathsf{T}\, \mathbf{\Nk} + c \, \partial_\mathbf{x}
-     * \mathbf{\Nk}^\mathsf{T} \,  \partial_\mathbf{x} \mathbf{\Nk} + \frac{\partial c}{\partial \knl} \,
-     * \partial_\mathbf{x} \mathbf{\Nk}^\mathsf{T} \, \partial_\mathbf{x}   \mathbf{\Nk}\, \qk \, \mathbf{\Nk} -
-     * \mathbf{\Nk}^\mathsf{T}\, \frac{\partial \kl}{\partial \knl} \right) J_0\, w_{qp}\, .
+     * \mathbf{\fk} = \sum_{qp} \left (\mathbf{\Nk}^\mathsf{T}\, \knl\, + c\, \partial_\mathbf{x}
+     * \mathbf{\Nk}^\mathsf{T}\,\partial_\mathbf{x} \mathbf{\Nk}\, \mathbf{\qk} - \mathbf{\Nk}^\mathsf{T}\, \kl \right )
+     * J_0\, w_{qp} \, .
      * \f]
      * If pNewdT<1, the routine returns early to signal time step reduction.
      * @param QTotal Total displacement vector in field-wise format: \f$\mathbf{q} = [\mathbf{\qu},
@@ -339,14 +335,8 @@ namespace Marmot::Elements {
      * @param Ke Tangent stiffness matrix (accumulated).
      * @param time Time data forwarded to materials.
      * @param dT Time increment.
-     * @param pNewdT Suggested scaling of dT by the material; if reduced (<1), the routine returns early.
      */
-    void computeYourself( const double* QTotal,
-                          const double* dQ,
-                          double*       Pe,
-                          double*       Ke,
-                          const double* time,
-                          double        dT );
+    void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
     /**
      * @brief Compute internal force without tangents.
@@ -362,12 +352,10 @@ namespace Marmot::Elements {
      * \mathbf{\qk}]^\mathsf{T}\f$.
      * @param dQ Incremental displacement.
      * @param Pe Internal force vector (accumulated).
-     * @param Ke Tangent stiffness matrix (accumulated).
      * @param time Time data forwarded to materials.
      * @param dT Time increment.
-     * @param pNewdT Suggested scaling of dT by the material; if reduced (<1), the routine returns early.
      */
-    void computeYourselfExplicit( const double* QTotal, const double* dQ, double* Pe, const double* time, double dT );
+    void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pe, double time, double dT );
     /**
      * @brief Compute consistent mass matrix using material density.
      * @details \f$\mathbf{M}_e = \sum_{qp} \rho\, \mathbf{N}^\mathsf{T}\mathbf{N}\, J_0 w\f$.
@@ -582,7 +570,7 @@ namespace Marmot::Elements {
 
   template < int nDim, int nNodes, int nNonlocalVariables, int nNonLocalNodes >
   void GeneralGradientEnhancedDisplacementFiniteElement< nDim, nNodes, nNonlocalVariables, nNonLocalNodes >::
-    computeYourself( const double* QTotal_, const double* dQ_, double* Pe_, double* Ke_, const double* time, double dT )
+    computeKernels( const double* QTotal_, const double* dQ_, double* Pe_, double* Ke_, double time, double dT )
   {
 
     Map< const RhsSized > QTotal( QTotal_ );
@@ -644,7 +632,7 @@ namespace Marmot::Elements {
         res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
         res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
         res.stateVars            = qp.managedStateVars->materialStateVars.data();
-        inc                      = { dE6, K, dK, time[1], dT };
+        inc                      = { dE6, K, dK, time, dT };
         CSized C                 = CSized::Zero();
         Voigt  S                 = Voigt::Zero();
 
@@ -694,7 +682,7 @@ namespace Marmot::Elements {
           res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
           res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
           res.stateVars            = qp.managedStateVars->materialStateVars.data();
-          inc                      = { dE, K, dK, time[1], dT };
+          inc                      = { dE, K, dK, time, dT };
           qp.material->computeStress( res, tan, inc );
 
           fU += B.transpose() * res.stress * qp.J0xW;
@@ -734,7 +722,7 @@ namespace Marmot::Elements {
 
   template < int nDim, int nNodes, int nNonlocalVariables, int nNonLocalNodes >
   void GeneralGradientEnhancedDisplacementFiniteElement< nDim, nNodes, nNonlocalVariables, nNonLocalNodes >::
-    computeYourselfExplicit( const double* QTotal_, const double* dQ_, double* Pe_, const double* time, double dT )
+    computeKernelsExplicit( const double* QTotal_, const double* dQ_, double* Pe_, double time, double dT )
   {
 
     Map< const RhsSized > QTotal( QTotal_ );
@@ -785,7 +773,7 @@ namespace Marmot::Elements {
         res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
         res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
         res.stateVars            = qp.managedStateVars->materialStateVars.data();
-        inc                      = { dE6, K, dK, time[1], dT };
+        inc                      = { dE6, K, dK, time, dT };
         Voigt S                  = Voigt::Zero();
 
         if ( sectionType == SectionType::PlaneStress ) {
@@ -819,7 +807,7 @@ namespace Marmot::Elements {
           res.elasticEnergyDensity = qp.managedStateVars->elasticStrainEnergy / qp.J0xW;
           res.dissipation          = qp.managedStateVars->dissipation / qp.J0xW;
           res.stateVars            = qp.managedStateVars->materialStateVars.data();
-          inc                      = { dE, K, dK, time[1], dT };
+          inc                      = { dE, K, dK, time, dT };
           qp.material->computeStressExplicit( res, inc );
 
           fU += B.transpose() * res.stress * qp.J0xW;
@@ -961,7 +949,7 @@ namespace Marmot::Elements {
                             const int                           elementFace,
                             const double*                       load,
                             const double*                       QTotal,
-                            const double*                       time,
+                            double                              time,
                             double                              dT )
   {
 
@@ -1039,7 +1027,7 @@ namespace Marmot::Elements {
                       const double* load,
 
                       const double* QTotal,
-                      const double* time,
+                      double        time,
                       double        dT )
   {
     Map< RhsSized >                              P( P_ );


### PR DESCRIPTION
- Modified element formulations (DisplacementFiniteElement, DisplacementFiniteStrainULElement, GeneralGradientEnhancedDisplacementFiniteElement) to compute internal force vectors with a positive sign (removing the negative sign mismatch).
- Removed outdated pNewDT / pNewdT reference parameters from computeYourself and computeYourselfExplicit interfaces and wrapped methods.
- Replaced local StressUpdateFailed exception handlers with direct propagation, allowing standard exceptions to bubble up to trigger step cutbacks.