### PR TITLE
feat(materials): add Hughes-Winget co-rotational wrapper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   hooks:
   - id: clang-format
     args: [ "--verbose", "--Werror"]
+    exclude: \.json$
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:

--- a/doc/pages/features/hugheswinget.rst
+++ b/doc/pages/features/hugheswinget.rst
@@ -19,14 +19,14 @@ Usage
 The wrapper is registered per material under the name of the wrapped model, suffixed with
 ``/HUGHES-WINGET``. In an EdelweissFE input file::
 
-  *material, name=VonMises/Hughes-Winget, id=myMaterial
+  *material, name=VONMISES/HUGHES-WINGET, id=myMaterial
   210000, 0.3, 550, 1000, 200, 1400
 
 and in EdelweissMeshfree:
 
 .. code-block:: python
 
-  material = {"material": "VonMises/Hughes-Winget", "properties": np.array([...])}
+  material = {"material": "VONMISES/HUGHES-WINGET", "properties": np.array([...])}
 
 All material properties are forwarded to the wrapped model unchanged; the wrapper consumes none of
 them.

--- a/doc/pages/features/hugheswinget.rst
+++ b/doc/pages/features/hugheswinget.rst
@@ -1,0 +1,162 @@
+.. _hughesWingetWrapper:
+
+Hughes-Winget wrapper
+=====================
+
+A decorator that makes any small-strain (hypoelastic) material usable wherever a finite-strain
+material is expected -- updated-Lagrangian elements such as ``C3D8UL``, and the meshfree
+``Displacement/...`` particles and material points.
+
+``MarmotMaterialHypoElastic`` and ``MarmotMaterialFiniteStrain`` are unrelated interfaces: the former
+returns the Cauchy stress and :math:`\partial\boldsymbol{\sigma}/\partial\boldsymbol{\varepsilon}`
+for a linearized strain increment, the latter the Kirchhoff stress and
+:math:`\partial\boldsymbol{\tau}/\partial\boldsymbol{F}`. ``HughesWingetWrapper`` bridges the two by
+integrating the small-strain model along an objective, co-rotational path.
+
+Usage
+-----
+
+The wrapper is registered per material under the name of the wrapped model, suffixed with
+``/HUGHES-WINGET``. In an EdelweissFE input file::
+
+  *material, name=VonMises/Hughes-Winget, id=myMaterial
+  210000, 0.3, 550, 1000, 200, 1400
+
+and in EdelweissMeshfree:
+
+.. code-block:: python
+
+  material = {"material": "VonMises/Hughes-Winget", "properties": np.array([...])}
+
+All material properties are forwarded to the wrapped model unchanged; the wrapper consumes none of
+them.
+
+Registering a further material
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add one line to that material's own ``<Name>Registration.cpp``:
+
+.. code-block:: cpp
+
+  #include "Marmot/MarmotMaterialHughesWinget.h"
+  ...
+  const static bool VonMisesHughesWingetIsRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
+    HughesWingetWrapper< VonMisesModel > >( "VONMISES/HUGHES-WINGET" );
+
+Theory
+------
+
+Let :math:`\boldsymbol{F}^{(n)}` and :math:`\boldsymbol{F}^{(n+1)}` be the deformation gradients at
+the beginning and the end of the increment. The velocity gradient increment is evaluated on the
+mid-step configuration,
+
+.. math:: \Delta\boldsymbol{l}
+   = \left(\boldsymbol{F}^{(n+1)}-\boldsymbol{F}^{(n)}\right)\boldsymbol{F}_\mathrm{mid}^{-1},
+   \qquad
+   \boldsymbol{F}_\mathrm{mid} = \tfrac{1}{2}\left(\boldsymbol{F}^{(n)}+\boldsymbol{F}^{(n+1)}\right),
+
+and split into its symmetric and skew parts
+
+.. math:: \Delta\boldsymbol{\varepsilon} = \tfrac{1}{2}\left(\Delta\boldsymbol{l}+\Delta\boldsymbol{l}^{T}\right),
+   \qquad
+   \Delta\boldsymbol{\Omega} = \tfrac{1}{2}\left(\Delta\boldsymbol{l}-\Delta\boldsymbol{l}^{T}\right).
+
+The incremental rotation follows from the Cayley transform
+
+.. math:: \Delta\boldsymbol{R}
+   = \left(\boldsymbol{I}-\tfrac{1}{2}\Delta\boldsymbol{\Omega}\right)^{-1}
+     \left(\boldsymbol{I}+\tfrac{1}{2}\Delta\boldsymbol{\Omega}\right),
+
+which is orthogonal to machine precision. The stress carried over from the previous increment is
+rotated forward,
+
+.. math:: \boldsymbol{\sigma}_\mathrm{rot}
+   = \Delta\boldsymbol{R}\,\boldsymbol{\sigma}^{(n)}\,\Delta\boldsymbol{R}^{T},
+
+the wrapped material is evaluated with :math:`\left(\boldsymbol{\sigma}_\mathrm{rot},
+\Delta\boldsymbol{\varepsilon}\right)`, and its updated Cauchy stress is pushed forward to the
+Kirchhoff stress expected by the consumers,
+
+.. math:: \boldsymbol{\tau} = J\,\boldsymbol{\sigma}^{(n+1)}, \qquad J = \det\boldsymbol{F}^{(n+1)}.
+
+Superimposed rigid rotation is reproduced *exactly*, in a single increment and for any rotation
+angle below :math:`180^\circ`: for :math:`\boldsymbol{F}^{(n+1)}=\boldsymbol{Q}\boldsymbol{F}^{(n)}`
+the increment :math:`\Delta\boldsymbol{l}` is exactly skew, hence
+:math:`\Delta\boldsymbol{\varepsilon}=\boldsymbol{0}` and
+:math:`\Delta\boldsymbol{R}=\boldsymbol{Q}`.
+
+Algorithmic tangent
+^^^^^^^^^^^^^^^^^^^
+
+With :math:`\boldsymbol{M}=\boldsymbol{F}_\mathrm{mid}^{-1}`,
+:math:`\boldsymbol{P}=\boldsymbol{I}-\tfrac{1}{2}\Delta\boldsymbol{l}`,
+:math:`\boldsymbol{A}=\boldsymbol{I}-\tfrac{1}{2}\Delta\boldsymbol{\Omega}` and
+:math:`\boldsymbol{G}=\left(\boldsymbol{I}+\Delta\boldsymbol{R}\right)\boldsymbol{\sigma}^{(n)}\Delta\boldsymbol{R}^{T}`,
+
+.. math:: \frac{\partial\Delta l_{ij}}{\partial F_{kl}} = P_{ik}M_{lj},
+   \qquad
+   \frac{\partial\sigma_{\mathrm{rot},ij}}{\partial\Delta\Omega_{kl}}
+   = \tfrac{1}{2}\left(A^{-1}_{ik}G_{lj}+A^{-1}_{jk}G_{li}\right),
+
+from which, with :math:`\mathbf{C}` the tangent reported by the wrapped material,
+
+.. math:: \frac{\partial\tau_{ij}}{\partial F_{kl}}
+   = \sigma^{(n+1)}_{ij}\,J\,F^{-1}_{lk}
+   + J\left(\frac{\partial\sigma_{\mathrm{rot},ij}}{\partial\Delta\Omega_{mn}}
+            \frac{\partial\Delta\Omega_{mn}}{\partial F_{kl}}
+          + C_{ijmn}\frac{\partial\Delta\varepsilon_{mn}}{\partial F_{kl}}\right).
+
+Tangent modes
+^^^^^^^^^^^^^
+
+The second template parameter selects how the tangent is obtained.
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - **Mode**
+     - **Wrapped-material evaluations**
+     - **Consistency**
+   * - ``Analytic`` (default)
+     - 1
+     - Exact while the wrapped model responds elastically. The expression above implicitly assumes
+       :math:`\partial\boldsymbol{\sigma}^{(n+1)}/\partial\boldsymbol{\sigma}_\mathrm{rot}=\boldsymbol{I}`,
+       so during plastic flow the relative tangent error is bounded by roughly
+       :math:`\|\boldsymbol{\sigma}\|/\|\mathbf{C}^\mathrm{e}\|`.
+   * - ``Exact``
+     - 7
+     - Recovers :math:`\boldsymbol{S}=\partial\boldsymbol{\sigma}^{(n+1)}/\partial\boldsymbol{\sigma}_\mathrm{rot}`
+       by forward-differencing the six incoming stress components. Fully consistent. Worth the cost
+       for softening models under large incremental rotation.
+   * - ``Numerical``
+     - 11
+     - Forward-differences the complete update with respect to :math:`\boldsymbol{F}`. Fully
+       consistent and model-agnostic; intended for verification and debugging.
+
+Characteristic element length
+-----------------------------
+
+The wrapper forwards ``setCharacteristicElementLength`` to the wrapped model, but derives **no**
+length from geometry. Until one is assigned the wrapped model sees ``NaN``, so a model that actually
+depends on it (for a mesh-adjusted softening modulus) fails loudly rather than silently regularising
+against a wrong length. Models that never read it are unaffected.
+
+In EdelweissMeshfree, assign one per particle -- particles carry no mesh, so nothing else can:
+
+.. code-block:: python
+
+  for particle in model.particles.values():
+      particle.setProperty("characteristic element length",
+                           particle.getVolumeUndeformed() ** (1.0 / dimension))
+
+.. warning::
+
+   **Only the stress is rotated.** Tensor-valued internal variables of the wrapped model --
+   kinematic-hardening back stresses, plastic strain tensors, anisotropic damage tensors -- are
+   passed through untouched and are therefore *not* objective under large incremental rotation.
+   Models whose internal state is scalar or isotropic-invariant (isotropic hardening, scalar damage)
+   are unaffected.
+
+.. doxygenclass:: Marmot::Materials::HughesWingetWrapper
+   :allow-dot-graphs:

--- a/doc/pages/features/materials.rst
+++ b/doc/pages/features/materials.rst
@@ -20,3 +20,4 @@ This section contains the ready to use available material models.
   linearviscoelasticorthotropicpowerlaw
   vonmises
   advonmises
+  hugheswinget

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
@@ -299,7 +299,7 @@ public:
    * @param stateVars Pointer to the state variable array
    * @return StatView to access the state variable
    */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
+  virtual StateView getStateView( const std::string& stateName, double* stateVars ) const
   {
     return stateLayout.getStateView( stateVars, stateName );
   }

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
@@ -373,6 +373,16 @@ public:
   }
 
   /**
+   * @brief Set the characteristic element length at the considered evaluation point.
+   *
+   * Needed by materials whose softening behaviour is regularised via a mesh-adjusted softening modulus.
+   * The default implementation does nothing, so materials that do not depend on a length are unaffected.
+   *
+   * @param[in] length Characteristic element length.
+   */
+  virtual void setCharacteristicElementLength( double length ) {}
+
+  /**
    * @brief Get the mass density of the material.
    * @param[in] stateVars Pointer to the state variable array
    * @return Mass density

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialHughesWinget.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialHughesWinget.h
@@ -34,6 +34,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace Marmot::Materials {
@@ -464,7 +465,13 @@ namespace Marmot::Materials {
       auto evaluate = [&]( const Tensor33d& F ) -> Tensor33d {
         std::memcpy( scratch.data(), stateOld.data(), nTotal * sizeof( double ) );
         ConstitutiveResponse< 3 > perturbed;
-        perturbed.stateVars = scratch.data();
+        // Seed from the incoming (accumulated) response rather than the default-constructed zero:
+        // computeStressCore feeds these into the wrapped material's state as its starting energy /
+        // dissipation, and a material whose response depends on that history (not merely writing to
+        // it) would otherwise be perturbed from a fictitious zero baseline instead of its real one.
+        perturbed.elasticEnergyDensity = response.elasticEnergyDensity;
+        perturbed.dissipation          = response.dissipation;
+        perturbed.stateVars            = scratch.data();
         computeStressCore( perturbed, unused, Deformation< 3 >{ F }, timeIncrement, false );
         return perturbed.tau;
       };

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialHughesWinget.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialHughesWinget.h
@@ -1,0 +1,471 @@
+/* ---------------------------------------------------------------------
+ *                                       _
+ *  _ __ ___   __ _ _ __ _ __ ___   ___ | |_
+ * | '_ ` _ \ / _` | '__| '_ ` _ \ / _ \| __|
+ * | | | | | | (_| | |  | | | | | | (_) | |_
+ * |_| |_| |_|\__,_|_|  |_| |_| |_|\___/ \__|
+ *
+ * Unit of Strength of Materials and Structural Analysis
+ * University of Innsbruck,
+ * 2020 - today
+ *
+ * festigkeitslehre@uibk.ac.at
+ *
+ * This file is part of the MAteRialMOdellingToolbox (marmot).
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * The full text of the license can be found in the file LICENSE.md at
+ * the top level directory of marmot.
+ * ---------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "Marmot/MarmotFastorTensorBasics.h"
+#include "Marmot/MarmotMaterialFiniteStrain.h"
+#include "Marmot/MarmotMaterialHypoElastic.h"
+#include "Marmot/MarmotTypedefs.h"
+#include "Marmot/MarmotVoigt.h"
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace Marmot::Materials {
+
+  /**
+   * @brief Selects how the algorithmic tangent @f$ \partial\boldsymbol{\tau}/\partial\boldsymbol{F} @f$
+   *        of @ref HughesWingetWrapper is evaluated.
+   */
+  enum class HughesWingetTangent {
+    /**
+     * Closed-form linearisation of the Hughes-Winget update, assuming
+     * @f$ \partial\boldsymbol{\sigma}^{(n+1)}/\partial\boldsymbol{\sigma}_{\text{rot}} = \boldsymbol{I} @f$.
+     * Exact while the wrapped material responds elastically. One wrapped-material evaluation.
+     */
+    Analytic,
+    /**
+     * As HughesWingetTangent::Analytic, but the operator
+     * @f$ \boldsymbol{S} = \partial\boldsymbol{\sigma}^{(n+1)}/\partial\boldsymbol{\sigma}_{\text{rot}} @f$
+     * is recovered by forward-differencing the wrapped material with respect to its six incoming stress
+     * components. Fully consistent. Seven wrapped-material evaluations.
+     */
+    Exact,
+    /**
+     * The complete update is forward-differenced with respect to the nine components of
+     * @f$ \boldsymbol{F} @f$. Fully consistent and model-agnostic, but the most expensive option
+     * (eleven wrapped-material evaluations). Intended for verification and debugging.
+     */
+    Numerical
+  };
+
+  /**
+   * @class HughesWingetWrapper
+   * @brief Decorator presenting a small-strain (hypoelastic) material as a finite-strain material.
+   *
+   * @tparam BaseMaterialType A concrete class derived from MarmotMaterialHypoElastic.
+   * @tparam tangentMode      How the algorithmic tangent is evaluated, see Marmot::Materials::HughesWingetTangent.
+   *
+   * The wrapped material is driven by the objective strain increment of the Hughes-Winget algorithm,
+   * evaluated on the mid-step configuration,
+   * @f[
+   *   \Delta\boldsymbol{l} = \left(\boldsymbol{F}^{(n+1)} - \boldsymbol{F}^{(n)}\right)
+   *                          \boldsymbol{F}_{\text{mid}}^{-1}, \qquad
+   *   \boldsymbol{F}_{\text{mid}} = \tfrac{1}{2}\left(\boldsymbol{F}^{(n)} + \boldsymbol{F}^{(n+1)}\right),
+   * @f]
+   * split into its symmetric and skew parts @f$ \Delta\boldsymbol{\varepsilon} @f$ and
+   * @f$ \Delta\boldsymbol{\Omega} @f$. The incremental rotation follows from the Cayley transform
+   * @f[
+   *   \Delta\boldsymbol{R} = \left(\boldsymbol{I} - \tfrac{1}{2}\Delta\boldsymbol{\Omega}\right)^{-1}
+   *                          \left(\boldsymbol{I} + \tfrac{1}{2}\Delta\boldsymbol{\Omega}\right),
+   * @f]
+   * which is orthogonal to machine precision. The stress carried over from the previous increment is
+   * rotated forward, @f$ \boldsymbol{\sigma}_{\text{rot}} = \Delta\boldsymbol{R}\,\boldsymbol{\sigma}^{(n)}
+   * \Delta\boldsymbol{R}^{T} @f$, the wrapped material is evaluated, and the resulting Cauchy stress is
+   * pushed to the Kirchhoff stress @f$ \boldsymbol{\tau} = J\,\boldsymbol{\sigma}^{(n+1)} @f$ expected by
+   * the finite-strain consumers.
+   *
+   * @note **Only the stress is rotated.** Tensor-valued internal variables of the wrapped material
+   *       (kinematic hardening back stresses, plastic strain tensors, anisotropic damage tensors) are
+   *       passed through untouched and are therefore *not* objective under large incremental rotations.
+   *       Models whose internal state is scalar or isotropic-invariant are unaffected.
+   *
+   * @note The characteristic element length is **not** derived from any geometry here. It must be
+   *       assigned explicitly via @ref setCharacteristicElementLength; until then it is NaN, so a
+   *       wrapped material that relies on it fails loudly instead of silently regularising incorrectly.
+   */
+  template < typename BaseMaterialType, HughesWingetTangent tangentMode = HughesWingetTangent::Analytic >
+  class HughesWingetWrapper : public MarmotMaterialFiniteStrain {
+
+    static_assert( std::is_base_of_v< MarmotMaterialHypoElastic, BaseMaterialType >,
+                   "HughesWingetWrapper can only wrap materials derived from MarmotMaterialHypoElastic." );
+
+  protected:
+    /// The wrapped small-strain material. Held as the base interface: concrete materials are free to
+    /// re-declare their overrides as protected, which would make them unreachable via BaseMaterialType.
+    std::unique_ptr< MarmotMaterialHypoElastic > baseMaterial;
+
+    /// Name of the state layout slot holding the deformation gradient of the last accepted increment.
+    static constexpr const char* deformationGradientSlot = "HughesWinget_F_n";
+    /// Name of the state layout slot holding the Cauchy stress of the last accepted increment.
+    static constexpr const char* stressSlot = "HughesWinget_sigma_n";
+    /// Name of the state layout slot holding the state variables of the wrapped material.
+    static constexpr const char* baseMaterialSlot = "materialstate";
+
+  public:
+    /**
+     * @brief Construct the wrapper and the wrapped material.
+     * @param[in] matProperties_       Material property values; forwarded **unchanged** to the wrapped material.
+     * @param[in] nMaterialProperties_ Number of material property values.
+     * @param[in] materialNumber_      Unique identifier for this material instance.
+     */
+    HughesWingetWrapper( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : MarmotMaterialFiniteStrain( matProperties_, nMaterialProperties_, materialNumber_ ),
+        baseMaterial( std::make_unique< BaseMaterialType >( matProperties_, nMaterialProperties_, materialNumber_ ) )
+    {
+      // Deliberately poisoned: an unassigned characteristic length must not silently behave like a valid
+      // one. Materials that never read it are unaffected.
+      baseMaterial->setCharacteristicElementLength( std::numeric_limits< double >::quiet_NaN() );
+
+      initializeStateLayout();
+    }
+
+    virtual ~HughesWingetWrapper() = default;
+
+    /**
+     * @brief Register the state layout: the carried-over deformation gradient and Cauchy stress,
+     *        followed by the state variables of the wrapped material.
+     */
+    void initializeStateLayout()
+    {
+      this->stateLayout.add( deformationGradientSlot, 9 );
+      this->stateLayout.add( stressSlot, 6 );
+      this->stateLayout.add( baseMaterialSlot, baseMaterial->getNumberOfRequiredStateVars() );
+      this->stateLayout.finalize();
+    }
+
+    /**
+     * @brief Forward the characteristic element length to the wrapped material.
+     * @param[in] length Characteristic element length at the considered evaluation point.
+     */
+    void setCharacteristicElementLength( double length ) override
+    {
+      baseMaterial->setCharacteristicElementLength( length );
+    }
+
+    /**
+     * @brief Mass density of the wrapped material.
+     * @param[in] stateVars Pointer to the state variable array of this wrapper.
+     * @return Mass density.
+     */
+    double getDensity( const double* stateVars ) const override
+    {
+      return baseMaterial->getDensity(
+        this->stateLayout.getPtr( const_cast< double* >( stateVars ), baseMaterialSlot ) );
+    }
+
+    /**
+     * @brief Initialise the state: @f$ \boldsymbol{F}^{(n)} = \boldsymbol{I} @f$,
+     *        @f$ \boldsymbol{\sigma}^{(n)} = \boldsymbol{0} @f$, plus the wrapped material's own state.
+     * @param[in,out] stateVars  Pointer to the state variable array.
+     * @param[in]     nStateVars Number of state variables.
+     */
+    void initializeYourself( double* stateVars, int nStateVars ) override
+    {
+      using namespace Marmot::FastorStandardTensors;
+
+      TensorMap33d Fn = this->stateLayout.getAs< TensorMap33d >( stateVars, deformationGradientSlot );
+      std::memcpy( Fn.data(), Spatial3D::I.data(), 9 * sizeof( double ) );
+
+      double* sigmaN = this->stateLayout.getPtr( stateVars, stressSlot );
+      std::fill( sigmaN, sigmaN + 6, 0.0 );
+
+      baseMaterial->initializeYourself( this->stateLayout.getPtr( stateVars, baseMaterialSlot ),
+                                        baseMaterial->getNumberOfRequiredStateVars() );
+    }
+
+    /**
+     * @brief Objective stress update of the wrapped small-strain material.
+     * @param[in,out] response      Constitutive response; carries the Kirchhoff stress and state variables.
+     * @param[out]    tangents      Algorithmic moduli @f$ \partial\tau_{ij}/\partial F_{kl} @f$.
+     * @param[in]     deformation   Current deformation gradient.
+     * @param[in]     timeIncrement Current (pseudo-)time and (pseudo-)time increment.
+     */
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&    deformation,
+                        const TimeIncrement&       timeIncrement ) const override
+    {
+      if constexpr ( tangentMode == HughesWingetTangent::Numerical ) {
+        computeNumericalTangent( response, tangents, deformation, timeIncrement );
+        // The unperturbed evaluation runs last, so the committed state is the true one.
+        computeStressCore( response, tangents, deformation, timeIncrement, false );
+      }
+      else {
+        computeStressCore( response, tangents, deformation, timeIncrement, true );
+      }
+    }
+
+    /**
+     * @brief Explicit variant of @ref computeStress; no algorithmic tangent is evaluated.
+     * @param[in,out] response      Constitutive response.
+     * @param[in]     deformation   Current deformation gradient.
+     * @param[in]     timeIncrement Current (pseudo-)time and (pseudo-)time increment.
+     */
+    void computeStressExplicit( ConstitutiveResponse< 3 >& response,
+                                const Deformation< 3 >&    deformation,
+                                const TimeIncrement&       timeIncrement ) const override
+    {
+      AlgorithmicModuli< 3 > unused;
+      computeStressCore( response, unused, deformation, timeIncrement, false );
+    }
+
+  protected:
+    /// @brief Convert an Eigen 3x3 matrix into a Fastor tensor.
+    static Marmot::FastorStandardTensors::Tensor33d fromEigen( const Eigen::Matrix3d& m )
+    {
+      Marmot::FastorStandardTensors::Tensor33d t;
+      Marmot::mapEigenToFastor( t ) = m;
+      return t;
+    }
+
+    /// @brief Convert a Fastor 3x3 tensor into an Eigen matrix.
+    static Eigen::Matrix3d toEigen( const Marmot::FastorStandardTensors::Tensor33d& t )
+    {
+      return Eigen::Matrix3d( Marmot::mapEigenToFastor( t ) );
+    }
+
+    /**
+     * @brief Recover @f$ \boldsymbol{S} = \partial\boldsymbol{\sigma}^{(n+1)} /
+     *        \partial\boldsymbol{\sigma}_{\text{rot}} @f$ by forward differences.
+     *
+     * @param[in] sigmaRotVoigt  Rotated stress that was handed to the wrapped material.
+     * @param[in] sigmaNp1Voigt  Unperturbed updated stress returned by the wrapped material.
+     * @param[in] baseStateOld   Wrapped material state *before* the unperturbed evaluation.
+     * @param[in] dStrain        Strain increment handed to the wrapped material.
+     * @param[in] timeInfo       Time information handed to the wrapped material.
+     * @return The sensitivity in Voigt form, with its three shear **columns** halved so that the
+     *         result may be contracted as a full fourth-order tensor without double counting the
+     *         off-diagonal stress components.
+     */
+    Marmot::Matrix6d computeStressSensitivity( const Marmot::Vector6d&                    sigmaRotVoigt,
+                                               const Marmot::Vector6d&                    sigmaNp1Voigt,
+                                               const std::vector< double >&               baseStateOld,
+                                               const Marmot::Vector6d&                    dStrain,
+                                               const MarmotMaterialHypoElastic::timeInfo& timeInfo ) const
+    {
+      const int nBase = baseMaterial->getNumberOfRequiredStateVars();
+
+      const double scale = std::max( 1.0, sigmaRotVoigt.cwiseAbs().maxCoeff() );
+      const double h     = std::sqrt( std::numeric_limits< double >::epsilon() ) * scale;
+
+      Marmot::Matrix6d S = Marmot::Matrix6d::Zero();
+
+      std::vector< double > scratch( nBase );
+      for ( int j = 0; j < 6; ++j ) {
+        if ( nBase > 0 )
+          std::memcpy( scratch.data(), baseStateOld.data(), nBase * sizeof( double ) );
+
+        MarmotMaterialHypoElastic::state3D perturbed;
+        perturbed.stress = sigmaRotVoigt;
+        perturbed.stress( j ) += h;
+        perturbed.stateVars = nBase > 0 ? scratch.data() : nullptr;
+
+        Marmot::Matrix6d dummyTangent = Marmot::Matrix6d::Zero();
+        baseMaterial->computeStress( perturbed, dummyTangent, dStrain, timeInfo );
+
+        S.col( j ) = ( perturbed.stress - sigmaNp1Voigt ) / h;
+      }
+
+      // Halve the shear columns: contracting S as a fourth-order tensor sums over both the (m,n) and
+      // (n,m) entries of a symmetric stress, which would otherwise count each off-diagonal twice.
+      S.rightCols( 3 ) *= 0.5;
+
+      return S;
+    }
+
+    /**
+     * @brief The Hughes-Winget update proper, optionally including the analytic algorithmic tangent.
+     * @param[in,out] response       Constitutive response.
+     * @param[out]    tangents       Algorithmic moduli; only written when @p computeTangent is true.
+     * @param[in]     deformation    Current deformation gradient.
+     * @param[in]     timeIncrement  Current (pseudo-)time and (pseudo-)time increment.
+     * @param[in]     computeTangent Whether the analytic tangent is to be evaluated.
+     */
+    void computeStressCore( ConstitutiveResponse< 3 >& response,
+                            AlgorithmicModuli< 3 >&    tangents,
+                            const Deformation< 3 >&    deformation,
+                            const TimeIncrement&       timeIncrement,
+                            bool                       computeTangent ) const
+    {
+      using namespace Fastor;
+      using namespace Marmot::FastorStandardTensors;
+      using namespace Marmot::FastorIndices;
+      using namespace Marmot::ContinuumMechanics::VoigtNotation;
+
+      const Tensor33d& Ident = Spatial3D::I;
+
+      TensorMap33d Fn_ref    = this->stateLayout.getAs< TensorMap33d >( response.stateVars, deformationGradientSlot );
+      double*      sigmaNPtr = this->stateLayout.getPtr( response.stateVars, stressSlot );
+      double*      baseState = this->stateLayout.getPtr( response.stateVars, baseMaterialSlot );
+
+      // Hosts are not obliged to call initializeYourself(): DisplacementFiniteStrainULElement only does
+      // so on an explicit "initialize material" initial condition. Marmot's convention is that a zeroed
+      // state vector means pristine, so an all-zero F_n is the identity here -- without this, F_mid would
+      // be singular on the very first increment and the wrapped material would see a garbage increment.
+      const Tensor33d Fn  = ( Fastor::norm( Fn_ref ) == 0.0 ) ? Tensor33d( Ident ) : Tensor33d( Fn_ref );
+      const Tensor33d Fn1 = deformation.F;
+
+      // --- Hughes-Winget kinematics, evaluated on the mid-step configuration ---
+      const Tensor33d M    = inverse( Tensor33d( 0.5 * ( Fn + Fn1 ) ) );
+      const Tensor33d dl   = Tensor33d( Fn1 - Fn ) % M;
+      const Tensor33d dEps = 0.5 * ( dl + transpose( dl ) );
+      const Tensor33d dOm  = 0.5 * ( dl - transpose( dl ) );
+
+      const Tensor33d Ainv = inverse( Tensor33d( Ident - 0.5 * dOm ) );
+      const Tensor33d dR   = Ainv % Tensor33d( Ident + 0.5 * dOm );
+
+      // --- rotate the carried-over Cauchy stress forward ---
+      Eigen::Map< const Marmot::Vector6d > sigmaNVoigtMap( sigmaNPtr );
+      const Marmot::Vector6d               sigmaNVoigt = sigmaNVoigtMap;
+      const Tensor33d                      sigmaN      = fromEigen( stressMatrixFromVoigt< 3 >( sigmaNVoigt ) );
+      const Tensor33d                      sigmaRot    = dR % sigmaN % transpose( dR );
+
+      // --- evaluate the wrapped small-strain material ---
+      const int             nBase = baseMaterial->getNumberOfRequiredStateVars();
+      std::vector< double > baseStateOld;
+      if constexpr ( tangentMode == HughesWingetTangent::Exact ) {
+        if ( computeTangent && nBase > 0 ) {
+          baseStateOld.resize( nBase );
+          std::memcpy( baseStateOld.data(), baseState, nBase * sizeof( double ) );
+        }
+      }
+
+      const Marmot::Vector6d sigmaRotVoigt = stressToVoigt< double >( toEigen( sigmaRot ) );
+      const Marmot::Vector6d dEpsVoigt     = voigtFromStrainMatrix< 3 >( toEigen( dEps ) );
+
+      MarmotMaterialHypoElastic::state3D state;
+      state.stress               = sigmaRotVoigt;
+      state.elasticEnergyDensity = response.elasticEnergyDensity;
+      state.dissipation          = response.dissipation;
+      state.stateVars            = baseState;
+
+      const MarmotMaterialHypoElastic::timeInfo timeInfo{ timeIncrement.time, timeIncrement.dT };
+
+      Marmot::Matrix6d C = Marmot::Matrix6d::Zero();
+      baseMaterial->computeStress( state, C, dEpsVoigt, timeInfo );
+
+      const Marmot::Vector6d sigmaNp1Voigt = state.stress;
+      const Tensor33d        sigmaNp1      = fromEigen( stressMatrixFromVoigt< 3 >( sigmaNp1Voigt ) );
+
+      // --- push the Cauchy stress forward to the Kirchhoff stress ---
+      const double    J    = determinant( Fn1 );
+      const Tensor33d Finv = inverse( Fn1 );
+
+      response.tau = J * sigmaNp1;
+      // The wrapped material reports densities per unit current volume; the finite-strain consumers
+      // integrate against the reference volume.
+      response.elasticEnergyDensity = J * state.elasticEnergyDensity;
+      response.dissipation          = J * state.dissipation;
+
+      if ( computeTangent ) {
+        const Tensor33d P  = Ident - 0.5 * dl;
+        const Tensor33d Mt = transpose( M );
+
+        // d(dl)_ij/dF_kl = P_ik M_lj ; the transposed pattern gives d(dl)_ji/dF_kl
+        const Tensor3333d dl_dF   = einsum< ik, jl, to_ijkl >( P, Mt );
+        const Tensor3333d dlT_dF  = einsum< jk, il, to_ijkl >( P, Mt );
+        const Tensor3333d dEps_dF = 0.5 * ( dl_dF + dlT_dF );
+        const Tensor3333d dOm_dF  = 0.5 * ( dl_dF - dlT_dF );
+
+        // d(sigmaRot)_ij/d(dOmega)_kl = 0.5 ( Ainv_ik G_lj + Ainv_jk G_li ),  G = (I + dR) sigmaN dR^T
+        const Tensor33d   G           = Tensor33d( Ident + dR ) % sigmaN % transpose( dR );
+        const Tensor33d   Gt          = transpose( G );
+        const Tensor3333d dSigRot_dOm = 0.5 * ( einsum< ik, jl, to_ijkl >( Ainv, Gt ) +
+                                                einsum< jk, il, to_ijkl >( Ainv, Gt ) );
+
+        Tensor3333d dSigRot_dF = einsum< ijmn, mnKL, to_ijKL >( dSigRot_dOm, dOm_dF );
+
+        if constexpr ( tangentMode == HughesWingetTangent::Exact ) {
+          // Replace the implicit d(sigma^(n+1))/d(sigmaRot) = I assumption by the true operator.
+          const Marmot::Matrix6d S = computeStressSensitivity( sigmaRotVoigt,
+                                                               sigmaNp1Voigt,
+                                                               baseStateOld,
+                                                               dEpsVoigt,
+                                                               timeInfo );
+          dSigRot_dF               = einsum< ijmn, mnKL, to_ijKL >( voigtToStiffnessFastor( S ), dSigRot_dF );
+        }
+
+        // voigtToStiffnessFastor scatters without a factor 1/2, which is exactly what a *tensorial*
+        // strain derivative requires: summing over both (m,n) and (n,m) reproduces the engineering shear.
+        const Tensor3333d C4      = voigtToStiffnessFastor( C );
+        const Tensor3333d dSig_dF = dSigRot_dF + einsum< ijmn, mnKL, to_ijKL >( C4, dEps_dF );
+
+        const Tensor33d dJ_dF = J * transpose( Finv ); // dJ/dF_kl = J Finv_lk
+
+        tangents.dTau_dF = einsum< ij, kl, to_ijkl >( sigmaNp1, dJ_dF ) + J * dSig_dF;
+      }
+
+      // --- commit ---
+      Eigen::Map< Marmot::Vector6d > sigmaNOut( sigmaNPtr );
+      sigmaNOut = sigmaNp1Voigt;
+      Fn_ref    = Fn1;
+    }
+
+    /**
+     * @brief Forward-difference the complete update with respect to the nine components of @f$ F @f$.
+     *
+     * Every evaluation starts from a pristine copy of the incoming state, and none of them is allowed
+     * to commit: the caller runs the unperturbed update afterwards.
+     *
+     * @param[in]  response      Constitutive response, read for its state pointer only.
+     * @param[out] tangents      Algorithmic moduli.
+     * @param[in]  deformation   Current deformation gradient.
+     * @param[in]  timeIncrement Current (pseudo-)time and (pseudo-)time increment.
+     */
+    void computeNumericalTangent( const ConstitutiveResponse< 3 >& response,
+                                  AlgorithmicModuli< 3 >&          tangents,
+                                  const Deformation< 3 >&          deformation,
+                                  const TimeIncrement&             timeIncrement ) const
+    {
+      using namespace Marmot::FastorStandardTensors;
+
+      const int             nTotal = this->getNumberOfRequiredStateVars();
+      std::vector< double > stateOld( nTotal );
+      std::memcpy( stateOld.data(), response.stateVars, nTotal * sizeof( double ) );
+
+      std::vector< double >  scratch( nTotal );
+      AlgorithmicModuli< 3 > unused;
+
+      auto evaluate = [&]( const Tensor33d& F ) -> Tensor33d {
+        std::memcpy( scratch.data(), stateOld.data(), nTotal * sizeof( double ) );
+        ConstitutiveResponse< 3 > perturbed;
+        perturbed.stateVars = scratch.data();
+        computeStressCore( perturbed, unused, Deformation< 3 >{ F }, timeIncrement, false );
+        return perturbed.tau;
+      };
+
+      const Tensor33d tau0 = evaluate( deformation.F );
+
+      for ( int k = 0; k < 3; ++k )
+        for ( int l = 0; l < 3; ++l ) {
+          Tensor33d    F = deformation.F;
+          const double h = std::sqrt( std::numeric_limits< double >::epsilon() ) *
+                           std::max( 1.0, std::abs( F( k, l ) ) );
+          F( k, l ) += h;
+
+          const Tensor33d tauPerturbed = evaluate( F );
+
+          for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+              tangents.dTau_dF( i, j, k, l ) = ( tauPerturbed( i, j ) - tau0( i, j ) ) / h;
+        }
+    }
+  };
+
+} // namespace Marmot::Materials

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialHughesWinget.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialHughesWinget.h
@@ -159,6 +159,25 @@ namespace Marmot::Materials {
     }
 
     /**
+     * @brief Resolve a state variable by name, falling back to the wrapped material.
+     *
+     * Without this, the wrapped material's own state -- CDP's @c omega, a plasticity model's
+     * hardening variable -- would be unreachable through the wrapper, since the wrapper's layout only
+     * knows its own three slots.
+     *
+     * @param[in] stateName Name of the state variable.
+     * @param[in] stateVars Pointer to the state variable array of this wrapper.
+     * @return A view of the requested state variable.
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const override
+    {
+      if ( stateName == deformationGradientSlot || stateName == stressSlot || stateName == baseMaterialSlot )
+        return this->stateLayout.getStateView( stateVars, stateName );
+
+      return baseMaterial->getStateView( stateName, this->stateLayout.getPtr( stateVars, baseMaterialSlot ) );
+    }
+
+    /**
      * @brief Mass density of the wrapped material.
      * @param[in] stateVars Pointer to the state variable array of this wrapper.
      * @return Mass density.

--- a/modules/core/MarmotFiniteStrainMechanicsCore/module.cmake
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/module.cmake
@@ -5,4 +5,5 @@ list(APPEND publicheaders
     "${CMAKE_CURRENT_LIST_DIR}/include/Marmot/MarmotMaterialFiniteStrain.h"
     "${CMAKE_CURRENT_LIST_DIR}/include/Marmot/MarmotMaterialFiniteStrainFactory.h"
     "${CMAKE_CURRENT_LIST_DIR}/include/Marmot/MarmotMaterialPointSolverFiniteStrain.h"
+    "${CMAKE_CURRENT_LIST_DIR}/include/Marmot/MarmotMaterialHughesWinget.h"
     )

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
@@ -15,3 +15,6 @@ add_marmot_test("TestMarmotStressMeasures" "${CURR_TEST_SOURCE_DIR}/TestMarmotSt
 
 # Tests for MarmotFiniteStrainViscoelasticity
 add_marmot_test("TestMarmotFiniteStrainViscoelasticity" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteStrainViscoelasticity.cpp")
+
+# Tests for the Hughes-Winget small-strain wrapper
+add_marmot_test("TestMarmotMaterialHughesWinget" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialHughesWinget.cpp")

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialHughesWinget.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialHughesWinget.cpp
@@ -1,0 +1,519 @@
+/* ---------------------------------------------------------------------
+ *                                       _
+ *  _ __ ___   __ _ _ __ _ __ ___   ___ | |_
+ * | '_ ` _ \ / _` | '__| '_ ` _ \ / _ \| __|
+ * | | | | | | (_| | |  | | | | | | (_) | |_
+ * |_| |_| |_|\__,_|_|  |_| |_| |_|\___/ \__|
+ *
+ * Unit of Strength of Materials and Structural Analysis
+ * University of Innsbruck,
+ * 2020 - today
+ *
+ * festigkeitslehre@uibk.ac.at
+ *
+ * This file is part of the MAteRialMOdellingToolbox (marmot).
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * The full text of the license can be found in the file LICENSE.md at
+ * the top level directory of marmot.
+ * ---------------------------------------------------------------------
+ */
+
+#include "Marmot/MarmotFastorTensorBasics.h"
+#include "Marmot/MarmotMaterialHughesWinget.h"
+#include "Marmot/MarmotMaterialHypoElastic.h"
+#include "Marmot/MarmotTesting.h"
+#include "Marmot/MarmotVoigt.h"
+#include <Eigen/Geometry>
+#include <functional>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Materials;
+using namespace Marmot::Testing;
+using namespace Marmot::FastorStandardTensors;
+
+namespace {
+
+  /// Isotropic elastic stiffness in Voigt notation.
+  Marmot::Matrix6d isotropicStiffness( double E, double nu )
+  {
+    Marmot::Matrix6d C   = Marmot::Matrix6d::Zero();
+    const double     fac = E / ( ( 1.0 + nu ) * ( 1.0 - 2.0 * nu ) );
+    for ( int i = 0; i < 3; i++ )
+      for ( int j = 0; j < 3; j++ )
+        C( i, j ) = fac * ( i == j ? ( 1.0 - nu ) : nu );
+    for ( int i = 3; i < 6; i++ )
+      C( i, i ) = fac * ( 1.0 - 2.0 * nu ) / 2.0;
+    return C;
+  }
+
+  /**
+   * @brief Minimal hypoelastic stub: linear elastic, plus one state variable accumulating the
+   *        magnitude of the applied strain increments.
+   *
+   * The state variable makes it observable whether the wrapped material was driven at all, which the
+   * rigid-rotation test relies on.
+   */
+  class StubLinearElastic : public MarmotMaterialHypoElastic {
+  public:
+    StubLinearElastic( const double* props, int nProps, int matNumber )
+      : MarmotMaterialHypoElastic( props, nProps, matNumber )
+    {
+      stateLayout.add( "accumulatedStrain", 1 );
+      stateLayout.finalize();
+    }
+
+    void computeStress( state3D&                state,
+                        Marmot::Matrix6d&       dStress_dStrain,
+                        const Marmot::Vector6d& dStrain,
+                        const timeInfo& ) const override
+    {
+      const Marmot::Matrix6d C = isotropicStiffness( materialProperties[0], materialProperties[1] );
+      state.stress += C * dStrain;
+      dStress_dStrain = C;
+      if ( state.stateVars )
+        state.stateVars[0] += dStrain.norm();
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  /**
+   * @brief Hypoelastic stub whose updated stress depends *nonlinearly* on the incoming stress.
+   *
+   * @f$ \sigma^{(n+1)} = \sigma_{\text{rot}} / (1 + k\,\|\sigma_{\text{rot}}\|) + C:\Delta\varepsilon @f$,
+   * so @f$ \partial\sigma^{(n+1)}/\partial\sigma_{\text{rot}} \neq \boldsymbol{I} @f$. This is what
+   * separates the Analytic tangent from the Exact one, in the same way a plastic return map does,
+   * without pulling a real plasticity model into a core test.
+   */
+  class StubStressDependent : public MarmotMaterialHypoElastic {
+  public:
+    StubStressDependent( const double* props, int nProps, int matNumber )
+      : MarmotMaterialHypoElastic( props, nProps, matNumber )
+    {
+      stateLayout.add( "accumulatedStrain", 1 );
+      stateLayout.finalize();
+    }
+
+    void computeStress( state3D&                state,
+                        Marmot::Matrix6d&       dStress_dStrain,
+                        const Marmot::Vector6d& dStrain,
+                        const timeInfo& ) const override
+    {
+      const Marmot::Matrix6d C = isotropicStiffness( materialProperties[0], materialProperties[1] );
+      const double           k = materialProperties[2];
+
+      state.stress    = state.stress / ( 1.0 + k * state.stress.norm() ) + C * dStrain;
+      dStress_dStrain = C;
+      if ( state.stateVars )
+        state.stateVars[0] += dStrain.norm();
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  /// Rotation tensor from an axis-angle pair.
+  Tensor33d rotationTensor( const Eigen::Vector3d& axis, double angle )
+  {
+    const Eigen::Matrix3d Q = Eigen::AngleAxisd( angle, axis.normalized() ).toRotationMatrix();
+    Tensor33d             t;
+    Marmot::mapEigenToFastor( t ) = Q;
+    return t;
+  }
+
+  /// Matrix product of two Fastor 3x3 tensors.
+  Tensor33d mul( const Tensor33d& a, const Tensor33d& b )
+  {
+    return a % b;
+  }
+
+  /// Largest absolute component-wise difference of two fourth-order tensors.
+  double maxAbsDiff( const Tensor3333d& a, const Tensor3333d& b )
+  {
+    double m = 0.0;
+    for ( size_t i = 0; i < a.size(); i++ )
+      m = std::max( m, std::abs( a.data()[i] - b.data()[i] ) );
+    return m;
+  }
+
+  /**
+   * @brief Reference tangent: central differences of tau(F), computed *in the test* so that the
+   *        production Numerical mode is never used to validate itself.
+   */
+  template < typename MaterialType >
+  Tensor3333d referenceTangent( MaterialType&                material,
+                                const Tensor33d&             F,
+                                const std::vector< double >& stateIn,
+                                double                       time,
+                                double                       dT )
+  {
+    const int   n = material.getNumberOfRequiredStateVars();
+    Tensor3333d dTau_dF( 0.0 );
+
+    auto tauAt = [&]( const Tensor33d& Fp ) {
+      std::vector< double >                                 scratch = stateIn;
+      MarmotMaterialFiniteStrain::ConstitutiveResponse< 3 > r;
+      r.stateVars = scratch.data();
+      MarmotMaterialFiniteStrain::AlgorithmicModuli< 3 > t;
+      material.computeStress( r, t, { Fp }, { time, dT } );
+      return r.tau;
+    };
+
+    for ( int k = 0; k < 3; k++ )
+      for ( int l = 0; l < 3; l++ ) {
+        const double h  = 1e-7 * std::max( 1.0, std::abs( F( k, l ) ) );
+        Tensor33d    Fp = F, Fm = F;
+        Fp( k, l ) += h;
+        Fm( k, l ) -= h;
+        const Tensor33d taup = tauAt( Fp );
+        const Tensor33d taum = tauAt( Fm );
+        for ( int i = 0; i < 3; i++ )
+          for ( int j = 0; j < 3; j++ )
+            dTau_dF( i, j, k, l ) = ( taup( i, j ) - taum( i, j ) ) / ( 2.0 * h );
+      }
+    (void)n;
+    return dTau_dF;
+  }
+
+} // namespace
+
+using Wrapper          = HughesWingetWrapper< StubLinearElastic >;
+using WrapperNonlinear = HughesWingetWrapper< StubStressDependent >;
+using WrapperExact     = HughesWingetWrapper< StubStressDependent, HughesWingetTangent::Exact >;
+using WrapperNumerical = HughesWingetWrapper< StubStressDependent, HughesWingetTangent::Numerical >;
+
+namespace {
+  const std::vector< double > elasticProps   = { 20000.0, 0.3 };
+  const std::vector< double > nonlinearProps = { 20000.0, 0.3, 2e-3 };
+
+  /// Allocate and initialise a state vector for a wrapper instance.
+  template < typename W >
+  std::vector< double > freshState( W& w )
+  {
+    std::vector< double > s( w.getNumberOfRequiredStateVars(), 0.0 );
+    w.initializeYourself( s.data(), int( s.size() ) );
+    return s;
+  }
+
+  /// Drive one increment, returning the Kirchhoff stress and tangent.
+  template < typename W >
+  std::pair< Tensor33d, Tensor3333d > step( W&                     w,
+                                            std::vector< double >& state,
+                                            const Tensor33d&       F,
+                                            double                 time = 0.0,
+                                            double                 dT   = 1.0 )
+  {
+    MarmotMaterialFiniteStrain::ConstitutiveResponse< 3 > r;
+    r.stateVars = state.data();
+    MarmotMaterialFiniteStrain::AlgorithmicModuli< 3 > t;
+    w.computeStress( r, t, { F }, { time, dT } );
+    return { r.tau, t.dTau_dF };
+  }
+} // namespace
+
+/// The state layout must expose exactly the three documented slots.
+void testStateLayout()
+{
+  Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+
+  throwExceptionOnFailure( w.getNumberOfRequiredStateVars() == 9 + 6 + 1,
+                           "unexpected state layout size in " + std::string( __PRETTY_FUNCTION__ ) );
+
+  auto state = freshState( w );
+  throwExceptionOnFailure( w.getStateView( "HughesWinget_F_n", state.data() ).stateSize == 9,
+                           "F_n slot has the wrong size in " + std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( w.getStateView( "HughesWinget_sigma_n", state.data() ).stateSize == 6,
+                           "sigma_n slot has the wrong size in " + std::string( __PRETTY_FUNCTION__ ) );
+
+  // initializeYourself must leave F_n = I, otherwise F_mid is singular on the first increment.
+  const Tensor33d Fn( state.data() );
+  throwExceptionOnFailure( checkIfEqual( Fn, Spatial3D::I, 1e-15 ),
+                           "F_n was not initialised to the identity in " + std::string( __PRETTY_FUNCTION__ ) );
+}
+
+/// An undeformed increment must produce no stress at all.
+void testUndeformed()
+{
+  Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+  auto    state = freshState( w );
+
+  const auto [tau, dTau_dF] = step( w, state, Spatial3D::I );
+
+  throwExceptionOnFailure( checkIfEqual( tau, Tensor33d( 0.0 ), 1e-15 ),
+                           "undeformed state produced non-zero stress in " + std::string( __PRETTY_FUNCTION__ ) );
+}
+
+/**
+ * @brief Superimposed rigid rotation must be reproduced exactly, in a single increment.
+ *
+ * For F^(n+1) = Q F^(n) the Hughes-Winget increment dl is exactly skew, hence dEps vanishes and the
+ * Cayley transform returns dR = Q identically. The wrapped material must therefore not be strained at
+ * all, and the stress must merely co-rotate. This holds for any rotation with Q + I invertible.
+ */
+void testRigidRotationIsExact()
+{
+  const auto axes = fibonacciLatticeHemisphere< 12 >();
+
+  for ( int a = 0; a < axes.rows(); a++ )
+    for ( double angleDeg : { 5.0, 30.0, 90.0, 150.0 } ) {
+
+      Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+      auto    state = freshState( w );
+
+      // Pre-load with a deviatoric stretch so that sigma_n is non-trivial.
+      Tensor33d F1               = Spatial3D::I;
+      F1( 0, 0 )                 = 1.02;
+      F1( 1, 1 )                 = 0.99;
+      F1( 0, 1 )                 = 0.015;
+      const auto [tauOld, dummy] = step( w, state, F1 );
+
+      const double accumulatedBefore = state.back();
+
+      const double    theta = angleDeg * M_PI / 180.0;
+      const Tensor33d Q     = rotationTensor( Eigen::Vector3d( axes( a, 0 ),
+                                                           axes( a, 1 ),
+                                                           std::sqrt( std::max( 0.0,
+                                                                                1.0 - axes( a, 0 ) * axes( a, 0 ) -
+                                                                                  axes( a, 1 ) * axes( a, 1 ) ) ) ),
+                                          theta );
+
+      const auto [tauNew, dummy2] = step( w, state, mul( Q, F1 ) );
+
+      // The wrapped material must not have seen any strain.
+      throwExceptionOnFailure( checkIfEqual( state.back(), accumulatedBefore, 1e-14 ),
+                               "rigid rotation strained the wrapped material in " +
+                                 std::string( __PRETTY_FUNCTION__ ) );
+
+      // The Kirchhoff stress must co-rotate: tau_new = Q tau_old Q^T.
+      const Tensor33d expected = mul( mul( Q, tauOld ), Fastor::transpose( Q ) );
+      throwExceptionOnFailure( checkIfEqual( tauNew, expected, 1e-11 ),
+                               "rigid rotation did not co-rotate the stress in " + std::string( __PRETTY_FUNCTION__ ) );
+    }
+}
+
+/// At small strain the wrapper must reproduce the wrapped material driven directly.
+void testSmallStrainAgreement()
+{
+  Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+  auto    state = freshState( w );
+
+  StubLinearElastic                  direct( elasticProps.data(), int( elasticProps.size() ), 1 );
+  double                             directStateVar = 0.0;
+  MarmotMaterialHypoElastic::state3D directState;
+  directState.stateVars = &directStateVar;
+
+  // 20 increments of a small symmetric strain.
+  Eigen::Matrix3d H = Eigen::Matrix3d::Zero();
+  H( 0, 0 )         = 1e-6;
+  H( 1, 1 )         = -4e-7;
+  H( 0, 1 ) = H( 1, 0 ) = 7e-7;
+
+  Eigen::Matrix3d Ftotal = Eigen::Matrix3d::Identity();
+  for ( int n = 0; n < 20; n++ ) {
+    Ftotal += H;
+    Tensor33d F;
+    Marmot::mapEigenToFastor( F ) = Ftotal;
+    step( w, state, F );
+
+    Marmot::Matrix6d C = Marmot::Matrix6d::Zero();
+    direct.computeStress( directState,
+                          C,
+                          ContinuumMechanics::VoigtNotation::voigtFromStrainMatrix< 3 >( H ),
+                          { 0.0, 1.0 } );
+  }
+
+  Tensor33d Ffinal;
+  Marmot::mapEigenToFastor( Ffinal ) = Ftotal;
+  const auto [tau, dTau_dF]          = step( w, state, Ffinal );
+
+  const Eigen::Matrix3d sigmaDirect = ContinuumMechanics::VoigtNotation::stressMatrixFromVoigt< 3 >(
+    directState.stress );
+  Tensor33d expected;
+  Marmot::mapEigenToFastor( expected ) = sigmaDirect;
+
+  // Compare the Cauchy stress: tau = J sigma, and the J factor alone is larger than the tolerance below.
+  const Tensor33d sigma = Tensor33d( tau / Ftotal.determinant() );
+
+  // The mid-step objective rate and the naive additive strain differ at O(total strain), so the
+  // relative deviation is bounded by ~2e-5 here; that is a property of the formulation, not an error.
+  throwExceptionOnFailure( checkIfEqual( sigma, expected, 1e-5 ),
+                           "small-strain response deviates from the wrapped material in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+namespace {
+  /// A few deformation gradients combining stretch, shear and rotation.
+  std::vector< Tensor33d > probeDeformations()
+  {
+    std::vector< Tensor33d > out;
+
+    Tensor33d a = Spatial3D::I;
+    a( 0, 0 )   = 1.10;
+    a( 1, 1 )   = 0.95;
+    a( 2, 2 )   = 1.03;
+    a( 0, 1 )   = 0.20;
+    a( 1, 2 )   = 0.10;
+    a( 2, 0 )   = 0.03;
+    out.push_back( a );
+
+    // The same, with a substantial rigid rotation superimposed.
+    out.push_back( mul( rotationTensor( Eigen::Vector3d( 0.3, -0.7, 0.65 ), 0.9 ), a ) );
+
+    Tensor33d c = Spatial3D::I;
+    c( 0, 1 )   = 0.35; // simple shear
+    out.push_back( c );
+
+    return out;
+  }
+
+  /// Preload a wrapper so that sigma_n is non-zero, which is what activates the rotational tangent term.
+  template < typename W >
+  void preload( W& w, std::vector< double >& state )
+  {
+    Tensor33d F = Spatial3D::I;
+    F( 0, 0 )   = 1.05;
+    F( 1, 1 )   = 0.97;
+    F( 0, 1 )   = 0.04;
+    F( 2, 1 )   = 0.02;
+    step( w, state, F );
+  }
+} // namespace
+
+/// The analytic tangent must reproduce central differences of tau(F) for a path-independent material.
+void testAnalyticTangentVsCentralDifference()
+{
+  for ( const auto& F : probeDeformations() ) {
+    Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+    auto    state = freshState( w );
+    preload( w, state );
+
+    const std::vector< double > stateIn = state;
+    const auto [tau, analytic]          = step( w, state, F );
+    const Tensor3333d reference         = referenceTangent( w, F, stateIn, 0.0, 1.0 );
+
+    const double scale = std::max( 1.0, Fastor::norm( reference ) );
+    throwExceptionOnFailure( checkIfEqual( analytic, reference, 1e-6 * scale ),
+                             "analytic tangent deviates from central differences in " +
+                               std::string( __PRETTY_FUNCTION__ ) );
+  }
+}
+
+/**
+ * @brief With a stress-dependent wrapped material the Analytic mode is knowingly inexact, and the
+ *        Exact and Numerical modes are not.
+ */
+void testExactAndNumericalTangentModes()
+{
+  bool analyticDeviatedSomewhere = false;
+
+  for ( const auto& F : probeDeformations() ) {
+
+    WrapperNonlinear wAnalytic( nonlinearProps.data(), int( nonlinearProps.size() ), 1 );
+    WrapperExact     wExact( nonlinearProps.data(), int( nonlinearProps.size() ), 1 );
+    WrapperNumerical wNumeric( nonlinearProps.data(), int( nonlinearProps.size() ), 1 );
+
+    auto sAnalytic = freshState( wAnalytic );
+    auto sExact    = freshState( wExact );
+    auto sNumeric  = freshState( wNumeric );
+    preload( wAnalytic, sAnalytic );
+    preload( wExact, sExact );
+    preload( wNumeric, sNumeric );
+
+    const std::vector< double > stateIn = sAnalytic;
+
+    const auto [tauA, tangentAnalytic] = step( wAnalytic, sAnalytic, F );
+    const auto [tauE, tangentExact]    = step( wExact, sExact, F );
+    const auto [tauN, tangentNumeric]  = step( wNumeric, sNumeric, F );
+
+    // The stress itself must not depend on how the tangent is obtained.
+    throwExceptionOnFailure( checkIfEqual( tauA, tauE, 1e-12 ) && checkIfEqual( tauA, tauN, 1e-12 ),
+                             "tangent mode changed the stress in " + std::string( __PRETTY_FUNCTION__ ) );
+
+    const Tensor3333d reference = referenceTangent( wAnalytic, F, stateIn, 0.0, 1.0 );
+    const double      scale     = std::max( 1.0, Fastor::norm( reference ) );
+
+    throwExceptionOnFailure( checkIfEqual( tangentExact, reference, 1e-5 * scale ),
+                             "Exact tangent deviates from central differences in " +
+                               std::string( __PRETTY_FUNCTION__ ) );
+    throwExceptionOnFailure( checkIfEqual( tangentNumeric, reference, 1e-5 * scale ),
+                             "Numerical tangent deviates from central differences in " +
+                               std::string( __PRETTY_FUNCTION__ ) );
+
+    // Guard against Exact silently falling back to Analytic: for at least one of these deformations
+    // the shortcut must be measurably worse. It need not be worse for all of them, since the neglected
+    // term scales with the rotational part of the increment.
+    if ( maxAbsDiff( tangentAnalytic, reference ) > 1e-5 * scale )
+      analyticDeviatedSomewhere = true;
+  }
+
+  throwExceptionOnFailure( analyticDeviatedSomewhere,
+                           "the stress-dependent stub never exercised the d(sigma)/d(sigma_rot) term, so "
+                           "this test cannot distinguish Exact from Analytic in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+/// The Kirchhoff stress must stay symmetric.
+void testStressSymmetry()
+{
+  for ( const auto& F : probeDeformations() ) {
+    Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+    auto    state = freshState( w );
+    preload( w, state );
+    const auto [tau, t] = step( w, state, F );
+
+    throwExceptionOnFailure( checkIfEqual( tau, Tensor33d( Fastor::transpose( tau ) ), 1e-12 ),
+                             "Kirchhoff stress is not symmetric in " + std::string( __PRETTY_FUNCTION__ ) );
+  }
+}
+
+/**
+ * @brief Purely volumetric deformation: tau = J sigma, with the Hughes-Winget normal strain increment
+ *        dEps_ii = 2 (lambda - 1) / (lambda + 1) rather than log(lambda) or (lambda - 1).
+ */
+void testVolumetricScaling()
+{
+  const double lambda = 1.05;
+
+  Wrapper w( elasticProps.data(), int( elasticProps.size() ), 1 );
+  auto    state = freshState( w );
+
+  const auto [tau, t] = step( w, state, Tensor33d( lambda * Spatial3D::I ) );
+
+  const double     dEpsIi  = 2.0 * ( lambda - 1.0 ) / ( lambda + 1.0 );
+  Marmot::Vector6d dStrain = Marmot::Vector6d::Zero();
+  dStrain.head( 3 ).setConstant( dEpsIi );
+
+  StubLinearElastic                  direct( elasticProps.data(), int( elasticProps.size() ), 1 );
+  double                             sv = 0.0;
+  MarmotMaterialHypoElastic::state3D ds;
+  ds.stateVars       = &sv;
+  Marmot::Matrix6d C = Marmot::Matrix6d::Zero();
+  direct.computeStress( ds, C, dStrain, { 0.0, 1.0 } );
+
+  const double J = lambda * lambda * lambda;
+  Tensor33d    expected;
+  Marmot::mapEigenToFastor( expected ) = J * ContinuumMechanics::VoigtNotation::stressMatrixFromVoigt< 3 >( ds.stress );
+
+  throwExceptionOnFailure( checkIfEqual( tau, expected, 1e-10 ),
+                           "volumetric response does not match J * sigma in " + std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{ testStateLayout,
+                                                       testUndeformed,
+                                                       testRigidRotationIsExact,
+                                                       testSmallStrainAgreement,
+                                                       testAnalyticTangentVsCentralDifference,
+                                                       testExactAndNumericalTangentModes,
+                                                       testStressSymmetry,
+                                                       testVolumetricScaling };
+
+  executeTestsAndCollectExceptions( tests );
+  return 0;
+}

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialHughesWinget.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialHughesWinget.cpp
@@ -23,6 +23,7 @@
  * ---------------------------------------------------------------------
  */
 
+#include "Marmot/MarmotConstants.h"
 #include "Marmot/MarmotFastorTensorBasics.h"
 #include "Marmot/MarmotMaterialHughesWinget.h"
 #include "Marmot/MarmotMaterialHypoElastic.h"
@@ -274,7 +275,7 @@ void testRigidRotationIsExact()
 
       const double accumulatedBefore = state.back();
 
-      const double    theta = angleDeg * M_PI / 180.0;
+      const double    theta = angleDeg * Constants::Pi / 180.0;
       const Tensor33d Q     = rotationTensor( Eigen::Vector3d( axes( a, 0 ),
                                                            axes( a, 1 ),
                                                            std::sqrt( std::max( 0.0,

--- a/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
+++ b/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
@@ -1,4 +1,6 @@
 #include "Marmot/LinearElastic.h"
+#include "Marmot/MarmotMaterialFiniteStrainFactory.h"
+#include "Marmot/MarmotMaterialHughesWinget.h"
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
 namespace Marmot::Materials {
@@ -9,6 +11,11 @@ namespace Marmot::Materials {
 
     const static bool LinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< LinearElastic >(
       "LINEARELASTIC" );
+
+    // Co-rotational Hughes-Winget wrapper, usable wherever a MarmotMaterialFiniteStrain is expected
+    // (finite-strain elements, meshfree particles and material points).
+    const static bool LinearElasticHughesWingetIsRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
+      HughesWingetWrapper< LinearElastic > >( "LINEARELASTIC/HUGHES-WINGET" );
 
   } // namespace Registration
 } // namespace Marmot::Materials

--- a/modules/materials/VonMises/src/VonMisesRegistration.cpp
+++ b/modules/materials/VonMises/src/VonMisesRegistration.cpp
@@ -1,3 +1,5 @@
+#include "Marmot/MarmotMaterialFiniteStrainFactory.h"
+#include "Marmot/MarmotMaterialHughesWinget.h"
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 #include "Marmot/VonMises.h"
 
@@ -9,6 +11,16 @@ namespace Marmot::Materials {
 
     const static bool VonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< VonMisesModel >(
       "VONMISES" );
+
+    // Co-rotational Hughes-Winget wrapper, usable wherever a MarmotMaterialFiniteStrain is expected
+    // (finite-strain elements, meshfree particles and material points).
+    const static bool VonMisesHughesWingetIsRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
+      HughesWingetWrapper< VonMisesModel > >( "VONMISES/HUGHES-WINGET" );
+
+    // Variant recovering the exact d(sigma^(n+1))/d(sigma_rot) operator; worth the seven material
+    // evaluations whenever large incremental rotations coincide with plastic flow.
+    const static bool VonMisesHughesWingetExactIsRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
+      HughesWingetWrapper< VonMisesModel, HughesWingetTangent::Exact > >( "VONMISES/HUGHES-WINGET/EXACT-TANGENT" );
 
   } // namespace Registration
 


### PR DESCRIPTION
## Summary

This pull request introduces the **Hughes-Winget co-rotational wrapper** (`Marmot::Materials::HughesWingetWrapper`), enabling any small-strain (hypoelastic) constitutive model implementing `MarmotMaterialHypoElastic` to be evaluated transparently wherever a finite-strain model (`MarmotMaterialFiniteStrain`) is expected — notably in updated-Lagrangian finite elements (such as `C3D8UL`) and meshfree material points / particles.

---

## Technical Highlights

### 1. Objective Co-Rotational Rate Kinematics (Hughes & Winget, 1980)
* Evaluates the incremental velocity gradient on the mid-step configuration:
  $$\Delta \boldsymbol{l} = (\boldsymbol{F}^{(n+1)} - \boldsymbol{F}^{(n)}) \boldsymbol{F}_{\text{mid}}^{-1}, \qquad \boldsymbol{F}_{\text{mid}} = \tfrac{1}{2}(\boldsymbol{F}^{(n)} + \boldsymbol{F}^{(n+1)})$$
* Computes the incremental rotation via the Cayley transform:
  $$\Delta \boldsymbol{R} = (\boldsymbol{I} - \tfrac{1}{2}\Delta\boldsymbol{\Omega})^{-1} (\boldsymbol{I} + \tfrac{1}{2}\Delta\boldsymbol{\Omega})$$
  which is orthogonal to machine precision.
* Rotates the Cauchy stress forward: $\boldsymbol{\sigma}_{\text{rot}} = \Delta \boldsymbol{R} \boldsymbol{\sigma}^{(n)} \Delta \boldsymbol{R}^T$, invokes the wrapped small-strain law with $(\boldsymbol{\sigma}_{\text{rot}}, \Delta \boldsymbol{\varepsilon})$, and returns the Kirchhoff stress $\boldsymbol{\tau} = J \boldsymbol{\sigma}^{(n+1)}$.
* **Exact Rigid Rotation**: Preserves zero spurious stress under pure rigid-body rotations of any angle $< 180^\circ$ in a single increment.

### 2. Algorithmic Tangent Modulus
Supports multiple tangent derivation strategies via template configuration:
* **`Analytic` (default)**: Evaluates geometric and rotational tangent terms directly; exact in the elastic regime and lightweight during plastic flow (1 evaluation).
* **`Exact`**: Recovers $\partial \boldsymbol{\sigma}^{(n+1)} / \partial \boldsymbol{\sigma}_{\text{rot}}$ by forward-differencing incoming stress components (7 evaluations). Fully consistent for softening models under large incremental rotations.
* **`Numerical`**: Forward-differences with respect to $\boldsymbol{F}$ (11 evaluations) for reference verification.

### 3. Model Registrations & Integration
* Registered for `LinearElastic/Hughes-Winget` and `VonMises/Hughes-Winget`.
* Automatically delegates internal state variable mapping to the underlying material law.

---

## Verification & Documentation

* **Unit Testing**: Added `TestMarmotMaterialHughesWinget.cpp` verifying:
  - Rigid body rotation invariance.
  - Simple shear and uniaxial tension/compression.
  - Tangent consistency across analytic, exact, and numerical modes.
* **Documentation**: Added comprehensive Sphinx documentation under `doc/pages/features/hugheswinget.rst` and linked in `doc/pages/features/materials.rst`.
