### PR TITLE
fix(mechanicscore): guard haighWestergaard() rho derivative singularity at J2=0

### DIFF
--- a/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
@@ -79,10 +79,11 @@ namespace Marmot {
       // state of exactly zero): autodiff/complex-step differentiation propagates that as a NaN
       // *derivative* even though rho's *value* (0) is perfectly well defined there. Below a tiny
       // threshold, skip sqrt() entirely and construct an exact zero of the correct type instead
-      // -- mirroring dRho_dStress()'s existing "rho <= 1e-16" near-origin convention (squared:
-      // J2 <= ~1e-32) -- rather than letting sqrt() propagate a NaN derivative. This also
-      // absorbs J2 rounding to a tiny negative value for near-hydrostatic states.
-      hw.rho = Marmot::Math::makeReal( J2_ ) <= 1e-32 ? T( 0. ) : sqrt( 2. * J2_ );
+      // -- mirroring dRho_dStress()'s existing "rho <= 1e-16" near-origin convention exactly
+      // (rho = sqrt(2*J2) <= 1e-16  <=>  J2 <= 5e-33) -- rather than letting sqrt() propagate a
+      // NaN derivative. This also absorbs J2 rounding to a tiny negative value for
+      // near-hydrostatic states.
+      hw.rho = Marmot::Math::makeReal( J2_ ) <= 5e-33 ? T( 0. ) : sqrt( 2. * J2_ );
 
       if ( Marmot::Math::makeReal( hw.rho ) != 0 ) {
         const T J3_ = J3( stress );

--- a/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
@@ -75,7 +75,14 @@ namespace Marmot {
       HaighWestergaardCoordinates< T > hw;
       const auto                       J2_ = J2( stress );
       hw.xi                                = I1( stress ) / sqrt3;
-      hw.rho                               = sqrt( 2. * J2_ );
+      // sqrt()'s derivative is singular at J2=0 (the hydrostatic axis, e.g. a virgin stress
+      // state of exactly zero): autodiff/complex-step differentiation propagates that as a NaN
+      // *derivative* even though rho's *value* (0) is perfectly well defined there. Below a tiny
+      // threshold, skip sqrt() entirely and construct an exact zero of the correct type instead
+      // -- mirroring dRho_dStress()'s existing "rho <= 1e-16" near-origin convention (squared:
+      // J2 <= ~1e-32) -- rather than letting sqrt() propagate a NaN derivative. This also
+      // absorbs J2 rounding to a tiny negative value for near-hydrostatic states.
+      hw.rho = Marmot::Math::makeReal( J2_ ) <= 1e-32 ? T( 0. ) : sqrt( 2. * J2_ );
 
       if ( Marmot::Math::makeReal( hw.rho ) != 0 ) {
         const T J3_ = J3( stress );

--- a/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
@@ -93,9 +93,6 @@ void testHaighWestergaardDual()
 
   throwExceptionOnFailure( checkIfEqual( hwoutput.xi, hwref.xi, 1e-13 ),
                            MakeString() << __PRETTY_FUNCTION__ << " test 1  failed: error in xi" );
-  // rho's derivative (not just its value) is checked here too: before the J2~0 guard in
-  // haighWestergaard(), sqrt()'s singular derivative at J2=0 made this a NaN and this check had
-  // to be disabled.
   throwExceptionOnFailure( checkIfEqual( hwoutput.rho, hwref.rho ),
                            MakeString() << __PRETTY_FUNCTION__ << " test 1  failed: error in rho" );
   throwExceptionOnFailure( checkIfEqual( hwoutput.theta, hwref.theta ),

--- a/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
@@ -93,8 +93,11 @@ void testHaighWestergaardDual()
 
   throwExceptionOnFailure( checkIfEqual( hwoutput.xi, hwref.xi, 1e-13 ),
                            MakeString() << __PRETTY_FUNCTION__ << " test 1  failed: error in xi" );
-  // throwExceptionOnFailure( checkIfEqual( hwoutput.rho, hwref.rho ),
-  //                          MakeString() << __PRETTY_FUNCTION__ << " test 1  failed: error in rho" );
+  // rho's derivative (not just its value) is checked here too: before the J2~0 guard in
+  // haighWestergaard(), sqrt()'s singular derivative at J2=0 made this a NaN and this check had
+  // to be disabled.
+  throwExceptionOnFailure( checkIfEqual( hwoutput.rho, hwref.rho ),
+                           MakeString() << __PRETTY_FUNCTION__ << " test 1  failed: error in rho" );
   throwExceptionOnFailure( checkIfEqual( hwoutput.theta, hwref.theta ),
                            MakeString() << __PRETTY_FUNCTION__ << " test 1  failed: error in theta" );
 


### PR DESCRIPTION
sqrt()'s derivative is singular at a zero argument, so autodiff / complex-step differentiation propagates a NaN *derivative* through `rho` even though `rho`'s *value* (0) is well defined on the hydrostatic axis. This is hit by every material point's first yield when the prior stress state is exactly zero (e.g. after a zero-load warm-up step), poisoning the local return-mapping Jacobian while the residual itself stays finite.

The fix guards the `rho` derivative at `J2=0`. Narrowly scoped, correct on its own merits independent of any surrounding investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)