### PR TITLE
fix(free-threading): replace racy lazy-static caches with C++11 magic…

### DIFF
--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -382,9 +382,6 @@ namespace Marmot::Elements {
   {
     using namespace std;
 
-    // C++11 guarantees thread-safe initialization of function-local statics with an
-    // initializer; the previous "declare empty, then fill on first use" pattern raced
-    // on the fill under real concurrency (free-threading).
     static const vector< vector< string > > nodeFields = [] {
       vector< vector< string > > nodeFields;
       for ( int i = 0; i < nNodes; i++ ) {

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -382,12 +382,17 @@ namespace Marmot::Elements {
   {
     using namespace std;
 
-    static vector< vector< string > > nodeFields;
-    if ( nodeFields.empty() )
+    // C++11 guarantees thread-safe initialization of function-local statics with an
+    // initializer; the previous "declare empty, then fill on first use" pattern raced
+    // on the fill under real concurrency (free-threading).
+    static const vector< vector< string > > nodeFields = [] {
+      vector< vector< string > > nodeFields;
       for ( int i = 0; i < nNodes; i++ ) {
         nodeFields.push_back( vector< string >() );
         nodeFields[i].push_back( "displacement" );
       }
+      return nodeFields;
+    }();
 
     return nodeFields;
   }
@@ -395,10 +400,12 @@ namespace Marmot::Elements {
   template < int nDim, int nNodes >
   std::vector< int > DisplacementFiniteElement< nDim, nNodes >::getDofIndicesPermutationPattern()
   {
-    static std::vector< int > permutationPattern;
-    if ( permutationPattern.empty() )
+    static const std::vector< int > permutationPattern = [] {
+      std::vector< int > permutationPattern;
       for ( int i = 0; i < nNodes * nDim; i++ )
         permutationPattern.push_back( i );
+      return permutationPattern;
+    }();
 
     return permutationPattern;
   }

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -444,12 +444,17 @@ namespace Marmot::Elements {
   {
     using namespace std;
 
-    static vector< vector< string > > nodeFields;
-    if ( nodeFields.empty() )
+    // C++11 guarantees thread-safe initialization of function-local statics with an
+    // initializer; the previous "declare empty, then fill on first use" pattern raced
+    // on the fill under real concurrency (free-threading).
+    static const vector< vector< string > > nodeFields = [] {
+      vector< vector< string > > nodeFields;
       for ( int i = 0; i < nNodes; i++ ) {
         nodeFields.push_back( vector< string >() );
         nodeFields[i].push_back( "displacement" );
       }
+      return nodeFields;
+    }();
 
     return nodeFields;
   }
@@ -457,12 +462,13 @@ namespace Marmot::Elements {
   template < int nDim, int nNodes >
   std::vector< int > DisplacementFiniteStrainULElement< nDim, nNodes >::getDofIndicesPermutationPattern()
   {
-    static std::vector< int > permutationPattern;
-    if ( permutationPattern.empty() ) {
+    static const std::vector< int > permutationPattern = [] {
+      std::vector< int > permutationPattern;
       for ( int i = 0; i < nNodes; i++ )
         for ( int j = 0; j < nDim; j++ )
           permutationPattern.push_back( i * nDim + j );
-    }
+      return permutationPattern;
+    }();
 
     return permutationPattern;
   }

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -444,9 +444,6 @@ namespace Marmot::Elements {
   {
     using namespace std;
 
-    // C++11 guarantees thread-safe initialization of function-local statics with an
-    // initializer; the previous "declare empty, then fill on first use" pattern raced
-    // on the fill under real concurrency (free-threading).
     static const vector< vector< string > > nodeFields = [] {
       vector< vector< string > > nodeFields;
       for ( int i = 0; i < nNodes; i++ ) {

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -486,8 +486,11 @@ namespace Marmot::Elements {
   {
     using namespace std;
 
-    static vector< vector< string > > nodeFields;
-    if ( nodeFields.empty() )
+    // C++11 guarantees thread-safe initialization of function-local statics with an
+    // initializer; the previous "declare empty, then fill on first use" pattern raced
+    // on the fill under real concurrency (free-threading).
+    static const vector< vector< string > > nodeFields = [] {
+      vector< vector< string > > nodeFields;
       for ( int i = 0; i < nNodes; i++ ) {
         nodeFields.push_back( vector< string >() );
         nodeFields[i].push_back( "displacement" );
@@ -501,6 +504,8 @@ namespace Marmot::Elements {
           }
         }
       }
+      return nodeFields;
+    }();
     return nodeFields;
   }
 
@@ -511,9 +516,8 @@ namespace Marmot::Elements {
     nNonlocalVariables,
     nNonLocalNodes >::getDofIndicesPermutationPattern()
   {
-    static std::vector< int > permutationPattern;
-
-    if ( permutationPattern.empty() ) {
+    static const std::vector< int > permutationPattern = [] {
+      std::vector< int > permutationPattern;
       for ( int i = 0; i < nNodes; i++ )
         for ( int j = 0; j < nDim; j++ )
           permutationPattern.push_back( i * nDim + nNonlocalVariables * ( i < nNonLocalNodes ? i : nNonLocalNodes ) +
@@ -521,7 +525,8 @@ namespace Marmot::Elements {
       for ( int j = 0; j < nNonlocalVariables; j++ )
         for ( int i = 0; i < nNonLocalNodes; i++ )
           permutationPattern.push_back( i * ( nDim + nNonlocalVariables ) + nDim + j );
-    }
+      return permutationPattern;
+    }();
     return permutationPattern;
   }
 

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -486,9 +486,6 @@ namespace Marmot::Elements {
   {
     using namespace std;
 
-    // C++11 guarantees thread-safe initialization of function-local statics with an
-    // initializer; the previous "declare empty, then fill on first use" pattern raced
-    // on the fill under real concurrency (free-threading).
     static const vector< vector< string > > nodeFields = [] {
       vector< vector< string > > nodeFields;
       for ( int i = 0; i < nNodes; i++ ) {


### PR DESCRIPTION
…-statics

getNodeFields() and getDofIndicesPermutationPattern() used a "declare empty static, then imperatively fill on first use" pattern with no synchronization, in DisplacementFiniteElement, DisplacementFiniteStrainULElement, and GeneralGradientEnhancedDisplacementFiniteElement. Under genuine free-threading concurrency (enabled once EdelweissFE/EdelweissMeshfree's Cython extensions declared freethreading_compatible), two threads racing on the empty() check could both push_back into the same std::vector at once - a real data race.

Found via a structural scan of modules/ for the
"static <container> x; ... if (x.empty())" idiom, not just grep (8 occurrences across 4 files total; the 4th, GradientEnhancedMicropolarCell.h, lives in its own nested repo under modules/cells/ and is fixed there separately).

Moved the fill into each static's initializer expression instead (an immediately-invoked lambda for the loop-based cases), which C++11 guarantees is thread-safe (compiler-emitted guard) - no manual mutex/std::call_once needed. Verified: Marmot's own ctest (46/46 pass, incl. TestDisplacementFiniteElement and TestGeneralGradientEnhancedDisplacementFiniteElement).