### PR TITLE
fix(mechanicscore): make haighWestergaard() near-origin threshold relative, not absolute

### DIFF
--- a/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
@@ -27,6 +27,7 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotTypedefs.h"
 #include "Marmot/MarmotVoigt.h"
+#include <algorithm>
 
 /**
  * @file HaighWestergaard.h
@@ -77,13 +78,23 @@ namespace Marmot {
       hw.xi                                = I1( stress ) / sqrt3;
       // sqrt()'s derivative is singular at J2=0 (the hydrostatic axis, e.g. a virgin stress
       // state of exactly zero): autodiff/complex-step differentiation propagates that as a NaN
-      // *derivative* even though rho's *value* (0) is perfectly well defined there. Below a tiny
+      // *derivative* even though rho's *value* (0) is perfectly well defined there. Below a
       // threshold, skip sqrt() entirely and construct an exact zero of the correct type instead
-      // -- mirroring dRho_dStress()'s existing "rho <= 1e-16" near-origin convention exactly
-      // (rho = sqrt(2*J2) <= 1e-16  <=>  J2 <= 5e-33) -- rather than letting sqrt() propagate a
-      // NaN derivative. This also absorbs J2 rounding to a tiny negative value for
-      // near-hydrostatic states.
-      hw.rho = Marmot::Math::makeReal( J2_ ) <= 5e-33 ? T( 0. ) : sqrt( 2. * J2_ );
+      // -- rather than letting sqrt() propagate a NaN derivative. This also absorbs J2 rounding
+      // to a tiny negative value for near-hydrostatic states.
+      //
+      // The threshold is relative to the stress tensor's own squared magnitude, NOT a fixed
+      // absolute constant: an absolute cutoff near machine epsilon (previously 5e-33, mirroring
+      // dRho_dStress()'s "rho <= 1e-16" convention squared) is far tighter than the actual
+      // floating-point roundoff floor of J2 -- a sum of squared stress-difference terms, itself
+      // subject to ~1e-16 RELATIVE roundoff. For a virgin (theoretically exactly zero) stress
+      // state, that roundoff floor scales with the stress components' own magnitude, which is
+      // unit-dependent (Pa vs. MPa vs. GPa) and can therefore land on either side of a fixed tiny
+      // absolute threshold depending on compiler/SIMD summation order -- observed in practice as
+      // AMR marking decisions flipping between a local build and CI for bit-identical input.
+      const auto   stressScaleSquared = Marmot::Math::makeReal( stress.squaredNorm() );
+      const double j2Threshold        = std::max( 1e-30, 1e-12 * stressScaleSquared );
+      hw.rho                          = Marmot::Math::makeReal( J2_ ) <= j2Threshold ? T( 0. ) : sqrt( 2. * J2_ );
 
       if ( Marmot::Math::makeReal( hw.rho ) != 0 ) {
         const T J3_ = J3( stress );

--- a/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
@@ -208,6 +208,25 @@ void testHaighWestergaardFromStrain()
                            MakeString() << __PRETTY_FUNCTION__ << " failed: error in theta" );
 }
 
+void testHaighWestergaardLargeMagnitudeHydrostatic()
+{
+  // The near-origin guard's threshold is relative to the stress tensor's own squared magnitude
+  // (see HaighWestergaard.h), so a Pa-scale (as opposed to this file's other tests' O(10)-scale)
+  // exactly hydrostatic stress state must still resolve to rho == 0 exactly -- guards against a
+  // relative threshold that scales incorrectly (e.g. inverted, or off by enough orders of
+  // magnitude to stop catching genuinely hydrostatic states at realistic engineering stress
+  // scales).
+  Eigen::Matrix< double, 6, 1 > stress;
+  stress << -1e6, -1e6, -1e6, 0., 0., 0.;
+
+  const auto hw = haighWestergaard( stress );
+
+  throwExceptionOnFailure( checkIfEqual( hw.rho, 0. ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " failed: rho should be exactly zero for a "
+                                           "large-magnitude, exactly hydrostatic stress state" );
+}
+
 int main()
 {
   auto tests = std::vector< std::function< void() > >{
@@ -215,6 +234,7 @@ int main()
     testHaighWestergaardDual,
     testHaighWestergaardComplexDouble,
     testHaighWestergaardFromStrain,
+    testHaighWestergaardLargeMagnitudeHydrostatic,
   };
 
   executeTestsAndCollectExceptions( tests );


### PR DESCRIPTION
## Summary

PR #59's near-origin guard in `haighWestergaard()` (skip `sqrt()` below a
`J2` threshold to avoid propagating a NaN derivative at the hydrostatic
axis) used a fixed absolute threshold (`J2 <= 5e-33`, mirroring
`dRho_dStress()`'s `rho <= 1e-16` convention squared). That threshold is
far tighter than the actual floating-point roundoff floor of `J2` — a
difference of two `O(stress^2)` terms (`I1^2/3 - I2`), itself subject to
~1e-16 relative roundoff. For a virgin (theoretically exactly zero)
stress state at any realistic engineering stress scale, whether the
computed `J2` lands above or below `5e-33` depends on compiler/SIMD
summation order, not on anything physical.

**Observed in practice**: several EdelweissFE AMR tests (all evaluating a
marker on the very first, zero-stress increment) passed reproducibly on
one machine/compiler and failed reproducibly on another — verified same
Marmot commit, same EdelweissFE commit, same thread count, clean
worktrees on both sides. The failures were bit-identical across unrelated
test cases, consistent with all of them hitting this exact branch.

## Fix

Threshold relative to the stress tensor's own squared magnitude
(`1e-12 * stress.squaredNorm()`, floored at `1e-30` for the all-zero-input
edge case) instead of a fixed constant.

## Test plan

- [x] Full Marmot suite: 46/46 passing
- [x] Added `testHaighWestergaardLargeMagnitudeHydrostatic`: a Pa-scale
      (not this file's usual O(10)) exactly-hydrostatic stress state must
      still resolve to `rho == 0` exactly
- [x] With the fixed library, all previously-divergent EdelweissFE AMR
      tests (`AMR_DynamicRefinement`, `AMR_DynamicRefinementEquilibrate`,
      `AMR_DynamicRefinementProjection`, `AMR_MixedMeshRefine`,
      `AMR_Refine3x3x3`, `AMR_TransparencyProbe`, `AMR_ContactRefineShear`)
      now pass
- Note: a unit test that discriminates the OLD vs. NEW threshold locally
  could not be constructed — the whole premise of the bug is that it
  doesn't reproduce on this machine/compiler, only on CI's.