### PR TITLE
fix: build and pass the test suite on macOS/arm64

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,0 +1,86 @@
+# This is a workflow to build the repo on macOS / arm64 (Apple Silicon).
+# GitHub's macos-14 and newer runners are Apple Silicon, so this exercises the
+# clang/libc++ toolchain, which is stricter than the GCC/libstdc++ combination
+# used by build_ubuntu.
+name: build_macos
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    # macos-latest is arm64 (Apple Silicon); use macos-13 for an Intel runner.
+    runs-on: macos-latest
+    # Set explicitly rather than relying on CMake's default: the macOS runners also
+    # ship Homebrew GCC, and picking that up would silently build against libstdc++,
+    # defeating the purpose of this job. No version is pinned - tracking whatever
+    # Apple clang the runner provides is what users actually have.
+    env:
+      CC:   clang
+      CXX:  clang++
+    steps:
+      - name: Show toolchain
+        shell: bash -leo pipefail {0}
+        run: |
+          ${CXX} --version
+          cmake --version
+
+      - name: Install Eigen
+        shell: bash -leo pipefail {0}
+        run: |
+          git clone --branch 3.4.0 https://gitlab.com/libeigen/eigen.git
+          cd eigen
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF  ..
+          sudo make install
+          cd ../..
+
+      # NOTE: the build directory is deliberately NOT called `build` here. autodiff
+      # ships a Bazel `BUILD` file in its repository root, and the macOS filesystem
+      # is case-insensitive, so `mkdir build` fails with "File exists" and `cd build`
+      # with "Not a directory". On Linux the two names are distinct, which is why
+      # build_ubuntu is unaffected.
+      - name: Install Autodiff
+        shell: bash -leo pipefail {0}
+        run: |
+          git clone --branch v1.1.0 https://github.com/autodiff/autodiff.git
+          cd autodiff
+          mkdir build-cmake
+          cd build-cmake
+          cmake -DAUTODIFF_BUILD_TESTS=OFF -DAUTODIFF_BUILD_PYTHON=OFF -DAUTODIFF_BUILD_EXAMPLES=OFF -DAUTODIFF_BUILD_DOCS=OFF ..
+          sudo make install
+          cd ../..
+
+      # NOTE: upstream Fastor does not compile on arm64 - it reaches x86 `cpuid`
+      # and `rdtsc` inline assembly on every non-Windows platform, and its scalar
+      # fallback backend has several defects that only surface off x86. The fork
+      # below is upstream `master` plus the minimal patch fixing exactly that.
+      # The fixes are offered upstream in romeric/Fastor#182 and #183; once either
+      # is merged, switch this step back to the upstream repository.
+      - name: Install Fastor (arm64-compatible fork)
+        shell: bash -leo pipefail {0}
+        run: |
+          git clone --branch arm64/apple-silicon-master https://github.com/BOKU-CMP-MEC-MAT/Fastor.git
+          cd Fastor
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF  ..
+          sudo make install
+          cd ../..
+
+      - name: Check out Marmot
+        uses: actions/checkout@v4
+
+      - name: Install Marmot
+        shell: bash -leo pipefail {0}
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          sudo make install
+          # --no-tests=error: ctest exits 0 on an empty test set, which would
+          # report success for a build that produced no tests at all.
+          ctest --output-on-failure --no-tests=error

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
       CXX:  g++-14
     steps:
       - name: Install Eigen
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch 3.4.0 https://gitlab.com/libeigen/eigen.git
           cd eigen
@@ -25,7 +25,7 @@ jobs:
           cd ../..
 
       - name: Install Autodiff
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch v1.1.0 https://github.com/autodiff/autodiff.git
           cd autodiff
@@ -36,7 +36,7 @@ jobs:
           cd ../..
 
       - name: Install Fastor
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch V0.6.4 https://github.com/romeric/Fastor.git
           cd Fastor
@@ -50,10 +50,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Marmot
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           mkdir build
           cd build
           cmake ..
           sudo make install
-          ctest --output-on-failure
+          # --no-tests=error: ctest exits 0 on an empty test set, which would
+          # report success for a build that produced no tests at all.
+          ctest --output-on-failure --no-tests=error

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainPlasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainPlasticity.cpp
@@ -98,6 +98,11 @@ auto testExponentialMapAndDerivative()
   double      a2 = 0.051617096256127606;
   double      a3 = 0.05242059889237864;
   Tensor3333d DexMapexpect;
+  // Fastor tensors are not zero-initialized by default, and the reference below sets only the
+  // non-zero components, so the remainder must be zeroed explicitly. Reading them otherwise is
+  // undefined behaviour: it happens to work while the stack is still zeroed, but once the stack
+  // has been written to beforehand the unset entries hold garbage (values up to ~1e29 observed).
+  DexMapexpect.zeros();
   DexMapexpect( 0, 0, 0, 0 ) = 1.05;
   DexMapexpect( 0, 1, 0, 1 ) = a1;
   DexMapexpect( 1, 0, 1, 0 ) = a1;

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
@@ -77,6 +77,19 @@ public:
   {
   }
 
+  /**
+   * @brief Virtual destructor.
+   *
+   * This class is abstract and instances are owned through base-class pointers
+   * (e.g. the std::unique_ptr held by the gradient-enhanced elements), so the
+   * destructor must be virtual — destroying a derived object through a base
+   * pointer with a non-virtual destructor is undefined behaviour. libstdc++
+   * silently invokes the wrong destructor, while libc++/clang diagnoses it
+   * (-Wdelete-abstract-non-virtual-dtor) and emits a trap instruction, which
+   * aborted every simulation using such a material on macOS/arm64.
+   */
+  virtual ~MarmotMaterialGeneralGradientEnhancedHypoElastic() = default;
+
   /// @brief Struct to hold the increment information.
   struct increment {
     Marmot::Vector6d                            dStrain; ///< Increment of the strain tensor in Voigt notation

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotVoigt.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotVoigt.cpp
@@ -286,7 +286,8 @@ void test_dJ2_dStress()
 
   throwExceptionOnFailure( checkIfEqual( Marmot::ContinuumMechanics::VoigtNotation::Derivatives::dJ2_dStress( stress )
                                            .norm(),
-                                         dJ2_dStress_FD.norm() ),
+                                         dJ2_dStress_FD.norm(),
+                                         1e-8 ),
                            MakeString() << __PRETTY_FUNCTION__ << " failed" );
 }
 
@@ -306,7 +307,8 @@ void test_dJ3_dStress()
 
   throwExceptionOnFailure( checkIfEqual( Marmot::ContinuumMechanics::VoigtNotation::Derivatives::dJ3_dStress( stress )
                                            .norm(),
-                                         dJ3_dStress_FD.norm() ),
+                                         dJ3_dStress_FD.norm(),
+                                         1e-8 ),
                            MakeString() << __PRETTY_FUNCTION__ << " failed" );
 }
 
@@ -327,7 +329,8 @@ void test_dJ2Strain_dStrain()
   throwExceptionOnFailure( checkIfEqual( Marmot::ContinuumMechanics::VoigtNotation::Derivatives::dJ2Strain_dStrain(
                                            strain )
                                            .norm(),
-                                         dJ2_dStrain_FD.norm() ),
+                                         dJ2_dStrain_FD.norm(),
+                                         1e-8 ),
                            MakeString() << __PRETTY_FUNCTION__ << " failed" );
 }
 
@@ -347,7 +350,8 @@ void test_dJ3Strain_dStrain()
   throwExceptionOnFailure( checkIfEqual( Marmot::ContinuumMechanics::VoigtNotation::Derivatives::dJ3Strain_dStrain(
                                            strain )
                                            .norm(),
-                                         dJ3_dStrain_FD.norm() ),
+                                         dJ3_dStrain_FD.norm(),
+                                         1e-8 ),
                            MakeString() << __PRETTY_FUNCTION__ << " failed" );
 }
 

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -945,7 +945,9 @@ namespace Marmot::Elements {
     Eigen::Map< RhsSized > LMM( M );
     LMM.setZero();
 
-    constexpr int nNodesLinear  = std::pow( 2, nDim );
+    // 2^nDim. std::pow is not constexpr in the standard (libstdc++ offers it as an
+    // extension, libc++ does not), so compute it with a shift to stay portable.
+    constexpr int nNodesLinear  = 1 << nDim;
     auto          linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
     for ( const auto& qp : qps ) {
       const auto N_    = this->N( qp.xi );


### PR DESCRIPTION
Marmot currently does not build on macOS/arm64 (Apple clang + libc++). Three independent fixes; each commit explains the failure mode and how it was verified.

1.     std::pow is not constexpr in the standard — libstdc++ offers it as an extension, libc++ rejects it. This is a hard build stop.

2.     MarmotMaterialGeneralGradientEnhancedHypoElastic is abstract and owned via std::unique_ptr of that base, but had no virtual destructor. Deleting through it is UB; clang emits a trap, so it dies with SIGTRAP.

3.     Two latent test bugs: TestMarmotVoigt compares analytic vs finite-difference derivatives with the default 1e-15 tolerance, and TestMarmotFiniteStrainPlasticity reads an uninitialised Fastor tensor.


Before: does not compile. After: builds clean, 46/46 ctests pass (Apple M4, clang 20, C++20, libc++). Nothing here is arm-specific in the algorithms — the Ubuntu CI is unaffected; these only surface with libc++.