### PR TITLE
refactor(core): rename MarmotLibrary namespace to Marmot::Registration

### DIFF
--- a/doc/pages/features/at2phasefield.rst
+++ b/doc/pages/features/at2phasefield.rst
@@ -79,7 +79,7 @@ Implementation
 --------------
 
 The model is implemented within the general gradient-enhanced hypoelastic framework
-(:cpp:class:`MarmotMaterialGeneralGradientEnhancedHypoElastic`), treating the phase-field
+(:cpp:class:`Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic`), treating the phase-field
 variable :math:`d` as the single nonlocal variable (:math:`\bar\kappa = d`).
 The gradient enhancement coefficient is constant: :math:`c = l^2`.
 

--- a/doc/pages/features/displacementfinitestrainelement.rst
+++ b/doc/pages/features/displacementfinitestrainelement.rst
@@ -5,7 +5,7 @@ Preliminaries
 -------------
 This element formulation is implemented in the class :cpp:class:`Marmot::Elements::DisplacementFiniteStrainULElement`, which represents a displacement-based finite element considering large deformations. The formulation is valid for general three-dimensional geometries and can be combined with arbitrary material models. It supports both body forces and surface tractions.
 
-This class inherits from the abstract base classes :cpp:class:`MarmotElement` and :cpp:class:`MarmotGeometryElement`, which provide common functionality for all finite elements in **Marmot**. In addition, it serves as a base class for specializations such as plane strain and axisymmetric elements.
+This class inherits from the abstract base classes :cpp:class:`Marmot::MarmotElement` and :cpp:class:`Marmot::MarmotGeometryElement`, which provide common functionality for all finite elements in **Marmot**. In addition, it serves as a base class for specializations such as plane strain and axisymmetric elements.
 
 Throughout the following derivations, Einstein summation convention is used, i.e., repeated indices imply summation. Uppercase indices refer to material coordinates, while lowercase indices refer to spatial coordinates. Accordingly, lowercase subscripts preceded by a comma denote spatial derivatives with respect to the current (deformed) configuration, e.g., :math:`(\bullet)_{,i} = \partial (\bullet)/\partial x_i`, while uppercase subscripts preceded by a comma denote material derivatives with respect to the reference (undeformed) configuration, e.g., :math:`(\bullet)_{,I} = \partial (\bullet)/\partial X_I`. Following this convention, the deformation gradient and its determinant is defined as
 

--- a/doc/pages/interfaces.md
+++ b/doc/pages/interfaces.md
@@ -27,7 +27,7 @@ A singularity container recipe is [available](https://github.com/matthiasneuner/
 
 ## Create your custom interface
 
-To create your custom interface to Marmot, you can leverage the `MarmotLibrary::MarmotMaterialHypoElasticFactory` and `MarmotLibrary::MarmotElementFactory` factories to create
+To create your custom interface to Marmot, you can leverage the `Marmot::Registration::MarmotMaterialHypoElasticFactory` and `Marmot::Registration::MarmotElementFactory` factories to create
 instances of registered material models and finite elements.
 Marmot provides two main base classes for materials:
 
@@ -43,7 +43,7 @@ which belongs to the class of `Marmot::MarmotMaterialHypoElastic` materials, and
 
 // Create the instance by material name
 auto material = std::unique_ptr<Marmot::MarmotMaterialHypoElastic>(
-        MarmotLibrary::MarmotMaterialHypoElasticFactory::createMaterial(
+        Marmot::Registration::MarmotMaterialHypoElasticFactory::createMaterial(
             "LINEARELASTIC", materialProperties, nMaterialProperties, anArbitraryIdentificationCode ));
 
 // assign a characteristic length parameter (specific to hypoelastic materials)
@@ -75,7 +75,7 @@ For instance, the `LinearElastic` material is registered as
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
 const static bool LinearElasticIsRegistered =
-    MarmotLibrary::MarmotMaterialHypoElasticFactory::registerMaterial< Marmot::Materials::LinearElastic >(
+    Marmot::Registration::MarmotMaterialHypoElasticFactory::registerMaterial< Marmot::Materials::LinearElastic >(
         "LINEARELASTIC" );
 ```
 
@@ -89,12 +89,12 @@ For instance, the 4-node plane strain displacement finite element "CPE4" is regi
 template < class T,
            Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
            typename T::SectionType                             sectionType >
-MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
 {
     return []( int elementID ) -> Marmot::MarmotElement* { return new T( elementID, integrationType, sectionType ); };
 }
 
-const static bool CPE4_isRegistered = MarmotLibrary::MarmotElementFactory::
+const static bool CPE4_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "CPE4",
                      makeFactoryFunction< DisplacementFiniteElement< 2, 4 >,
                                           FullIntegration,
@@ -111,7 +111,7 @@ int elementNumber = 1;
 
 // create the instance by element name
 auto theElement = std::unique_ptr<Marmot::MarmotElement>(
-        MarmotLibrary::MarmotElementFactory::createElement( "CPE4", elementNumber ) );
+        Marmot::Registration::MarmotElementFactory::createElement( "CPE4", elementNumber ) );
 
 // assign nodal coordinates
 theElement->assignNodeCoordinates( coordinates );

--- a/doc/pages/interfaces.md
+++ b/doc/pages/interfaces.md
@@ -31,18 +31,18 @@ To create your custom interface to Marmot, you can leverage the `MarmotLibrary::
 instances of registered material models and finite elements.
 Marmot provides two main base classes for materials:
 
-- `MarmotMaterialHypoElastic` — for small-strain materials formulated in rate form (hypoelastic constitutive relations).
-- `MarmotMaterialFiniteStrain` — for large-strain materials formulated in terms of the deformation gradient.
+- `Marmot::MarmotMaterialHypoElastic` — for small-strain materials formulated in rate form (hypoelastic constitutive relations).
+- `Marmot::MarmotMaterialFiniteStrain` — for large-strain materials formulated in terms of the deformation gradient.
 
-Finite elements are derived from the general parent class `MarmotElement`.
+Finite elements are derived from the general parent class `Marmot::MarmotElement`.
 
 For instance, the following procedure may be employed to create an instance of a `Marmot::Materials::LinearElastic` material model,
-which belongs to the class of `MarmotMaterialHypoElastic` materials, and compute the current stress state:
+which belongs to the class of `Marmot::MarmotMaterialHypoElastic` materials, and compute the current stress state:
 ```cpp
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
 // Create the instance by material name
-auto material = std::unique_ptr<MarmotMaterialHypoElastic>(
+auto material = std::unique_ptr<Marmot::MarmotMaterialHypoElastic>(
         MarmotLibrary::MarmotMaterialHypoElasticFactory::createMaterial(
             "LINEARELASTIC", materialProperties, nMaterialProperties, anArbitraryIdentificationCode ));
 
@@ -53,15 +53,15 @@ material->setCharacteristicElementLength( theCharacteristicElementLength );
 const int             nStateVars = material->getNumberOfRequiredStateVars();
 std::vector< double > stateVars( nStateVars, 0.0 );
 
-MarmotMaterialHypoElastic::state3D state = MarmotMaterialHypoElastic::state3D()
+Marmot::MarmotMaterialHypoElastic::state3D state = Marmot::MarmotMaterialHypoElastic::state3D()
 state.stateVars           = stateVars.data();
 
 // compute stresses
-Marmot::Matrix6d                          dStress_dStrain;
-const Marmot::Vector6d                    dStrain  = Marmot::Vector6d::Zero(); // strain increment
-const double                              time     = 0.0;                      // current time
-const double                              dTime    = 0.01;                     // time increment
-const MarmotMaterialHypoElastic::timeInfo timeInfo = { time, dTime };
+Marmot::Matrix6d                                  dStress_dStrain;
+const Marmot::Vector6d                            dStrain  = Marmot::Vector6d::Zero(); // strain increment
+const double                                      time     = 0.0;                      // current time
+const double                                      dTime    = 0.01;                     // time increment
+const Marmot::MarmotMaterialHypoElastic::timeInfo timeInfo = { time, dTime };
 material->computeStress( state, dStress_dStrain, dStrain, timeInfo );
 ```
 
@@ -91,7 +91,7 @@ template < class T,
            typename T::SectionType                             sectionType >
 MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
 {
-    return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
+    return []( int elementID ) -> Marmot::MarmotElement* { return new T( elementID, integrationType, sectionType ); };
 }
 
 const static bool CPE4_isRegistered = MarmotLibrary::MarmotElementFactory::
@@ -110,18 +110,18 @@ Creating a specific element instance and computing the kernel is straightforward
 int elementNumber = 1;
 
 // create the instance by element name
-auto theElement = std::unique_ptr<MarmotElement>(
+auto theElement = std::unique_ptr<Marmot::MarmotElement>(
         MarmotLibrary::MarmotElementFactory::createElement( "CPE4", elementNumber ) );
 
 // assign nodal coordinates
 theElement->assignNodeCoordinates( coordinates );
 
 // assign properties (e.g., thickness)
-theElement->assignProperty( ElementProperties( propertiesElement, nPropertiesElement ) );
+theElement->assignProperty( Marmot::ElementProperties( propertiesElement, nPropertiesElement ) );
 
 // assign a material section by material name
 // MarmotElement takes care to create the required instances of MarmotMaterial
-theElement->assignProperty( MarmotMaterialSection( "LINEARELASTIC", propertiesMaterial, nPropertiesMaterial ) );
+theElement->assignProperty( Marmot::MarmotMaterialSection( "LINEARELASTIC", propertiesMaterial, nPropertiesMaterial ) );
 
 // assign state vars to the element
 // MarmotElement automatically assigns the state vars also to MarmotMaterial instances

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
@@ -30,251 +30,255 @@
 #include <string>
 #include <vector>
 
-/**
- * @class MarmotElement
- * @brief Abstract base class for finite elements in the Marmot framework.
- *
- * This class defines the generic interface for finite elements, including
- * methods for state variable handling, geometry, degrees of freedom,
- * initialization, loading, and numerical integration. Concrete element
- * implementations must override the pure virtual functions.
- */
-class MarmotElement {
-
-public:
-  /** @brief Types of element state variables used in initialization and output. */
-  enum StateTypes {
-
-    Sigma11,                      ///< Normal stress component σ₁₁.
-    Sigma22,                      ///< Normal stress component σ₂₂.
-    Sigma33,                      ///< Normal stress component σ₃₃.
-    HydrostaticStress,            ///< Hydrostatic (mean) stress.
-    GeostaticStress,              ///< Geostatic in-situ stress state.
-    MarmotMaterialStateVars,      ///< Internal material state variables.
-    MarmotMaterialInitialization, ///< Trigger for material model initialization.
-    HasEigenDeformation,          ///< Flag indicating presence of eigen (initial) deformation.
-  };
-
-  /** @brief Types of distributed loads applicable to element boundaries. */
-  enum DistributedLoadTypes {
-    Pressure,        ///< Pressure load (normal to surface)
-    SurfaceTorsion,  ///< Surface torsional load
-    SurfaceTraction, ///< Surface traction vector
-  };
-
-  /** @brief Virtual destructor for safe polymorphic cleanup. */
-  virtual ~MarmotElement();
-
-  /** @return Number of state variables required by the element. */
-  virtual int getNumberOfRequiredStateVars() = 0;
+namespace Marmot {
 
   /**
-   * @brief Get the nodal field names (e.g. displacement, rotation).
-   * @return A 2D vector of strings representing the fields per node.
-   */
-  virtual std::vector< std::vector< std::string > > getNodeFields() = 0;
-
-  /**
-   * @brief Get permutation pattern for degrees of freedom.
-   * @return Vector of indices describing the permutation.
-   */
-  virtual std::vector< int > getDofIndicesPermutationPattern() = 0;
-
-  /** @return Number of nodes in the element. */
-  virtual int getNNodes() = 0;
-
-  /** @return Number of spatial dimensions (2D/3D). */
-  virtual int getNSpatialDimensions() = 0;
-
-  /** @return Number of degrees of freedom per element. */
-  virtual int getNDofPerElement() = 0;
-
-  /** @return String describing the element shape in Ensight Gold notation (e.g. "quad4", "hexa8"). */
-  virtual std::string getElementShape() = 0;
-
-  /**
-   * @brief Assign state variable array to element.
-   * @param[in,out] stateVars Pointer to state variable array.
-   * @param[in] nStateVars Number of state variables.
-   */
-  virtual void assignStateVars( double* stateVars, int nStateVars ) = 0;
-
-  /**
-   * @brief Assign element property set.
-   * @param[in] property Element property object containing material, geometry, etc.
-   */
-  virtual void assignProperty( const ElementProperties& property );
-
-  /**
-   * @brief Assign material section property.
-   * @param[in] property Material section definition (e.g. cross-sectional data).
-   */
-  virtual void assignProperty( const MarmotMaterialSection& property );
-
-  /**
-   * @brief Assign a single property of the element by name.
-   * @param[in] propertyName Name of the property.
-   * @param[in] properties Pointer to the array of property values.
-   * @note Default implementation throws an exception, as an element not overriding this
-   * interface does not support any named properties.
-   */
-  virtual void assignProperty( const std::string& propertyName, const double* properties )
-  {
-    throw std::invalid_argument( MakeString()
-                                 << __PRETTY_FUNCTION__ << ": unsupported named property '" << propertyName << "'" );
-  };
-
-  /**
-   * @brief Get the names of all the valid properties of the element.
-   * @return Vector of strings containing the property names.
-   * @note Default implementation returns an empty vector, as an element not overriding this
-   * interface does not expose any named properties.
-   */
-  virtual std::vector< std::string > getPropertyNames() const { return {}; };
-
-  /**
-   * @brief Assign nodal coordinates to element.
-   * @param[in] coordinates Pointer to array of nodal coordinates.
-   */
-  virtual void assignNodeCoordinates( const double* coordinates ) = 0;
-
-  /** @brief Initialize element state and internal variables. */
-  virtual void initializeYourself() = 0;
-
-  /**
-   * @brief Apply initial conditions to the element.
-   * @param[in] state State type to be set.
-   * @param[in] values Array of initial values.
-   */
-  virtual void setInitialConditions( StateTypes state, const double* values ) = 0;
-
-  /**
-   * @brief Perform element computations (stiffness, residual, etc.).
-   * @param[in] QTotal Total dof vector.
-   * @param[in] dQ Incremental dof vector.
-   * @param[out] Pint Internal force vector.
-   * @param[out] K Stiffness matrix.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
-   */
-  virtual void computeKernels( const double* QTotal,
-                               const double* dQ,
-                               double*       Pint,
-                               double*       K,
-                               double        time,
-                               double        dT ) = 0;
-
-  /**
-   * @brief Perform element computations for explicit time integration.
-   * @param[in] QTotal Total dof vector.
-   * @param[in] dQ Incremental dof vector.
-   * @param[out] Pint Internal force vector.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
+   * @class MarmotElement
+   * @brief Abstract base class for finite elements in the Marmot framework.
    *
-   * @note Default implementation throws an exception.
+   * This class defines the generic interface for finite elements, including
+   * methods for state variable handling, geometry, degrees of freedom,
+   * initialization, loading, and numerical integration. Concrete element
+   * implementations must override the pure virtual functions.
    */
-  virtual void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pint, double time, double dT )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-  /**
-   * @brief Compute contribution from distributed surface loads.
-   * @param[in] loadType Type of load.
-   * @param[out] Pext External load vector.
-   * @param[out] K Stiffness matrix.
-   * @param[in] elementFace Index of element face.
-   * @param[in] load Applied load values.
-   * @param[in] QTotal Total dof vector.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
-   */
-  virtual void computeDistributedLoad( DistributedLoadTypes loadType,
-                                       double*              Pext,
-                                       double*              K,
-                                       int                  elementFace,
-                                       const double*        load,
-                                       const double*        QTotal,
-                                       double               time,
-                                       double               dT ) = 0;
+  class MarmotElement {
 
-  /**
-   * @brief Compute contribution from body forces.
-   * @param[out] Pext External load vector.
-   * @param[out] K Stiffness matrix.
-   * @param[in] load Body force vector.
-   * @param[in] QTotal Total displacement vector.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
-   */
-  virtual void computeBodyForce( double*       Pext,
+  public:
+    /** @brief Types of element state variables used in initialization and output. */
+    enum StateTypes {
+
+      Sigma11,                      ///< Normal stress component σ₁₁.
+      Sigma22,                      ///< Normal stress component σ₂₂.
+      Sigma33,                      ///< Normal stress component σ₃₃.
+      HydrostaticStress,            ///< Hydrostatic (mean) stress.
+      GeostaticStress,              ///< Geostatic in-situ stress state.
+      MarmotMaterialStateVars,      ///< Internal material state variables.
+      MarmotMaterialInitialization, ///< Trigger for material model initialization.
+      HasEigenDeformation,          ///< Flag indicating presence of eigen (initial) deformation.
+    };
+
+    /** @brief Types of distributed loads applicable to element boundaries. */
+    enum DistributedLoadTypes {
+      Pressure,        ///< Pressure load (normal to surface)
+      SurfaceTorsion,  ///< Surface torsional load
+      SurfaceTraction, ///< Surface traction vector
+    };
+
+    /** @brief Virtual destructor for safe polymorphic cleanup. */
+    virtual ~MarmotElement();
+
+    /** @return Number of state variables required by the element. */
+    virtual int getNumberOfRequiredStateVars() = 0;
+
+    /**
+     * @brief Get the nodal field names (e.g. displacement, rotation).
+     * @return A 2D vector of strings representing the fields per node.
+     */
+    virtual std::vector< std::vector< std::string > > getNodeFields() = 0;
+
+    /**
+     * @brief Get permutation pattern for degrees of freedom.
+     * @return Vector of indices describing the permutation.
+     */
+    virtual std::vector< int > getDofIndicesPermutationPattern() = 0;
+
+    /** @return Number of nodes in the element. */
+    virtual int getNNodes() = 0;
+
+    /** @return Number of spatial dimensions (2D/3D). */
+    virtual int getNSpatialDimensions() = 0;
+
+    /** @return Number of degrees of freedom per element. */
+    virtual int getNDofPerElement() = 0;
+
+    /** @return String describing the element shape in Ensight Gold notation (e.g. "quad4", "hexa8"). */
+    virtual std::string getElementShape() = 0;
+
+    /**
+     * @brief Assign state variable array to element.
+     * @param[in,out] stateVars Pointer to state variable array.
+     * @param[in] nStateVars Number of state variables.
+     */
+    virtual void assignStateVars( double* stateVars, int nStateVars ) = 0;
+
+    /**
+     * @brief Assign element property set.
+     * @param[in] property Element property object containing material, geometry, etc.
+     */
+    virtual void assignProperty( const ElementProperties& property );
+
+    /**
+     * @brief Assign material section property.
+     * @param[in] property Material section definition (e.g. cross-sectional data).
+     */
+    virtual void assignProperty( const MarmotMaterialSection& property );
+
+    /**
+     * @brief Assign a single property of the element by name.
+     * @param[in] propertyName Name of the property.
+     * @param[in] properties Pointer to the array of property values.
+     * @note Default implementation throws an exception, as an element not overriding this
+     * interface does not support any named properties.
+     */
+    virtual void assignProperty( const std::string& propertyName, const double* properties )
+    {
+      throw std::invalid_argument( MakeString()
+                                   << __PRETTY_FUNCTION__ << ": unsupported named property '" << propertyName << "'" );
+    };
+
+    /**
+     * @brief Get the names of all the valid properties of the element.
+     * @return Vector of strings containing the property names.
+     * @note Default implementation returns an empty vector, as an element not overriding this
+     * interface does not expose any named properties.
+     */
+    virtual std::vector< std::string > getPropertyNames() const { return {}; };
+
+    /**
+     * @brief Assign nodal coordinates to element.
+     * @param[in] coordinates Pointer to array of nodal coordinates.
+     */
+    virtual void assignNodeCoordinates( const double* coordinates ) = 0;
+
+    /** @brief Initialize element state and internal variables. */
+    virtual void initializeYourself() = 0;
+
+    /**
+     * @brief Apply initial conditions to the element.
+     * @param[in] state State type to be set.
+     * @param[in] values Array of initial values.
+     */
+    virtual void setInitialConditions( StateTypes state, const double* values ) = 0;
+
+    /**
+     * @brief Perform element computations (stiffness, residual, etc.).
+     * @param[in] QTotal Total dof vector.
+     * @param[in] dQ Incremental dof vector.
+     * @param[out] Pint Internal force vector.
+     * @param[out] K Stiffness matrix.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     */
+    virtual void computeKernels( const double* QTotal,
+                                 const double* dQ,
+                                 double*       Pint,
                                  double*       K,
-                                 const double* load,
-                                 const double* QTotal,
                                  double        time,
                                  double        dT ) = 0;
 
-  /**
-   * @brief Compute lumped inertia matrix.
-   * @param[out] I Inertia matrix.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeLumpedInertia( double* I )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    /**
+     * @brief Perform element computations for explicit time integration.
+     * @param[in] QTotal Total dof vector.
+     * @param[in] dQ Incremental dof vector.
+     * @param[out] Pint Internal force vector.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     *
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pint, double time, double dT )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+    /**
+     * @brief Compute contribution from distributed surface loads.
+     * @param[in] loadType Type of load.
+     * @param[out] Pext External load vector.
+     * @param[out] K Stiffness matrix.
+     * @param[in] elementFace Index of element face.
+     * @param[in] load Applied load values.
+     * @param[in] QTotal Total dof vector.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     */
+    virtual void computeDistributedLoad( DistributedLoadTypes loadType,
+                                         double*              Pext,
+                                         double*              K,
+                                         int                  elementFace,
+                                         const double*        load,
+                                         const double*        QTotal,
+                                         double               time,
+                                         double               dT ) = 0;
+
+    /**
+     * @brief Compute contribution from body forces.
+     * @param[out] Pext External load vector.
+     * @param[out] K Stiffness matrix.
+     * @param[in] load Body force vector.
+     * @param[in] QTotal Total displacement vector.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     */
+    virtual void computeBodyForce( double*       Pext,
+                                   double*       K,
+                                   const double* load,
+                                   const double* QTotal,
+                                   double        time,
+                                   double        dT ) = 0;
+
+    /**
+     * @brief Compute lumped inertia matrix.
+     * @param[out] I Inertia matrix.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeLumpedInertia( double* I )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Compute consistent inertia matrix.
+     * @param[out] I Inertia matrix.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeConsistentInertia( double* I )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Compute critical time step for explicit dynamics.
+     * @param[out] criticalTimeStep Suggested critical time step size.
+     * @param[in] QTotal Total dof vector.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Compute internal energy of the element.
+     * @param[out] internalEnergy Computed internal energy.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeInternalEnergy( double& internalEnergy )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Access element state at a quadrature point.
+     * @param[in] stateName Name of the state variable.
+     * @param[in] quadraturePoint Index of quadrature point.
+     * @return View into state variable.
+     */
+    virtual StateView getStateView( const std::string& stateName, int quadraturePoint ) = 0;
+
+    /**
+     * @brief Get coordinates of element center.
+     * @return Vector of coordinates at element centroid.
+     */
+    virtual std::vector< double > getCoordinatesAtCenter() = 0;
+
+    /**
+     * @brief Get coordinates of quadrature points.
+     * @return 2D vector of coordinates at quadrature points.
+     */
+    virtual std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints() = 0;
+
+    /** @return Number of quadrature points used by the element. */
+    virtual int getNumberOfQuadraturePoints() = 0;
   };
 
-  /**
-   * @brief Compute consistent inertia matrix.
-   * @param[out] I Inertia matrix.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeConsistentInertia( double* I )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-
-  /**
-   * @brief Compute critical time step for explicit dynamics.
-   * @param[out] criticalTimeStep Suggested critical time step size.
-   * @param[in] QTotal Total dof vector.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-
-  /**
-   * @brief Compute internal energy of the element.
-   * @param[out] internalEnergy Computed internal energy.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeInternalEnergy( double& internalEnergy )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-
-  /**
-   * @brief Access element state at a quadrature point.
-   * @param[in] stateName Name of the state variable.
-   * @param[in] quadraturePoint Index of quadrature point.
-   * @return View into state variable.
-   */
-  virtual StateView getStateView( const std::string& stateName, int quadraturePoint ) = 0;
-
-  /**
-   * @brief Get coordinates of element center.
-   * @return Vector of coordinates at element centroid.
-   */
-  virtual std::vector< double > getCoordinatesAtCenter() = 0;
-
-  /**
-   * @brief Get coordinates of quadrature points.
-   * @return 2D vector of coordinates at quadrature points.
-   */
-  virtual std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints() = 0;
-
-  /** @return Number of quadrature points used by the element. */
-  virtual int getNumberOfQuadraturePoints() = 0;
-};
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @class MarmotElementFactory
@@ -82,4 +82,4 @@ namespace MarmotLibrary {
     static ElementFactoryMap& elementFactoryFunctionByName();
   };
 
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
@@ -39,7 +39,7 @@ namespace MarmotLibrary {
   class MarmotElementFactory {
   public:
     /// @brief Factory function pointer type: takes an element number and returns a new MarmotElement.
-    using elementFactoryFunction = MarmotElement* (*)( int elementNumber );
+    using elementFactoryFunction = Marmot::MarmotElement* (*)( int elementNumber );
     MarmotElementFactory()       = delete;
 
     /**
@@ -49,12 +49,12 @@ namespace MarmotLibrary {
      * @return Pointer to the created MarmotElement instance.
      * @throws std::invalid_argument if @p elementName is not registered.
      */
-    static MarmotElement* createElement( const std::string& elementName, int elementNumber )
+    static Marmot::MarmotElement* createElement( const std::string& elementName, int elementNumber )
     {
       auto& map = elementFactoryFunctionByName();
       auto  it  = map.find( elementName );
       if ( it == map.end() ) {
-        throw std::invalid_argument( MakeString()
+        throw std::invalid_argument( Marmot::MakeString()
                                      << __PRETTY_FUNCTION__ << "Element " + elementName + " not registered!" );
       }
 

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementProperty.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementProperty.h
@@ -25,46 +25,50 @@
 #pragma once
 #include <string>
 
-/** @struct MarmotMaterialSection
- * @brief Structure to hold material section properties.
- *
- * This structure is used to define a material section with its code and properties,
- * allowing for flexible material definitions in finite element analysis.
- */
-class MarmotMaterialSection {
-public:
-  const std::string materialName;        ///< Name identifying the material model.
-  const double*     materialProperties;  ///< Pointer to the array of material property values.
-  int               nMaterialProperties; ///< Number of material property values.
+namespace Marmot {
 
-  /**
-   * @brief Construct a MarmotMaterialSection.
-   * @param[in] materialName       Name identifying the material model.
-   * @param[in] materialProperties Pointer to the array of material property values.
-   * @param[in] nMaterialProperties Number of material property values.
+  /** @struct MarmotMaterialSection
+   * @brief Structure to hold material section properties.
+   *
+   * This structure is used to define a material section with its code and properties,
+   * allowing for flexible material definitions in finite element analysis.
    */
-  MarmotMaterialSection( const std::string materialName, const double* materialProperties, int nMaterialProperties )
-    : materialName( materialName ),
-      materialProperties( materialProperties ),
-      nMaterialProperties( nMaterialProperties ){};
-};
+  class MarmotMaterialSection {
+  public:
+    const std::string materialName;        ///< Name identifying the material model.
+    const double*     materialProperties;  ///< Pointer to the array of material property values.
+    int               nMaterialProperties; ///< Number of material property values.
 
-/** @struct ElementProperties
- * @brief Structure to hold element properties.
- *
- * This structure is used to define properties of a finite element,
- * allowing for flexible element definitions in finite element analysis.
- */
-class ElementProperties {
-public:
-  const double* elementProperties;  ///< Pointer to the array of element property values.
-  int           nElementProperties; ///< Number of element property values.
+    /**
+     * @brief Construct a MarmotMaterialSection.
+     * @param[in] materialName       Name identifying the material model.
+     * @param[in] materialProperties Pointer to the array of material property values.
+     * @param[in] nMaterialProperties Number of material property values.
+     */
+    MarmotMaterialSection( const std::string materialName, const double* materialProperties, int nMaterialProperties )
+      : materialName( materialName ),
+        materialProperties( materialProperties ),
+        nMaterialProperties( nMaterialProperties ){};
+  };
 
-  /**
-   * @brief Construct an ElementProperties object.
-   * @param[in] elementProperties  Pointer to the array of element property values.
-   * @param[in] nElementProperties Number of element property values.
+  /** @struct ElementProperties
+   * @brief Structure to hold element properties.
+   *
+   * This structure is used to define properties of a finite element,
+   * allowing for flexible element definitions in finite element analysis.
    */
-  ElementProperties( const double* elementProperties, int nElementProperties )
-    : elementProperties( elementProperties ), nElementProperties( nElementProperties ){};
-};
+  class ElementProperties {
+  public:
+    const double* elementProperties;  ///< Pointer to the array of element property values.
+    int           nElementProperties; ///< Number of element property values.
+
+    /**
+     * @brief Construct an ElementProperties object.
+     * @param[in] elementProperties  Pointer to the array of element property values.
+     * @param[in] nElementProperties Number of element property values.
+     */
+    ElementProperties( const double* elementProperties, int nElementProperties )
+      : elementProperties( elementProperties ), nElementProperties( nElementProperties ){};
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
@@ -29,146 +29,150 @@
 #include <functional>
 #include <memory>
 
-/**
- * @class MarmotElementSpatialWrapper
- * @brief Wrapper that embeds a lower-dimensional child element (e.g.\ a truss) into a
- *        higher-dimensional ambient space (2-D or 3-D).
- *
- * The projection transformation is constructed automatically from the supplied
- * nodal coordinates.  The child element is created via a user-provided factory
- * functor so that the wrapper remains independent of the concrete child type.
- */
-class MarmotElementSpatialWrapper : public MarmotElement {
-
-public:
-  const int nDim;                                ///< Number of spatial dimensions of the ambient space.
-  const int nDimChild;                           ///< Number of spatial dimensions of the child element.
-  const int nNodes;                              ///< Number of nodes shared by parent and child element.
-  const int nRhsChild;                           ///< Size of the child element's right-hand-side vector.
-  const Eigen::Map< const Eigen::VectorXi >
-            rhsIndicesToBeProjected;             ///< Indices in the child RHS vector that need projection.
-  const int projectedSize;                       ///< Number of projected DOFs (child-element dimension).
-  const int unprojectedSize;                     ///< Number of unprojected DOFs (ambient-space dimension).
-
-  std::unique_ptr< MarmotElement > childElement; ///< Owned child element instance.
-  Eigen::MatrixXd                  T;            ///< Coordinate transformation matrix from child to parent space.
-  Eigen::MatrixXd                  P;            ///< Projection matrix mapping parent DOFs to child DOFs.
-  Eigen::MatrixXd                  projectedCoordinates; ///< Nodal coordinates expressed in the child (local) frame.
+namespace Marmot {
 
   /**
-   * @brief Construct the spatial wrapper.
-   * @param[in] nDim                      Number of spatial dimensions of the ambient space.
-   * @param[in] nChildDim                 Number of spatial dimensions of the child element.
-   * @param[in] nNodes                    Number of nodes.
-   * @param[in] sizeRhsChild              Size of the child element's right-hand-side vector.
-   * @param[in] rhsIndicesToBeWrapped_    Array of child-RHS indices to be projected.
-   * @param[in] nRhsIndicesToBeWrapped    Length of @p rhsIndicesToBeWrapped_.
-   * @param[in] childElement              Owning pointer to the child element instance.
+   * @class MarmotElementSpatialWrapper
+   * @brief Wrapper that embeds a lower-dimensional child element (e.g.\ a truss) into a
+   *        higher-dimensional ambient space (2-D or 3-D).
+   *
+   * The projection transformation is constructed automatically from the supplied
+   * nodal coordinates.  The child element is created via a user-provided factory
+   * functor so that the wrapper remains independent of the concrete child type.
    */
-  MarmotElementSpatialWrapper( int                              nDim,
-                               int                              nChildDim,
-                               int                              nNodes,
-                               int                              sizeRhsChild,
-                               const int                        rhsIndicesToBeWrapped_[],
-                               int                              nRhsIndicesToBeWrapped,
-                               std::unique_ptr< MarmotElement > childElement );
+  class MarmotElementSpatialWrapper : public MarmotElement {
 
-  /// @copydoc MarmotElement::getNumberOfRequiredStateVars
-  int getNumberOfRequiredStateVars();
+  public:
+    const int nDim;                                ///< Number of spatial dimensions of the ambient space.
+    const int nDimChild;                           ///< Number of spatial dimensions of the child element.
+    const int nNodes;                              ///< Number of nodes shared by parent and child element.
+    const int nRhsChild;                           ///< Size of the child element's right-hand-side vector.
+    const Eigen::Map< const Eigen::VectorXi >
+              rhsIndicesToBeProjected;             ///< Indices in the child RHS vector that need projection.
+    const int projectedSize;                       ///< Number of projected DOFs (child-element dimension).
+    const int unprojectedSize;                     ///< Number of unprojected DOFs (ambient-space dimension).
 
-  /// @copydoc MarmotElement::getNodeFields
-  std::vector< std::vector< std::string > > getNodeFields();
+    std::unique_ptr< MarmotElement > childElement; ///< Owned child element instance.
+    Eigen::MatrixXd                  T;            ///< Coordinate transformation matrix from child to parent space.
+    Eigen::MatrixXd                  P;            ///< Projection matrix mapping parent DOFs to child DOFs.
+    Eigen::MatrixXd                  projectedCoordinates; ///< Nodal coordinates expressed in the child (local) frame.
 
-  /// @copydoc MarmotElement::getDofIndicesPermutationPattern
-  std::vector< int > getDofIndicesPermutationPattern();
+    /**
+     * @brief Construct the spatial wrapper.
+     * @param[in] nDim                      Number of spatial dimensions of the ambient space.
+     * @param[in] nChildDim                 Number of spatial dimensions of the child element.
+     * @param[in] nNodes                    Number of nodes.
+     * @param[in] sizeRhsChild              Size of the child element's right-hand-side vector.
+     * @param[in] rhsIndicesToBeWrapped_    Array of child-RHS indices to be projected.
+     * @param[in] nRhsIndicesToBeWrapped    Length of @p rhsIndicesToBeWrapped_.
+     * @param[in] childElement              Owning pointer to the child element instance.
+     */
+    MarmotElementSpatialWrapper( int                              nDim,
+                                 int                              nChildDim,
+                                 int                              nNodes,
+                                 int                              sizeRhsChild,
+                                 const int                        rhsIndicesToBeWrapped_[],
+                                 int                              nRhsIndicesToBeWrapped,
+                                 std::unique_ptr< MarmotElement > childElement );
 
-  /// @copydoc MarmotElement::getNNodes
-  int getNNodes();
+    /// @copydoc MarmotElement::getNumberOfRequiredStateVars
+    int getNumberOfRequiredStateVars();
 
-  /// @copydoc MarmotElement::getNSpatialDimensions
-  int getNSpatialDimensions();
+    /// @copydoc MarmotElement::getNodeFields
+    std::vector< std::vector< std::string > > getNodeFields();
 
-  /// @copydoc MarmotElement::getNDofPerElement
-  int getNDofPerElement();
+    /// @copydoc MarmotElement::getDofIndicesPermutationPattern
+    std::vector< int > getDofIndicesPermutationPattern();
 
-  /// @copydoc MarmotElement::getElementShape
-  std::string getElementShape();
+    /// @copydoc MarmotElement::getNNodes
+    int getNNodes();
 
-  /// @copydoc MarmotElement::assignStateVars
-  void assignStateVars( double* stateVars, int nStateVars );
+    /// @copydoc MarmotElement::getNSpatialDimensions
+    int getNSpatialDimensions();
 
-  /// @copydoc MarmotElement::assignProperty(const ElementProperties&)
-  void assignProperty( const ElementProperties& property );
+    /// @copydoc MarmotElement::getNDofPerElement
+    int getNDofPerElement();
 
-  /// @copydoc MarmotElement::assignProperty(const MarmotMaterialSection&)
-  void assignProperty( const MarmotMaterialSection& property );
+    /// @copydoc MarmotElement::getElementShape
+    std::string getElementShape();
 
-  /// @copydoc MarmotElement::assignProperty(const std::string&, const double*)
-  void assignProperty( const std::string& propertyName, const double* properties ) override;
+    /// @copydoc MarmotElement::assignStateVars
+    void assignStateVars( double* stateVars, int nStateVars );
 
-  /// @copydoc MarmotElement::getPropertyNames
-  std::vector< std::string > getPropertyNames() const override;
+    /// @copydoc MarmotElement::assignProperty(const ElementProperties&)
+    void assignProperty( const ElementProperties& property );
 
-  /// @copydoc MarmotElement::assignNodeCoordinates
-  void assignNodeCoordinates( const double* coordinates );
+    /// @copydoc MarmotElement::assignProperty(const MarmotMaterialSection&)
+    void assignProperty( const MarmotMaterialSection& property );
 
-  /// @copydoc MarmotElement::initializeYourself
-  void initializeYourself();
+    /// @copydoc MarmotElement::assignProperty(const std::string&, const double*)
+    void assignProperty( const std::string& propertyName, const double* properties ) override;
 
-  /**
-   * @brief Perform element computations with coordinate transformation.
-   * @param[in]  QTotal  Total dof vector in the ambient (parent) space.
-   * @param[in]  dQ      Incremental dof vector in the ambient space.
-   * @param[out] Pe      Internal force vector in the ambient space.
-   * @param[out] Ke      Stiffness matrix in the ambient space.
-   * @param[in]  time    Current time.
-   * @param[in]  dT      Time step size.
-   */
-  void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
+    /// @copydoc MarmotElement::getPropertyNames
+    std::vector< std::string > getPropertyNames() const override;
 
-  /// @copydoc MarmotElement::setInitialConditions
-  void setInitialConditions( StateTypes state, const double* values );
+    /// @copydoc MarmotElement::assignNodeCoordinates
+    void assignNodeCoordinates( const double* coordinates );
 
-  /**
-   * @brief Compute contribution from distributed surface loads with coordinate transformation.
-   * @param[in]  loadType    Type of distributed load.
-   * @param[out] P           External load vector in the ambient space.
-   * @param[out] K           Load stiffness matrix in the ambient space.
-   * @param[in]  elementFace Index of element face.
-   * @param[in]  load        Applied load values.
-   * @param[in]  QTotal      Total dof vector.
-   * @param[in]  time        Current time.
-   * @param[in]  dT          Time step size.
-   */
-  void computeDistributedLoad( DistributedLoadTypes loadType,
-                               double*              P,
-                               double*              K,
-                               int                  elementFace,
-                               const double*        load,
-                               const double*        QTotal,
-                               double               time,
-                               double               dT );
+    /// @copydoc MarmotElement::initializeYourself
+    void initializeYourself();
 
-  /**
-   * @brief Compute body force contribution with coordinate transformation.
-   * @param[out] P      External load vector in the ambient space.
-   * @param[out] K      Load stiffness matrix in the ambient space.
-   * @param[in]  load   Applied body force values.
-   * @param[in]  QTotal Total dof vector.
-   * @param[in]  time   Current time.
-   * @param[in]  dT     Time step size.
-   */
-  void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
+    /**
+     * @brief Perform element computations with coordinate transformation.
+     * @param[in]  QTotal  Total dof vector in the ambient (parent) space.
+     * @param[in]  dQ      Incremental dof vector in the ambient space.
+     * @param[out] Pe      Internal force vector in the ambient space.
+     * @param[out] Ke      Stiffness matrix in the ambient space.
+     * @param[in]  time    Current time.
+     * @param[in]  dT      Time step size.
+     */
+    void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
-  /// @copydoc MarmotElement::getStateView
-  StateView getStateView( const std::string& stateName, int quadraturePoint );
+    /// @copydoc MarmotElement::setInitialConditions
+    void setInitialConditions( StateTypes state, const double* values );
 
-  /// @copydoc MarmotElement::getCoordinatesAtCenter
-  std::vector< double > getCoordinatesAtCenter();
+    /**
+     * @brief Compute contribution from distributed surface loads with coordinate transformation.
+     * @param[in]  loadType    Type of distributed load.
+     * @param[out] P           External load vector in the ambient space.
+     * @param[out] K           Load stiffness matrix in the ambient space.
+     * @param[in]  elementFace Index of element face.
+     * @param[in]  load        Applied load values.
+     * @param[in]  QTotal      Total dof vector.
+     * @param[in]  time        Current time.
+     * @param[in]  dT          Time step size.
+     */
+    void computeDistributedLoad( DistributedLoadTypes loadType,
+                                 double*              P,
+                                 double*              K,
+                                 int                  elementFace,
+                                 const double*        load,
+                                 const double*        QTotal,
+                                 double               time,
+                                 double               dT );
 
-  /// @copydoc MarmotElement::getCoordinatesAtQuadraturePoints
-  std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints();
+    /**
+     * @brief Compute body force contribution with coordinate transformation.
+     * @param[out] P      External load vector in the ambient space.
+     * @param[out] K      Load stiffness matrix in the ambient space.
+     * @param[in]  load   Applied body force values.
+     * @param[in]  QTotal Total dof vector.
+     * @param[in]  time   Current time.
+     * @param[in]  dT     Time step size.
+     */
+    void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
 
-  /// @copydoc MarmotElement::getNumberOfQuadraturePoints
-  int getNumberOfQuadraturePoints();
-};
+    /// @copydoc MarmotElement::getStateView
+    StateView getStateView( const std::string& stateName, int quadraturePoint );
+
+    /// @copydoc MarmotElement::getCoordinatesAtCenter
+    std::vector< double > getCoordinatesAtCenter();
+
+    /// @copydoc MarmotElement::getCoordinatesAtQuadraturePoints
+    std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints();
+
+    /// @copydoc MarmotElement::getNumberOfQuadraturePoints
+    int getNumberOfQuadraturePoints();
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotGeometryElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotGeometryElement.h
@@ -29,112 +29,116 @@
 #include <iostream>
 #include <map>
 
-/**
- * @class MarmotGeometryElement
- * @brief Statically-sized geometry base class for all isoparametric Marmot elements.
- *
- * @tparam nDim   Number of spatial dimensions (1, 2 or 3).
- * @tparam nNodes Number of element nodes.
- *
- * Provides shape functions @c N, their natural-coordinate derivatives @c dNdXi,
- * the B-operator @c B, and the element Jacobian.  The element shape is determined
- * automatically from the template parameters.
- *
- * Concrete MarmotElement classes inherit from this class to access the geometric
- * infrastructure without code duplication.
- */
-template < int nDim, int nNodes >
-class MarmotGeometryElement {
+namespace Marmot {
 
-public:
-  /*Typedefs*/
-  /* static constexpr VoigtSize voigtSize = ( ( ( nDim * nDim ) + nDim ) / 2 ); */
-  /// @brief Voigt notation size for @p nDim spatial dimensions.
-  static constexpr Marmot::ContinuumMechanics::VoigtNotation::VoigtSize
-    voigtSize = Marmot::ContinuumMechanics::VoigtNotation::voigtSizeFromDimension( nDim );
+  /**
+   * @class MarmotGeometryElement
+   * @brief Statically-sized geometry base class for all isoparametric Marmot elements.
+   *
+   * @tparam nDim   Number of spatial dimensions (1, 2 or 3).
+   * @tparam nNodes Number of element nodes.
+   *
+   * Provides shape functions @c N, their natural-coordinate derivatives @c dNdXi,
+   * the B-operator @c B, and the element Jacobian.  The element shape is determined
+   * automatically from the template parameters.
+   *
+   * Concrete MarmotElement classes inherit from this class to access the geometric
+   * infrastructure without code duplication.
+   */
+  template < int nDim, int nNodes >
+  class MarmotGeometryElement {
 
-  typedef Eigen::Matrix< double, nDim, 1 >             XiSized;          ///< Natural-coordinate vector.
-  typedef Eigen::Matrix< double, nDim * nNodes, 1 >    CoordinateVector; ///< Flat nodal-coordinate vector.
-  typedef Eigen::Matrix< double, nDim, nDim >          JacobianSized;    ///< Square Jacobian matrix.
-  typedef Eigen::Matrix< double, 1, nNodes >           NSized;           ///< Row vector of shape function values.
-  typedef Eigen::Matrix< double, nDim, nNodes * nDim > NBSized;          ///< Expanded interpolation operator N_B.
-  typedef Eigen::Matrix< double, nDim, nNodes >        dNdXiSized;  ///< Matrix of shape function natural derivatives.
-  typedef Eigen::Matrix< double, voigtSize, nNodes * nDim > BSized; ///< Standard B-operator matrix.
-  typedef Eigen::Matrix< double, 4, nNodes * nDim >
-    BSizedAxisymmetric; ///< Axisymmetric B-operator matrix (4 Voigt components).
+  public:
+    /*Typedefs*/
+    /* static constexpr VoigtSize voigtSize = ( ( ( nDim * nDim ) + nDim ) / 2 ); */
+    /// @brief Voigt notation size for @p nDim spatial dimensions.
+    static constexpr Marmot::ContinuumMechanics::VoigtNotation::VoigtSize
+      voigtSize = Marmot::ContinuumMechanics::VoigtNotation::voigtSizeFromDimension( nDim );
 
-  /*Properties*/
-  Eigen::Map< const CoordinateVector >       coordinates; ///< Map into the externally-owned nodal-coordinate array.
-  const Marmot::FiniteElement::ElementShapes shape;       ///< Element shape determined from @p nDim and @p nNodes.
+    typedef Eigen::Matrix< double, nDim, 1 >             XiSized;          ///< Natural-coordinate vector.
+    typedef Eigen::Matrix< double, nDim * nNodes, 1 >    CoordinateVector; ///< Flat nodal-coordinate vector.
+    typedef Eigen::Matrix< double, nDim, nDim >          JacobianSized;    ///< Square Jacobian matrix.
+    typedef Eigen::Matrix< double, 1, nNodes >           NSized;           ///< Row vector of shape function values.
+    typedef Eigen::Matrix< double, nDim, nNodes * nDim > NBSized;          ///< Expanded interpolation operator N_B.
+    typedef Eigen::Matrix< double, nDim, nNodes >        dNdXiSized;  ///< Matrix of shape function natural derivatives.
+    typedef Eigen::Matrix< double, voigtSize, nNodes * nDim > BSized; ///< Standard B-operator matrix.
+    typedef Eigen::Matrix< double, 4, nNodes * nDim >
+      BSizedAxisymmetric; ///< Axisymmetric B-operator matrix (4 Voigt components).
 
-  /*Methods*/
-  /// @brief Default constructor. Initialises the coordinate map to @c nullptr and deduces the element shape.
-  MarmotGeometryElement()
-    : coordinates( nullptr ), shape( Marmot::FiniteElement::getElementShapeByMetric( nDim, nNodes ) ){};
+    /*Properties*/
+    Eigen::Map< const CoordinateVector >       coordinates; ///< Map into the externally-owned nodal-coordinate array.
+    const Marmot::FiniteElement::ElementShapes shape;       ///< Element shape determined from @p nDim and @p nNodes.
 
-  /// @brief Returns an Ensight Gold shape string (e.g. @c quad4, @c hexa8) for this element.
-  std::string getElementShape() const
-  {
-    using namespace Marmot::FiniteElement;
-    static std::map< ElementShapes, std::string > shapes = { { Bar2, "bar2" },
-                                                             { Quad4, "quad4" },
-                                                             { Quad8, "quad8" },
-                                                             { Tetra4, "tetra4" },
-                                                             { Tetra10, "tetra10" },
-                                                             { Hexa8, "hexa8" },
-                                                             { Hexa20, "hexa20" } };
+    /*Methods*/
+    /// @brief Default constructor. Initialises the coordinate map to @c nullptr and deduces the element shape.
+    MarmotGeometryElement()
+      : coordinates( nullptr ), shape( Marmot::FiniteElement::getElementShapeByMetric( nDim, nNodes ) ){};
 
-    return shapes[this->shape];
-  }
+    /// @brief Returns an Ensight Gold shape string (e.g. @c quad4, @c hexa8) for this element.
+    std::string getElementShape() const
+    {
+      using namespace Marmot::FiniteElement;
+      static std::map< ElementShapes, std::string > shapes = { { Bar2, "bar2" },
+                                                               { Quad4, "quad4" },
+                                                               { Quad8, "quad8" },
+                                                               { Tetra4, "tetra4" },
+                                                               { Tetra10, "tetra10" },
+                                                               { Hexa8, "hexa8" },
+                                                               { Hexa20, "hexa20" } };
 
-  /// @brief Maps the externally-owned coordinate array into the @ref coordinates member.
-  /// @param[in] coords Pointer to the flat nodal-coordinate array.
-  void assignNodeCoordinates( const double* coords )
-  {
-    new ( &coordinates ) Eigen::Map< const CoordinateVector >( coords );
-  }
+      return shapes[this->shape];
+    }
 
-  /*Please specialize these functions for each element individially
-   *.cpp file.
-   *Fully specialized templates are precompiled in marmotMechanics (rather than the unspecialized and
-   *partially specialized templates)
-   * */
-  /// @brief Evaluate the shape function row vector at natural coordinates @p xi.
-  NSized N( const XiSized& xi ) const;
-  /// @brief Evaluate the matrix of shape function natural derivatives at @p xi.
-  dNdXiSized dNdXi( const XiSized& xi ) const;
-  /// @brief Compute the standard B-operator from physical derivatives @p dNdX.
-  BSized B( const dNdXiSized& dNdX ) const;
-  /// @brief Compute the axisymmetric B-operator (4 components).
-  BSizedAxisymmetric B_axisymmetric( const dNdXiSized& dNdX, const NSized& N, const XiSized& x_gauss ) const;
-  /// @brief Compute the B̄-operator using the B-bar selective-reduced-integration method.
-  BSized B_bar( const dNdXiSized& dNdX, const dNdXiSized& dNdX0 ) const;
-  /// @brief Compute the Green–Lagrange strain operator for deformation gradient @p F.
-  BSized BGreen( const dNdXiSized& dNdX, const JacobianSized& F ) const;
+    /// @brief Maps the externally-owned coordinate array into the @ref coordinates member.
+    /// @param[in] coords Pointer to the flat nodal-coordinate array.
+    void assignNodeCoordinates( const double* coords )
+    {
+      new ( &coordinates ) Eigen::Map< const CoordinateVector >( coords );
+    }
 
-  /*These functions are equal for each element and independent of node number and  nDimension*/
-  /// @brief Compute the expanded interpolation operator N_B from shape function values @p N.
-  NBSized NB( const NSized& N ) const { return Marmot::FiniteElement::NB< nDim, nNodes >( N ); }
+    /*Please specialize these functions for each element individially
+     *.cpp file.
+     *Fully specialized templates are precompiled in marmotMechanics (rather than the unspecialized and
+     *partially specialized templates)
+     * */
+    /// @brief Evaluate the shape function row vector at natural coordinates @p xi.
+    NSized N( const XiSized& xi ) const;
+    /// @brief Evaluate the matrix of shape function natural derivatives at @p xi.
+    dNdXiSized dNdXi( const XiSized& xi ) const;
+    /// @brief Compute the standard B-operator from physical derivatives @p dNdX.
+    BSized B( const dNdXiSized& dNdX ) const;
+    /// @brief Compute the axisymmetric B-operator (4 components).
+    BSizedAxisymmetric B_axisymmetric( const dNdXiSized& dNdX, const NSized& N, const XiSized& x_gauss ) const;
+    /// @brief Compute the B̄-operator using the B-bar selective-reduced-integration method.
+    BSized B_bar( const dNdXiSized& dNdX, const dNdXiSized& dNdX0 ) const;
+    /// @brief Compute the Green–Lagrange strain operator for deformation gradient @p F.
+    BSized BGreen( const dNdXiSized& dNdX, const JacobianSized& F ) const;
 
-  /// @brief Compute the element Jacobian from natural derivatives @p dNdXi and the stored nodal coordinates.
-  JacobianSized Jacobian( const dNdXiSized& dNdXi ) const
-  {
-    return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdXi, coordinates );
-  }
+    /*These functions are equal for each element and independent of node number and  nDimension*/
+    /// @brief Compute the expanded interpolation operator N_B from shape function values @p N.
+    NBSized NB( const NSized& N ) const { return Marmot::FiniteElement::NB< nDim, nNodes >( N ); }
 
-  /// @brief Compute physical derivatives @p dN/dX from natural derivatives and the inverse Jacobian.
-  /// @param[in] dNdXi        Natural-coordinate derivatives.
-  /// @param[in] JacobianInverse  Inverse of the element Jacobian.
-  dNdXiSized dNdX( const dNdXiSized& dNdXi, const JacobianSized& JacobianInverse ) const
-  {
-    return ( dNdXi.transpose() * JacobianInverse ).transpose();
-  }
+    /// @brief Compute the element Jacobian from natural derivatives @p dNdXi and the stored nodal coordinates.
+    JacobianSized Jacobian( const dNdXiSized& dNdXi ) const
+    {
+      return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdXi, coordinates );
+    }
 
-  /// @brief Compute the deformation gradient \f$\mathbf{F}\f$ from physical derivatives and displacements @p Q.
-  /// @param[in] dNdX Physical shape function derivatives.
-  /// @param[in] Q    Element displacement vector.
-  JacobianSized F( const dNdXiSized& dNdX, const CoordinateVector& Q ) const
-  {
-    return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdX, Q ) + JacobianSized::Identity();
-  }
-};
+    /// @brief Compute physical derivatives @p dN/dX from natural derivatives and the inverse Jacobian.
+    /// @param[in] dNdXi        Natural-coordinate derivatives.
+    /// @param[in] JacobianInverse  Inverse of the element Jacobian.
+    dNdXiSized dNdX( const dNdXiSized& dNdXi, const JacobianSized& JacobianInverse ) const
+    {
+      return ( dNdXi.transpose() * JacobianInverse ).transpose();
+    }
+
+    /// @brief Compute the deformation gradient \f$\mathbf{F}\f$ from physical derivatives and displacements @p Q.
+    /// @param[in] dNdX Physical shape function derivatives.
+    /// @param[in] Q    Element displacement vector.
+    JacobianSized F( const dNdXiSized& dNdX, const CoordinateVector& Q ) const
+    {
+      return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdX, Q ) + JacobianSized::Identity();
+    }
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/src/MarmotElement.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotElement.cpp
@@ -1,7 +1,11 @@
 #include "Marmot/MarmotElement.h"
 
-MarmotElement::~MarmotElement() {}
+namespace Marmot {
 
-void MarmotElement::assignProperty( const ElementProperties& property ) {}
+  MarmotElement::~MarmotElement() {}
 
-void MarmotElement::assignProperty( const MarmotMaterialSection& property ) {}
+  void MarmotElement::assignProperty( const ElementProperties& property ) {}
+
+  void MarmotElement::assignProperty( const MarmotMaterialSection& property ) {}
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/src/MarmotElementFactory.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotElementFactory.cpp
@@ -1,6 +1,6 @@
 #include "Marmot/MarmotElementFactory.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 MarmotElementFactory::ElementFactoryMap& MarmotElementFactory::elementFactoryFunctionByName()
 {

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
@@ -3,274 +3,284 @@
 #include "Marmot/MarmotVoigt.h"
 #include <iostream>
 
-using namespace Eigen;
-MarmotElementSpatialWrapper::MarmotElementSpatialWrapper( int                              nDim,
-                                                          int                              nDimChild,
-                                                          int                              nNodes,
-                                                          int                              nRhsChild,
-                                                          const int                        rhsIndicesToBeWrapped[],
-                                                          int                              nRhsIndicesToBeWrapped,
-                                                          std::unique_ptr< MarmotElement > childElement )
+namespace Marmot {
 
-  : nDim( nDim ),
-    nDimChild( nDimChild ),
-    nNodes( nNodes ),
-    nRhsChild( nRhsChild ),
-    rhsIndicesToBeProjected( rhsIndicesToBeWrapped, nRhsIndicesToBeWrapped ),
-    projectedSize( nRhsChild ),
-    unprojectedSize( nRhsChild + rhsIndicesToBeProjected.size() * ( nDim - nDimChild ) ),
-    childElement( std::move( childElement ) )
-{
-}
+  using namespace Eigen;
+  MarmotElementSpatialWrapper::MarmotElementSpatialWrapper( int                              nDim,
+                                                            int                              nDimChild,
+                                                            int                              nNodes,
+                                                            int                              nRhsChild,
+                                                            const int                        rhsIndicesToBeWrapped[],
+                                                            int                              nRhsIndicesToBeWrapped,
+                                                            std::unique_ptr< MarmotElement > childElement )
 
-int MarmotElementSpatialWrapper::getNumberOfRequiredStateVars()
-{
-  return childElement->getNumberOfRequiredStateVars();
-}
-
-std::vector< std::vector< std::string > > MarmotElementSpatialWrapper::getNodeFields()
-{
-  return childElement->getNodeFields();
-}
-
-int MarmotElementSpatialWrapper::getNNodes()
-{
-  return nNodes;
-}
-
-int MarmotElementSpatialWrapper::getNSpatialDimensions()
-{
-  return nDim;
-}
-
-int MarmotElementSpatialWrapper::getNDofPerElement()
-{
-  return unprojectedSize;
-}
-
-std::string MarmotElementSpatialWrapper::getElementShape()
-{
-  return childElement->getElementShape();
-}
-
-void MarmotElementSpatialWrapper::assignProperty( const MarmotMaterialSection& property )
-{
-  childElement->assignProperty( property );
-}
-
-void MarmotElementSpatialWrapper::assignProperty( const ElementProperties& property )
-{
-  childElement->assignProperty( property );
-}
-
-void MarmotElementSpatialWrapper::assignProperty( const std::string& propertyName, const double* properties )
-{
-  childElement->assignProperty( propertyName, properties );
-}
-
-std::vector< std::string > MarmotElementSpatialWrapper::getPropertyNames() const
-{
-  return childElement->getPropertyNames();
-}
-
-std::vector< int > MarmotElementSpatialWrapper::getDofIndicesPermutationPattern()
-{
-  std::vector< int > permutationPattern;
-
-  auto childPermutationPattern = childElement->getDofIndicesPermutationPattern();
-
-  int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
-  int indexChild;
-  while ( i < projectedSize ) {
-
-    indexChild = childPermutationPattern[i];
-    if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
-      // copy the Transformation block wise ( if current DOF is projected )
-      for ( int l = 0; l < nDim; l++ )
-        permutationPattern.push_back( indexChild + j + l );
-
-      i += nDimChild;
-      j += ( nDim - nDimChild );
-      k += 1;
-    }
-    else {
-      permutationPattern.push_back( indexChild + j );
-      i++;
-      j++;
-    }
+    : nDim( nDim ),
+      nDimChild( nDimChild ),
+      nNodes( nNodes ),
+      nRhsChild( nRhsChild ),
+      rhsIndicesToBeProjected( rhsIndicesToBeWrapped, nRhsIndicesToBeWrapped ),
+      projectedSize( nRhsChild ),
+      unprojectedSize( nRhsChild + rhsIndicesToBeProjected.size() * ( nDim - nDimChild ) ),
+      childElement( std::move( childElement ) )
+  {
   }
 
-  return permutationPattern;
-}
-
-void MarmotElementSpatialWrapper::assignStateVars( double* stateVars, int nStateVars )
-{
-  childElement->assignStateVars( stateVars, nStateVars );
-}
-
-void MarmotElementSpatialWrapper::initializeYourself()
-{
-  childElement->initializeYourself();
-}
-
-void MarmotElementSpatialWrapper::assignNodeCoordinates( const double* coordinates )
-{
-  Map< const MatrixXd > unprojectedCoordinates( coordinates, nDim, nNodes );
-
-  if ( nDimChild == 1 ) {
-    // take the (normalized) directional vector based on the first 2 nodes (valid for truss2,
-    // truss3);
-    VectorXd n = unprojectedCoordinates.col( 1 ) - unprojectedCoordinates.col( 0 );
-    n /= n.norm();
-    T = n.transpose();
+  int MarmotElementSpatialWrapper::getNumberOfRequiredStateVars()
+  {
+    return childElement->getNumberOfRequiredStateVars();
   }
 
-  P = MatrixXd::Zero( projectedSize, unprojectedSize );
-  // Alternatively: P as a Sparse matrix; currently not necessary...
-
-  int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
-  while ( i < projectedSize ) {
-
-    if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
-      // copy the Transformation block wise ( if current DOF is projected )
-      P.block( i, j, nDimChild, nDim ) = T;
-
-      i += nDimChild;
-      j += nDim;
-      k += 1;
-    }
-    else {
-      P( i, j ) = 1.0;
-      i++;
-      j++;
-    }
+  std::vector< std::vector< std::string > > MarmotElementSpatialWrapper::getNodeFields()
+  {
+    return childElement->getNodeFields();
   }
 
-  // Projection of node coordinates
-  projectedCoordinates = MatrixXd::Zero( nDimChild, nNodes );
-  for ( int i = 0; i < nNodes; i++ )
-    projectedCoordinates.col( i ) = T * unprojectedCoordinates.col( i );
+  int MarmotElementSpatialWrapper::getNNodes()
+  {
+    return nNodes;
+  }
 
-  childElement->assignNodeCoordinates( projectedCoordinates.data() );
-}
+  int MarmotElementSpatialWrapper::getNSpatialDimensions()
+  {
+    return nDim;
+  }
 
-void MarmotElementSpatialWrapper::computeKernels( const double* Q,
-                                                  const double* dQ,
-                                                  double*       Pe_,
-                                                  double*       Ke_,
-                                                  double        time,
-                                                  double        dT )
-{
-  Map< const VectorXd > Q_Unprojected( Q, unprojectedSize );
-  Map< const VectorXd > dQ_Unprojected( dQ, unprojectedSize );
+  int MarmotElementSpatialWrapper::getNDofPerElement()
+  {
+    return unprojectedSize;
+  }
 
-  VectorXd Q_Projected  = P * Q_Unprojected;
-  VectorXd dQ_Projected = P * dQ_Unprojected;
+  std::string MarmotElementSpatialWrapper::getElementShape()
+  {
+    return childElement->getElementShape();
+  }
 
-  VectorXd Pe_Projected = VectorXd::Zero( projectedSize );
-  MatrixXd Ke_Projected = MatrixXd::Zero( projectedSize, projectedSize );
+  void MarmotElementSpatialWrapper::assignProperty( const MarmotMaterialSection& property )
+  {
+    childElement->assignProperty( property );
+  }
 
-  childElement
-    ->computeKernels( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
+  void MarmotElementSpatialWrapper::assignProperty( const ElementProperties& property )
+  {
+    childElement->assignProperty( property );
+  }
 
-  Map< VectorXd > Pe_Unprojected( Pe_, unprojectedSize );
-  Map< MatrixXd > Ke_Unprojected( Ke_, unprojectedSize, unprojectedSize );
+  void MarmotElementSpatialWrapper::assignProperty( const std::string& propertyName, const double* properties )
+  {
+    childElement->assignProperty( propertyName, properties );
+  }
 
-  Ke_Unprojected += P.transpose() * Ke_Projected * P;
-  Pe_Unprojected += P.transpose() * Pe_Projected;
-}
+  std::vector< std::string > MarmotElementSpatialWrapper::getPropertyNames() const
+  {
+    return childElement->getPropertyNames();
+  }
 
-void MarmotElementSpatialWrapper::setInitialConditions( StateTypes state, const double* values )
-{
-  childElement->setInitialConditions( state, values );
-}
+  std::vector< int > MarmotElementSpatialWrapper::getDofIndicesPermutationPattern()
+  {
+    std::vector< int > permutationPattern;
 
-void MarmotElementSpatialWrapper::computeDistributedLoad( DistributedLoadTypes loadType,
-                                                          double*              P_,
-                                                          double*              K,
-                                                          int                  elementFace,
-                                                          const double*        load,
-                                                          const double*        QTotal,
-                                                          double               time,
-                                                          double               dT )
-{
-  VectorXd P_Projected = VectorXd::Zero( projectedSize );
-  MatrixXd Ke_Projected( projectedSize, projectedSize );
+    auto childPermutationPattern = childElement->getDofIndicesPermutationPattern();
 
-  childElement
-    ->computeDistributedLoad( loadType, P_Projected.data(), Ke_Projected.data(), elementFace, QTotal, load, time, dT );
+    int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
+    int indexChild;
+    while ( i < projectedSize ) {
 
-  Map< VectorXd > P_Unprojected( P_, unprojectedSize );
-  P_Unprojected = P.transpose() * P_Projected;
+      indexChild = childPermutationPattern[i];
+      if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
+        // copy the Transformation block wise ( if current DOF is projected )
+        for ( int l = 0; l < nDim; l++ )
+          permutationPattern.push_back( indexChild + j + l );
 
-  Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
-  Ke_Unprojected = P.transpose() * Ke_Projected * P;
-}
+        i += nDimChild;
+        j += ( nDim - nDimChild );
+        k += 1;
+      }
+      else {
+        permutationPattern.push_back( indexChild + j );
+        i++;
+        j++;
+      }
+    }
 
-void MarmotElementSpatialWrapper::computeBodyForce( double*       P_,
-                                                    double*       K,
-                                                    const double* load,
-                                                    const double* QTotal,
+    return permutationPattern;
+  }
+
+  void MarmotElementSpatialWrapper::assignStateVars( double* stateVars, int nStateVars )
+  {
+    childElement->assignStateVars( stateVars, nStateVars );
+  }
+
+  void MarmotElementSpatialWrapper::initializeYourself()
+  {
+    childElement->initializeYourself();
+  }
+
+  void MarmotElementSpatialWrapper::assignNodeCoordinates( const double* coordinates )
+  {
+    Map< const MatrixXd > unprojectedCoordinates( coordinates, nDim, nNodes );
+
+    if ( nDimChild == 1 ) {
+      // take the (normalized) directional vector based on the first 2 nodes (valid for truss2,
+      // truss3);
+      VectorXd n = unprojectedCoordinates.col( 1 ) - unprojectedCoordinates.col( 0 );
+      n /= n.norm();
+      T = n.transpose();
+    }
+
+    P = MatrixXd::Zero( projectedSize, unprojectedSize );
+    // Alternatively: P as a Sparse matrix; currently not necessary...
+
+    int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
+    while ( i < projectedSize ) {
+
+      if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
+        // copy the Transformation block wise ( if current DOF is projected )
+        P.block( i, j, nDimChild, nDim ) = T;
+
+        i += nDimChild;
+        j += nDim;
+        k += 1;
+      }
+      else {
+        P( i, j ) = 1.0;
+        i++;
+        j++;
+      }
+    }
+
+    // Projection of node coordinates
+    projectedCoordinates = MatrixXd::Zero( nDimChild, nNodes );
+    for ( int i = 0; i < nNodes; i++ )
+      projectedCoordinates.col( i ) = T * unprojectedCoordinates.col( i );
+
+    childElement->assignNodeCoordinates( projectedCoordinates.data() );
+  }
+
+  void MarmotElementSpatialWrapper::computeKernels( const double* Q,
+                                                    const double* dQ,
+                                                    double*       Pe_,
+                                                    double*       Ke_,
                                                     double        time,
                                                     double        dT )
-{
-  VectorXd P_Projected = VectorXd::Zero( projectedSize );
-  MatrixXd Ke_Projected( projectedSize, projectedSize );
+  {
+    Map< const VectorXd > Q_Unprojected( Q, unprojectedSize );
+    Map< const VectorXd > dQ_Unprojected( dQ, unprojectedSize );
 
-  childElement->computeBodyForce( P_Projected.data(), Ke_Projected.data(), load, QTotal, time, dT );
+    VectorXd Q_Projected  = P * Q_Unprojected;
+    VectorXd dQ_Projected = P * dQ_Unprojected;
 
-  Map< VectorXd > P_Unprojected( P_, unprojectedSize );
-  P_Unprojected = P.transpose() * P_Projected;
+    VectorXd Pe_Projected = VectorXd::Zero( projectedSize );
+    MatrixXd Ke_Projected = MatrixXd::Zero( projectedSize, projectedSize );
 
-  Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
-  Ke_Unprojected = P.transpose() * Ke_Projected * P;
-}
+    childElement
+      ->computeKernels( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
 
-StateView MarmotElementSpatialWrapper::getStateView( const std::string& stateName, int quadraturePoint )
-{
-  if ( stateName == "MarmotElementSpatialWrapper.T" ) {
-    return { T.data(), static_cast< int >( T.size() ) };
+    Map< VectorXd > Pe_Unprojected( Pe_, unprojectedSize );
+    Map< MatrixXd > Ke_Unprojected( Ke_, unprojectedSize, unprojectedSize );
+
+    Ke_Unprojected += P.transpose() * Ke_Projected * P;
+    Pe_Unprojected += P.transpose() * Pe_Projected;
   }
 
-  return childElement->getStateView( stateName, quadraturePoint );
-}
-
-std::vector< double > MarmotElementSpatialWrapper::getCoordinatesAtCenter()
-{
-  std::vector< double > coords( nDim );
-
-  Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
-
-  const auto                          coordsChild_ = childElement->getCoordinatesAtCenter();
-  Eigen::Map< const Eigen::VectorXd > coordsChild( &coordsChild_[0], coordsChild_.size() );
-
-  coordsMap = P.transpose() * coordsChild;
-
-  return coords;
-}
-
-std::vector< std::vector< double > > MarmotElementSpatialWrapper::getCoordinatesAtQuadraturePoints()
-{
-  auto listedChildCoords = childElement->getCoordinatesAtQuadraturePoints();
-
-  std::vector< std::vector< double > > listedCoords;
-
-  std::vector< double >         coords( nDim );
-  Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
-
-  for ( const auto& coordsChild : listedChildCoords ) {
-    Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], nDim );
-    coordsMap = P.transpose() * coordsChildMap;
-
-    listedCoords.push_back( coords );
+  void MarmotElementSpatialWrapper::setInitialConditions( StateTypes state, const double* values )
+  {
+    childElement->setInitialConditions( state, values );
   }
 
-  return listedCoords;
-}
+  void MarmotElementSpatialWrapper::computeDistributedLoad( DistributedLoadTypes loadType,
+                                                            double*              P_,
+                                                            double*              K,
+                                                            int                  elementFace,
+                                                            const double*        load,
+                                                            const double*        QTotal,
+                                                            double               time,
+                                                            double               dT )
+  {
+    VectorXd P_Projected = VectorXd::Zero( projectedSize );
+    MatrixXd Ke_Projected( projectedSize, projectedSize );
 
-int MarmotElementSpatialWrapper::getNumberOfQuadraturePoints()
-{
-  auto numberOfQuadraturePoints = childElement->getNumberOfQuadraturePoints();
+    childElement->computeDistributedLoad( loadType,
+                                          P_Projected.data(),
+                                          Ke_Projected.data(),
+                                          elementFace,
+                                          QTotal,
+                                          load,
+                                          time,
+                                          dT );
 
-  return numberOfQuadraturePoints;
-}
+    Map< VectorXd > P_Unprojected( P_, unprojectedSize );
+    P_Unprojected = P.transpose() * P_Projected;
+
+    Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
+    Ke_Unprojected = P.transpose() * Ke_Projected * P;
+  }
+
+  void MarmotElementSpatialWrapper::computeBodyForce( double*       P_,
+                                                      double*       K,
+                                                      const double* load,
+                                                      const double* QTotal,
+                                                      double        time,
+                                                      double        dT )
+  {
+    VectorXd P_Projected = VectorXd::Zero( projectedSize );
+    MatrixXd Ke_Projected( projectedSize, projectedSize );
+
+    childElement->computeBodyForce( P_Projected.data(), Ke_Projected.data(), load, QTotal, time, dT );
+
+    Map< VectorXd > P_Unprojected( P_, unprojectedSize );
+    P_Unprojected = P.transpose() * P_Projected;
+
+    Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
+    Ke_Unprojected = P.transpose() * Ke_Projected * P;
+  }
+
+  StateView MarmotElementSpatialWrapper::getStateView( const std::string& stateName, int quadraturePoint )
+  {
+    if ( stateName == "MarmotElementSpatialWrapper.T" ) {
+      return { T.data(), static_cast< int >( T.size() ) };
+    }
+
+    return childElement->getStateView( stateName, quadraturePoint );
+  }
+
+  std::vector< double > MarmotElementSpatialWrapper::getCoordinatesAtCenter()
+  {
+    std::vector< double > coords( nDim );
+
+    Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
+
+    const auto                          coordsChild_ = childElement->getCoordinatesAtCenter();
+    Eigen::Map< const Eigen::VectorXd > coordsChild( &coordsChild_[0], coordsChild_.size() );
+
+    coordsMap = P.transpose() * coordsChild;
+
+    return coords;
+  }
+
+  std::vector< std::vector< double > > MarmotElementSpatialWrapper::getCoordinatesAtQuadraturePoints()
+  {
+    auto listedChildCoords = childElement->getCoordinatesAtQuadraturePoints();
+
+    std::vector< std::vector< double > > listedCoords;
+
+    std::vector< double >         coords( nDim );
+    Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
+
+    for ( const auto& coordsChild : listedChildCoords ) {
+      Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], nDim );
+      coordsMap = P.transpose() * coordsChildMap;
+
+      listedCoords.push_back( coords );
+    }
+
+    return listedCoords;
+  }
+
+  int MarmotElementSpatialWrapper::getNumberOfQuadraturePoints()
+  {
+    auto numberOfQuadraturePoints = childElement->getNumberOfQuadraturePoints();
+
+    return numberOfQuadraturePoints;
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/src/MarmotGeometryElement.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotGeometryElement.cpp
@@ -1,228 +1,232 @@
 #include "Marmot/MarmotGeometryElement.h"
 
-using namespace Eigen;
+namespace Marmot {
 
-/* Template Specialization for Shape functions.
- * These (full) specializations are precompiled into the current static marmotMechanics.
- * Thus, they act as static links to the corresponding FiniteElement functions.
- *
- * For a new element, please specialize ALL functions.
- *
- * */
+  using namespace Eigen;
 
-// Bar2
-template <>
-MarmotGeometryElement< 1, 2 >::NSized MarmotGeometryElement< 1, 2 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial1D::Bar2::N( xi( 0 ) );
-}
-// Quad4
-template <>
-MarmotGeometryElement< 2, 4 >::NSized MarmotGeometryElement< 2, 4 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad4::N( xi );
-}
-// Quad8
-template <>
-MarmotGeometryElement< 2, 8 >::NSized MarmotGeometryElement< 2, 8 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad8::N( xi );
-}
-// Tetra4
-template <>
-MarmotGeometryElement< 3, 4 >::NSized MarmotGeometryElement< 3, 4 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra4::N( xi );
-}
-// Tetra10
-template <>
-MarmotGeometryElement< 3, 10 >::NSized MarmotGeometryElement< 3, 10 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra10::N( xi );
-}
-// Hexa8
-template <>
-MarmotGeometryElement< 3, 8 >::NSized MarmotGeometryElement< 3, 8 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa8::N( xi );
-}
-// Hexa20
-template <>
-MarmotGeometryElement< 3, 20 >::NSized MarmotGeometryElement< 3, 20 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa20::N( xi );
-}
+  /* Template Specialization for Shape functions.
+   * These (full) specializations are precompiled into the current static marmotMechanics.
+   * Thus, they act as static links to the corresponding FiniteElement functions.
+   *
+   * For a new element, please specialize ALL functions.
+   *
+   * */
 
-/* Template Specialization for Shape functions derivatives.
- * */
-// Bar2
-template <>
-MarmotGeometryElement< 1, 2 >::dNdXiSized MarmotGeometryElement< 1, 2 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial1D::Bar2::dNdXi( xi( 0 ) );
-}
-// Quad4
-template <>
-MarmotGeometryElement< 2, 4 >::dNdXiSized MarmotGeometryElement< 2, 4 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad4::dNdXi( xi );
-}
-// Quad8
-template <>
-MarmotGeometryElement< 2, 8 >::dNdXiSized MarmotGeometryElement< 2, 8 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad8::dNdXi( xi );
-}
-// Tetra4
-template <>
-MarmotGeometryElement< 3, 4 >::dNdXiSized MarmotGeometryElement< 3, 4 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra4::dNdXi( xi );
-}
-// Tetra10
-template <>
-MarmotGeometryElement< 3, 10 >::dNdXiSized MarmotGeometryElement< 3, 10 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra10::dNdXi( xi );
-}
-// Hexa8
-template <>
-MarmotGeometryElement< 3, 8 >::dNdXiSized MarmotGeometryElement< 3, 8 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa8::dNdXi( xi );
-}
-// Hexa20
-template <>
-MarmotGeometryElement< 3, 20 >::dNdXiSized MarmotGeometryElement< 3, 20 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa20::dNdXi( xi );
-}
+  // Bar2
+  template <>
+  MarmotGeometryElement< 1, 2 >::NSized MarmotGeometryElement< 1, 2 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial1D::Bar2::N( xi( 0 ) );
+  }
+  // Quad4
+  template <>
+  MarmotGeometryElement< 2, 4 >::NSized MarmotGeometryElement< 2, 4 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad4::N( xi );
+  }
+  // Quad8
+  template <>
+  MarmotGeometryElement< 2, 8 >::NSized MarmotGeometryElement< 2, 8 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad8::N( xi );
+  }
+  // Tetra4
+  template <>
+  MarmotGeometryElement< 3, 4 >::NSized MarmotGeometryElement< 3, 4 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra4::N( xi );
+  }
+  // Tetra10
+  template <>
+  MarmotGeometryElement< 3, 10 >::NSized MarmotGeometryElement< 3, 10 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra10::N( xi );
+  }
+  // Hexa8
+  template <>
+  MarmotGeometryElement< 3, 8 >::NSized MarmotGeometryElement< 3, 8 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa8::N( xi );
+  }
+  // Hexa20
+  template <>
+  MarmotGeometryElement< 3, 20 >::NSized MarmotGeometryElement< 3, 20 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa20::N( xi );
+  }
 
-/* Template Specialization for B Operator
- * Note that partial template specialization (i.e., for all nDim=2 and all nDim=3) is not valid for
- * methods (only for classes) in C++, and, hence, the B Operator must be specialized for each
- * nDim/nNodes combination individually.
- * */
+  /* Template Specialization for Shape functions derivatives.
+   * */
+  // Bar2
+  template <>
+  MarmotGeometryElement< 1, 2 >::dNdXiSized MarmotGeometryElement< 1, 2 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial1D::Bar2::dNdXi( xi( 0 ) );
+  }
+  // Quad4
+  template <>
+  MarmotGeometryElement< 2, 4 >::dNdXiSized MarmotGeometryElement< 2, 4 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad4::dNdXi( xi );
+  }
+  // Quad8
+  template <>
+  MarmotGeometryElement< 2, 8 >::dNdXiSized MarmotGeometryElement< 2, 8 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad8::dNdXi( xi );
+  }
+  // Tetra4
+  template <>
+  MarmotGeometryElement< 3, 4 >::dNdXiSized MarmotGeometryElement< 3, 4 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra4::dNdXi( xi );
+  }
+  // Tetra10
+  template <>
+  MarmotGeometryElement< 3, 10 >::dNdXiSized MarmotGeometryElement< 3, 10 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra10::dNdXi( xi );
+  }
+  // Hexa8
+  template <>
+  MarmotGeometryElement< 3, 8 >::dNdXiSized MarmotGeometryElement< 3, 8 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa8::dNdXi( xi );
+  }
+  // Hexa20
+  template <>
+  MarmotGeometryElement< 3, 20 >::dNdXiSized MarmotGeometryElement< 3, 20 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa20::dNdXi( xi );
+  }
 
-/* TODO: Replace by constexpr if expression for each dimension -> get rid of partial specializations; full
- * specialization should be possible
- *
- * */
+  /* Template Specialization for B Operator
+   * Note that partial template specialization (i.e., for all nDim=2 and all nDim=3) is not valid for
+   * methods (only for classes) in C++, and, hence, the B Operator must be specialized for each
+   * nDim/nNodes combination individually.
+   * */
 
-// Bar2
-template <>
-typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::B( const dNdXiSized& dNdX ) const
-{
-  return dNdX;
-}
-// Quad4
-template <>
-typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial2D::B< 4 >( dNdX );
-}
-// axisymmetric quad8
-template <>
-typename MarmotGeometryElement< 2, 4 >::BSizedAxisymmetric MarmotGeometryElement< 2, 4 >::B_axisymmetric(
-  const dNdXiSized& dNdX,
-  const NSized&     N,
-  const XiSized&    x_gauss ) const
-{
-  return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 4 >( dNdX, N, x_gauss );
-}
-// Quad8
-template <>
-typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial2D::B< 8 >( dNdX );
-}
-// axisymmetric quad8
-template <>
-typename MarmotGeometryElement< 2, 8 >::BSizedAxisymmetric MarmotGeometryElement< 2, 8 >::B_axisymmetric(
-  const dNdXiSized& dNdX,
-  const NSized&     N,
-  const XiSized&    x_gauss ) const
-{
-  return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 8 >( dNdX, N, x_gauss );
-}
-// Tetra4
-template <>
-typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 4 >( dNdX );
-}
-// Tetra10
-template <>
-typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 10 >( dNdX );
-}
-// Hexa8
-template <>
-typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 8 >( dNdX );
-}
-// Hexa8 B-bar
-template <>
-typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B_bar( const dNdXiSized& dNdX,
-                                                                                     const dNdXiSized& dNdX0 ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B_bar< 8 >( dNdX, dNdX0 );
-}
-// Hexa20
-template <>
-typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 20 >( dNdX );
-}
+  /* TODO: Replace by constexpr if expression for each dimension -> get rid of partial specializations; full
+   * specialization should be possible
+   *
+   * */
 
-// Bar2
-template <>
-typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return dNdX * F( 0, 0 );
-}
-// Quad4
-template <>
-typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial2D::BGreen< 4 >( dNdX, F );
-}
-// Quad8
-template <>
-typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial2D::BGreen< 8 >( dNdX, F );
-}
-// Tetra4
-template <>
-typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 4 >( dNdX, F );
-}
-// Tetra10
-template <>
-typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::BGreen( const dNdXiSized&    dNdX,
+  // Bar2
+  template <>
+  typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::B( const dNdXiSized& dNdX ) const
+  {
+    return dNdX;
+  }
+  // Quad4
+  template <>
+  typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::B< 4 >( dNdX );
+  }
+  // axisymmetric quad8
+  template <>
+  typename MarmotGeometryElement< 2, 4 >::BSizedAxisymmetric MarmotGeometryElement< 2, 4 >::B_axisymmetric(
+    const dNdXiSized& dNdX,
+    const NSized&     N,
+    const XiSized&    x_gauss ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 4 >( dNdX, N, x_gauss );
+  }
+  // Quad8
+  template <>
+  typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::B< 8 >( dNdX );
+  }
+  // axisymmetric quad8
+  template <>
+  typename MarmotGeometryElement< 2, 8 >::BSizedAxisymmetric MarmotGeometryElement< 2, 8 >::B_axisymmetric(
+    const dNdXiSized& dNdX,
+    const NSized&     N,
+    const XiSized&    x_gauss ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 8 >( dNdX, N, x_gauss );
+  }
+  // Tetra4
+  template <>
+  typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 4 >( dNdX );
+  }
+  // Tetra10
+  template <>
+  typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 10 >( dNdX );
+  }
+  // Hexa8
+  template <>
+  typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 8 >( dNdX );
+  }
+  // Hexa8 B-bar
+  template <>
+  typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B_bar( const dNdXiSized& dNdX,
+                                                                                       const dNdXiSized& dNdX0 ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B_bar< 8 >( dNdX, dNdX0 );
+  }
+  // Hexa20
+  template <>
+  typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 20 >( dNdX );
+  }
+
+  // Bar2
+  template <>
+  typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::BGreen( const dNdXiSized&    dNdX,
                                                                                         const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 10 >( dNdX, F );
-}
-// Hexa8
-template <>
-typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 8 >( dNdX, F );
-}
-// Hexa20
-template <>
-typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::BGreen( const dNdXiSized&    dNdX,
+  {
+    return dNdX * F( 0, 0 );
+  }
+  // Quad4
+  template <>
+  typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::BGreen( const dNdXiSized&    dNdX,
                                                                                         const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 20 >( dNdX, F );
-}
+  {
+    return Marmot::FiniteElement::Spatial2D::BGreen< 4 >( dNdX, F );
+  }
+  // Quad8
+  template <>
+  typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                        const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::BGreen< 8 >( dNdX, F );
+  }
+  // Tetra4
+  template <>
+  typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                        const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 4 >( dNdX, F );
+  }
+  // Tetra10
+  template <>
+  typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                          const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 10 >( dNdX, F );
+  }
+  // Hexa8
+  template <>
+  typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                        const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 8 >( dNdX, F );
+  }
+  // Hexa20
+  template <>
+  typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                          const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 20 >( dNdX, F );
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
@@ -29,353 +29,364 @@
 #include <cmath>
 #include <vector>
 
-/**
- * @class MarmotMaterialFiniteStrain
- * @brief Abstract base class for mechanical materials in the finite strain regime.
- *
- * Derived classes implement computeStress() to provide the constitutive response
- * (Kirchhoff stress, density, elastic energy density) and the algorithmic tangent.
- */
-class MarmotMaterialFiniteStrain {
-
-protected:
-  const double* materialProperties;  ///< Pointer to the array of material property values.
-  const int     nMaterialProperties; ///< Number of material property values.
-
-public:
-  const int materialNumber; ///< Unique identifier for this material instance.
+namespace Marmot {
 
   /**
-   * @brief Construct a MarmotMaterialFiniteStrain.
-   * @param[in] matProperties_       Pointer to the array of material property values.
-   * @param[in] nMaterialProperties_ Number of material property values.
-   * @param[in] materialNumber_      Unique identifier for this material instance.
-   */
-  MarmotMaterialFiniteStrain( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
-    : materialProperties( matProperties_ ),
-      nMaterialProperties( nMaterialProperties_ ),
-      materialNumber( materialNumber_ )
-  {
-  }
-
-  /// Default destructor
-  virtual ~MarmotMaterialFiniteStrain() = default;
-
-  /// Layout of the state variables
-  MarmotStateLayoutDynamic stateLayout;
-
-  /**
-   * @struct ConstitutiveResponse
-   * @brief Constitutive response of a material at given state.
-   * @tparam nDim Number of spatial dimensions (2 or 3).
+   * @class MarmotMaterialFiniteStrain
+   * @brief Abstract base class for mechanical materials in the finite strain regime.
    *
-   *  Contains stress, density and elastic energy density.
+   * Derived classes implement computeStress() to provide the constitutive response
+   * (Kirchhoff stress, density, elastic energy density) and the algorithmic tangent.
    */
-  template < int nDim >
-  struct ConstitutiveResponse {
-    Fastor::Tensor< double, nDim, nDim > tau;                  ///< Kirchhoff stress
-    double                               elasticEnergyDensity; ///< elastic energy per unit volume
-    double                               dissipation;          ///< dissipation per unit volume
-    double*                              stateVars;            ///< pointer to state variables
+  class MarmotMaterialFiniteStrain {
+
+  protected:
+    const double* materialProperties;  ///< Pointer to the array of material property values.
+    const int     nMaterialProperties; ///< Number of material property values.
+
+  public:
+    const int materialNumber; ///< Unique identifier for this material instance.
 
     /**
-     * @brief Default constructor.
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+     * @brief Construct a MarmotMaterialFiniteStrain.
+     * @param[in] matProperties_       Pointer to the array of material property values.
+     * @param[in] nMaterialProperties_ Number of material property values.
+     * @param[in] materialNumber_      Unique identifier for this material instance.
      */
-    ConstitutiveResponse()
-      : tau( Fastor::Tensor< double, nDim, nDim >( 0.0 ) ),
-        elasticEnergyDensity( 0.0 ),
-        dissipation( 0.0 ),
-        stateVars( nullptr )
+    MarmotMaterialFiniteStrain( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : materialProperties( matProperties_ ),
+        nMaterialProperties( nMaterialProperties_ ),
+        materialNumber( materialNumber_ )
     {
     }
+
+    /// Default destructor
+    virtual ~MarmotMaterialFiniteStrain() = default;
+
+    /// Layout of the state variables
+    MarmotStateLayoutDynamic stateLayout;
+
     /**
-     * @brief Constructor for initializing the constitutive response.
-     * @param tau_ Kirchhoff stress tensor.
-     * @param elasticEnergyDensity_ Elastic energy density.
-     * @param dissipation_ Dissipation per unit volume.
-     * @param stateVars_ Pointer to state variables.
+     * @struct ConstitutiveResponse
+     * @brief Constitutive response of a material at given state.
+     * @tparam nDim Number of spatial dimensions (2 or 3).
+     *
+     *  Contains stress, density and elastic energy density.
      */
-    ConstitutiveResponse( const Fastor::Tensor< double, nDim, nDim >& tau_,
-                          double                                      elasticEnergyDensity_,
-                          double                                      dissipation_,
-                          double*                                     stateVars_ )
-      : tau( tau_ ), elasticEnergyDensity( elasticEnergyDensity_ ), dissipation( dissipation_ ), stateVars( stateVars_ )
+    template < int nDim >
+    struct ConstitutiveResponse {
+      Fastor::Tensor< double, nDim, nDim > tau;                  ///< Kirchhoff stress
+      double                               elasticEnergyDensity; ///< elastic energy per unit volume
+      double                               dissipation;          ///< dissipation per unit volume
+      double*                              stateVars;            ///< pointer to state variables
+
+      /**
+       * @brief Default constructor.
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      ConstitutiveResponse()
+        : tau( Fastor::Tensor< double, nDim, nDim >( 0.0 ) ),
+          elasticEnergyDensity( 0.0 ),
+          dissipation( 0.0 ),
+          stateVars( nullptr )
+      {
+      }
+      /**
+       * @brief Constructor for initializing the constitutive response.
+       * @param tau_ Kirchhoff stress tensor.
+       * @param elasticEnergyDensity_ Elastic energy density.
+       * @param dissipation_ Dissipation per unit volume.
+       * @param stateVars_ Pointer to state variables.
+       */
+      ConstitutiveResponse( const Fastor::Tensor< double, nDim, nDim >& tau_,
+                            double                                      elasticEnergyDensity_,
+                            double                                      dissipation_,
+                            double*                                     stateVars_ )
+        : tau( tau_ ),
+          elasticEnergyDensity( elasticEnergyDensity_ ),
+          dissipation( dissipation_ ),
+          stateVars( stateVars_ )
+      {
+      }
+    };
+
+    /**
+     * @struct AlgorithmicModuli
+     * @brief Algorithmic tangent moduli of a material.
+     * @tparam nDim Number of spatial dimensions (2 or 3).
+     *
+     * Contains the algorithmic tangent moduli \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$
+     * with respect to the deformation gradient \f$\boldsymbol{F}\f$.
+     * */
+    template < int nDim >
+    struct AlgorithmicModuli {
+      Fastor::Tensor< double, nDim, nDim, nDim, nDim > dTau_dF; ///< tangent operator w.r.t. deformation gradient
+    };
+
+    /**
+     * @struct Deformation
+     * @brief Represents the deformation state of a material.
+     *
+     * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
+     * material.
+     */
+    template < int nDim >
+    struct Deformation {
+      Fastor::Tensor< double, nDim, nDim > F; ///< deformation gradient
+    };
+
+    /**
+     * @struct TimeIncrement
+     * @brief Represents a time increment in a simulation.
+     *
+     * This struct holds information about the current time
+     * and the time step size (dT).
+     */
+    struct TimeIncrement {
+      const double time; ///< time at the beginning of the increment
+      const double dT;   ///< size of the time increment
+    };
+
+    /**
+     * @brief Updates the material state.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] tangents AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * Computes the Kirchhoff \f$\boldsymbol{\tau}\f$ stress
+     * from the deformation gradient \f$\boldsymbol{F}\f$ and the
+     * time increment \f$\Delta t\f$.
+     * It further updates the mass density \f$\rho\f$ and the elastic energy density.
+     * Additionally, computes the algorithmic tangent moduli
+     * \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$.
+     *
+     * */
+    virtual void computeStress( ConstitutiveResponse< 3 >& response,
+                                AlgorithmicModuli< 3 >&    tangents,
+                                const Deformation< 3 >&    deformation,
+                                const TimeIncrement&       timeIncrement ) const = 0;
+
+    /**
+     * @brief Explicit version of computeStress for use in explicit time integration schemes.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * @note The default implementation calls computeStress and ignores the algorithmic tangent.
+     * @note Derived classes may override this method for efficiency reasons.
+     */
+    virtual void computeStressExplicit( ConstitutiveResponse< 3 >& response,
+                                        const Deformation< 3 >&    deformation,
+                                        const TimeIncrement&       timeIncrement ) const
     {
+      AlgorithmicModuli< 3 > tangents;
+      computeStress( response, tangents, deformation, timeIncrement );
     }
-  };
 
-  /**
-   * @struct AlgorithmicModuli
-   * @brief Algorithmic tangent moduli of a material.
-   * @tparam nDim Number of spatial dimensions (2 or 3).
-   *
-   * Contains the algorithmic tangent moduli \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$
-   * with respect to the deformation gradient \f$\boldsymbol{F}\f$.
-   * */
-  template < int nDim >
-  struct AlgorithmicModuli {
-    Fastor::Tensor< double, nDim, nDim, nDim, nDim > dTau_dF; ///< tangent operator w.r.t. deformation gradient
-  };
+    /**
+     * @brief Computes the Kirchhoff stress given the deformation, time increment, and eigen deformation.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] tangents AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
+     *
+     */
+    virtual void computeStress( ConstitutiveResponse< 3 >&                  response,
+                                AlgorithmicModuli< 3 >&                     tangents,
+                                const Deformation< 3 >&                     deformation,
+                                const TimeIncrement&                        timeIncrement,
+                                const std::tuple< double, double, double >& eigenDeformation ) const;
 
-  /**
-   * @struct Deformation
-   * @brief Represents the deformation state of a material.
-   *
-   * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
-   * material.
-   */
-  template < int nDim >
-  struct Deformation {
-    Fastor::Tensor< double, nDim, nDim > F; ///< deformation gradient
-  };
+    /**
+     * @brief Compute stress under plane strain conditions.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] algorithmicModuli AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * It uses the general 3D computeStress function for a plane strain Deformation.
+     * The algorithmic tangent is modified according to plane strain conditions.
+     */
+    virtual void computePlaneStrain( ConstitutiveResponse< 3 >& response,
+                                     AlgorithmicModuli< 3 >&    algorithmicModuli,
+                                     const Deformation< 3 >&    deformation,
+                                     const TimeIncrement&       timeIncrement ) const;
 
-  /**
-   * @struct TimeIncrement
-   * @brief Represents a time increment in a simulation.
-   *
-   * This struct holds information about the current time
-   * and the time step size (dT).
-   */
-  struct TimeIncrement {
-    const double time; ///< time at the beginning of the increment
-    const double dT;   ///< size of the time increment
-  };
-
-  /**
-   * @brief Updates the material state.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] tangents AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * Computes the Kirchhoff \f$\boldsymbol{\tau}\f$ stress
-   * from the deformation gradient \f$\boldsymbol{F}\f$ and the
-   * time increment \f$\Delta t\f$.
-   * It further updates the mass density \f$\rho\f$ and the elastic energy density.
-   * Additionally, computes the algorithmic tangent moduli
-   * \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$.
-   *
-   * */
-  virtual void computeStress( ConstitutiveResponse< 3 >& response,
-                              AlgorithmicModuli< 3 >&    tangents,
-                              const Deformation< 3 >&    deformation,
-                              const TimeIncrement&       timeIncrement ) const = 0;
-
-  /**
-   * @brief Explicit version of computeStress for use in explicit time integration schemes.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * @note The default implementation calls computeStress and ignores the algorithmic tangent.
-   * @note Derived classes may override this method for efficiency reasons.
-   */
-  virtual void computeStressExplicit( ConstitutiveResponse< 3 >& response,
-                                      const Deformation< 3 >&    deformation,
-                                      const TimeIncrement&       timeIncrement ) const
-  {
-    AlgorithmicModuli< 3 > tangents;
-    computeStress( response, tangents, deformation, timeIncrement );
-  }
-
-  /**
-   * @brief Computes the Kirchhoff stress given the deformation, time increment, and eigen deformation.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] tangents AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
-   *
-   */
-  virtual void computeStress( ConstitutiveResponse< 3 >&                  response,
-                              AlgorithmicModuli< 3 >&                     tangents,
-                              const Deformation< 3 >&                     deformation,
-                              const TimeIncrement&                        timeIncrement,
-                              const std::tuple< double, double, double >& eigenDeformation ) const;
-
-  /**
-   * @brief Compute stress under plane strain conditions.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] algorithmicModuli AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * It uses the general 3D computeStress function for a plane strain Deformation.
-   * The algorithmic tangent is modified according to plane strain conditions.
-   */
-  virtual void computePlaneStrain( ConstitutiveResponse< 3 >& response,
-                                   AlgorithmicModuli< 3 >&    algorithmicModuli,
-                                   const Deformation< 3 >&    deformation,
-                                   const TimeIncrement&       timeIncrement ) const;
-
-  /**
-   * @brief Explicit version of computePlaneStrain for use in explicit time integration schemes.
-   * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
-   */
-  virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >& response,
-                                           const Deformation< 3 >&    deformation,
-                                           const TimeIncrement&       timeIncrement ) const
-  {
-    AlgorithmicModuli< 3 > algorithmicModuli;
-    computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement );
-  }
-
-  /**
-   * @brief Compute stress under plane strain conditions with eigen deformation.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] algorithmicModuli AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
-   *
-   * It uses the general 3D computeStress function for a plane strain Deformation.
-   * The algorithmic tangent is modified according to plane strain conditions.
-   */
-  virtual void computePlaneStrain( ConstitutiveResponse< 3 >&                  response,
-                                   AlgorithmicModuli< 3 >&                     algorithmicModuli,
-                                   const Deformation< 3 >&                     deformation,
-                                   const TimeIncrement&                        timeIncrement,
-                                   const std::tuple< double, double, double >& eigenDeformation ) const;
-
-  /**
-   * @brief Explicit version of computePlaneStrain with eigen deformation for use in explicit time integration schemes.
-   * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
-   */
-  virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >&                  response,
-                                           const Deformation< 3 >&                     deformation,
-                                           const TimeIncrement&                        timeIncrement,
-                                           const std::tuple< double, double, double >& eigenDeformation ) const
-  {
-    AlgorithmicModuli< 3 > algorithmicModuli;
-    computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
-  }
-
-  /**
-   * @brief Compute stress under plane stress conditions.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] algorithmicModuli AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * It uses the general 3D computeStress function and iteratively finds the out-of-plane deformation.
-   * The algorithmic tangent is modified according to plane stress conditions.
-   */
-  virtual void computePlaneStress( ConstitutiveResponse< 2 >& response,
-                                   AlgorithmicModuli< 2 >&    algorithmicModuli,
-                                   const Deformation< 2 >&    deformation,
-                                   const TimeIncrement&       timeIncrement ) const;
-
-  /**
-   * @brief Explicit version of computePlaneStress for use in explicit time integration schemes.
-   * @note The default implementation calls computePlaneStress and ignores the algorithmic tangent.
-   */
-  virtual void computePlaneStressExplicit( ConstitutiveResponse< 2 >& response,
-                                           const Deformation< 2 >&    deformation,
-                                           const TimeIncrement&       timeIncrement ) const
-  {
-    AlgorithmicModuli< 2 > algorithmicModuli;
-    computePlaneStress( response, algorithmicModuli, deformation, timeIncrement );
-  }
-
-  /**
-   * @brief Find the eigen deformation that corresponds to a given eigen stress.
-   * @param initialGuess Initial guess for the eigen deformation.
-   * @param eigenStress Target eigen stress.
-   * @param stateVars Pointer to the state variable array used during iteration.
-   * @return Eigen deformation that corresponds to the given eigen stress.
-   *
-   * This function iteratively finds the eigen deformation that corresponds to a given eigen stress.
-   * This is used e.g. for geostatic stress initialization.
-   */
-  std::tuple< double, double, double > findEigenDeformationForEigenStress(
-    const std::tuple< double, double, double >& initialGuess,
-    const std::tuple< double, double, double >& eigenStress,
-    double*                                     stateVars ) const;
-
-  /**
-   * @brief Get a view to the state variables.
-   * @param stateName Name of the state variable
-   * @param stateVars Pointer to the state variable array
-   * @return StatView to access the state variable
-   */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
-  {
-    return stateLayout.getStateView( stateVars, stateName );
-  }
-
-  /**
-   * @brief Get the total number of required state variables.
-   * @return Total number of required state variables
-   */
-  int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
-  /**
-   * @brief Initialize the state variables at a material point.
-   * @param stateVars Pointer to the state variable array
-   * @param nStateVars Number of state variables
-   *
-   * @note The default implementation initializes all state variables to zero.
-   */
-  virtual void initializeYourself( double* stateVars, int nStateVars )
-  {
-    for ( int i = 0; i < nStateVars; ++i ) {
-      stateVars[i] = 0.0;
+    /**
+     * @brief Explicit version of computePlaneStrain for use in explicit time integration schemes.
+     * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
+     */
+    virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >& response,
+                                             const Deformation< 3 >&    deformation,
+                                             const TimeIncrement&       timeIncrement ) const
+    {
+      AlgorithmicModuli< 3 > algorithmicModuli;
+      computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement );
     }
-  }
 
-  /**
-   * @brief Get the maximum wave speed of the material for a given deformation gradient.
-   * @param[in] stateVars Pointer to the state variable array
-   * @param[in] deformationGradient Current deformation gradient used as perturbation reference
-   * @return Maximum wave speed
-   * @details The default implementation computes diagonal Voigt tangent entries by centered
-   * finite differences and returns `sqrt(max(C_ii) / rho)`.
-   */
-  virtual double getMaximumWaveSpeed( const double*                         stateVars,
-                                      const Fastor::Tensor< double, 3, 3 >& deformationGradient ) const
-  {
-    constexpr double dEps = 1e-6;
+    /**
+     * @brief Compute stress under plane strain conditions with eigen deformation.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] algorithmicModuli AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
+     *
+     * It uses the general 3D computeStress function for a plane strain Deformation.
+     * The algorithmic tangent is modified according to plane strain conditions.
+     */
+    virtual void computePlaneStrain( ConstitutiveResponse< 3 >&                  response,
+                                     AlgorithmicModuli< 3 >&                     algorithmicModuli,
+                                     const Deformation< 3 >&                     deformation,
+                                     const TimeIncrement&                        timeIncrement,
+                                     const std::tuple< double, double, double >& eigenDeformation ) const;
 
-    const int nStateVars = getNumberOfRequiredStateVars();
+    /**
+     * @brief Explicit version of computePlaneStrain with eigen deformation for use in explicit time integration
+     * schemes.
+     * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
+     */
+    virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >&                  response,
+                                             const Deformation< 3 >&                     deformation,
+                                             const TimeIncrement&                        timeIncrement,
+                                             const std::tuple< double, double, double >& eigenDeformation ) const
+    {
+      AlgorithmicModuli< 3 > algorithmicModuli;
+      computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
+    }
 
-    double     maxStiffnessDiagonal = 0.0;
-    const auto timeIncrement        = TimeIncrement{ 0.0, 1.0 };
+    /**
+     * @brief Compute stress under plane stress conditions.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] algorithmicModuli AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * It uses the general 3D computeStress function and iteratively finds the out-of-plane deformation.
+     * The algorithmic tangent is modified according to plane stress conditions.
+     */
+    virtual void computePlaneStress( ConstitutiveResponse< 2 >& response,
+                                     AlgorithmicModuli< 2 >&    algorithmicModuli,
+                                     const Deformation< 2 >&    deformation,
+                                     const TimeIncrement&       timeIncrement ) const;
 
-    for ( int i = 0; i < 3; ++i ) {
-      std::vector< double > stateVarsPlus( nStateVars, 0.0 );
-      std::vector< double > stateVarsMinus( nStateVars, 0.0 );
-      if ( stateVars != nullptr && nStateVars > 0 ) {
-        std::copy_n( stateVars, nStateVars, stateVarsPlus.begin() );
-        std::copy_n( stateVars, nStateVars, stateVarsMinus.begin() );
+    /**
+     * @brief Explicit version of computePlaneStress for use in explicit time integration schemes.
+     * @note The default implementation calls computePlaneStress and ignores the algorithmic tangent.
+     */
+    virtual void computePlaneStressExplicit( ConstitutiveResponse< 2 >& response,
+                                             const Deformation< 2 >&    deformation,
+                                             const TimeIncrement&       timeIncrement ) const
+    {
+      AlgorithmicModuli< 2 > algorithmicModuli;
+      computePlaneStress( response, algorithmicModuli, deformation, timeIncrement );
+    }
+
+    /**
+     * @brief Find the eigen deformation that corresponds to a given eigen stress.
+     * @param initialGuess Initial guess for the eigen deformation.
+     * @param eigenStress Target eigen stress.
+     * @param stateVars Pointer to the state variable array used during iteration.
+     * @return Eigen deformation that corresponds to the given eigen stress.
+     *
+     * This function iteratively finds the eigen deformation that corresponds to a given eigen stress.
+     * This is used e.g. for geostatic stress initialization.
+     */
+    std::tuple< double, double, double > findEigenDeformationForEigenStress(
+      const std::tuple< double, double, double >& initialGuess,
+      const std::tuple< double, double, double >& eigenStress,
+      double*                                     stateVars ) const;
+
+    /**
+     * @brief Get a view to the state variables.
+     * @param stateName Name of the state variable
+     * @param stateVars Pointer to the state variable array
+     * @return StatView to access the state variable
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const
+    {
+      return stateLayout.getStateView( stateVars, stateName );
+    }
+
+    /**
+     * @brief Get the total number of required state variables.
+     * @return Total number of required state variables
+     */
+    int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
+    /**
+     * @brief Initialize the state variables at a material point.
+     * @param stateVars Pointer to the state variable array
+     * @param nStateVars Number of state variables
+     *
+     * @note The default implementation initializes all state variables to zero.
+     */
+    virtual void initializeYourself( double* stateVars, int nStateVars )
+    {
+      for ( int i = 0; i < nStateVars; ++i ) {
+        stateVars[i] = 0.0;
+      }
+    }
+
+    /**
+     * @brief Get the maximum wave speed of the material for a given deformation gradient.
+     * @param[in] stateVars Pointer to the state variable array
+     * @param[in] deformationGradient Current deformation gradient used as perturbation reference
+     * @return Maximum wave speed
+     * @details The default implementation computes diagonal Voigt tangent entries by centered
+     * finite differences and returns `sqrt(max(C_ii) / rho)`.
+     */
+    virtual double getMaximumWaveSpeed( const double*                         stateVars,
+                                        const Fastor::Tensor< double, 3, 3 >& deformationGradient ) const
+    {
+      constexpr double dEps = 1e-6;
+
+      const int nStateVars = getNumberOfRequiredStateVars();
+
+      double     maxStiffnessDiagonal = 0.0;
+      const auto timeIncrement        = TimeIncrement{ 0.0, 1.0 };
+
+      for ( int i = 0; i < 3; ++i ) {
+        std::vector< double > stateVarsPlus( nStateVars, 0.0 );
+        std::vector< double > stateVarsMinus( nStateVars, 0.0 );
+        if ( stateVars != nullptr && nStateVars > 0 ) {
+          std::copy_n( stateVars, nStateVars, stateVarsPlus.begin() );
+          std::copy_n( stateVars, nStateVars, stateVarsMinus.begin() );
+        }
+
+        auto FPlus  = deformationGradient;
+        auto FMinus = deformationGradient;
+        FPlus( i, i ) *= ( 1.0 + dEps );
+        FMinus( i, i ) *= ( 1.0 - dEps );
+
+        Deformation< 3 > deformationPlus{ FPlus };
+        Deformation< 3 > deformationMinus{ FMinus };
+
+        ConstitutiveResponse< 3 > responsePlus{ Fastor::Tensor< double, 3, 3 >( 0.0 ), 0.0, 0.0, stateVarsPlus.data() };
+        ConstitutiveResponse< 3 > responseMinus{ Fastor::Tensor< double, 3, 3 >( 0.0 ),
+                                                 0.0,
+                                                 0.0,
+                                                 stateVarsMinus.data() };
+
+        computeStressExplicit( responsePlus, deformationPlus, timeIncrement );
+        computeStressExplicit( responseMinus, deformationMinus, timeIncrement );
+
+        const double dLogStrain = std::log( 1.0 + dEps ) - std::log( 1.0 - dEps );
+        const double Cii        = ( responsePlus.tau( i, i ) - responseMinus.tau( i, i ) ) / dLogStrain;
+        maxStiffnessDiagonal    = std::max( maxStiffnessDiagonal, Cii );
       }
 
-      auto FPlus  = deformationGradient;
-      auto FMinus = deformationGradient;
-      FPlus( i, i ) *= ( 1.0 + dEps );
-      FMinus( i, i ) *= ( 1.0 - dEps );
-
-      Deformation< 3 > deformationPlus{ FPlus };
-      Deformation< 3 > deformationMinus{ FMinus };
-
-      ConstitutiveResponse< 3 > responsePlus{ Fastor::Tensor< double, 3, 3 >( 0.0 ), 0.0, 0.0, stateVarsPlus.data() };
-      ConstitutiveResponse< 3 > responseMinus{ Fastor::Tensor< double, 3, 3 >( 0.0 ), 0.0, 0.0, stateVarsMinus.data() };
-
-      computeStressExplicit( responsePlus, deformationPlus, timeIncrement );
-      computeStressExplicit( responseMinus, deformationMinus, timeIncrement );
-
-      const double dLogStrain = std::log( 1.0 + dEps ) - std::log( 1.0 - dEps );
-      const double Cii        = ( responsePlus.tau( i, i ) - responseMinus.tau( i, i ) ) / dLogStrain;
-      maxStiffnessDiagonal    = std::max( maxStiffnessDiagonal, Cii );
+      const double density = getDensity( stateVars );
+      return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
     }
 
-    const double density = getDensity( stateVars );
-    return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
-  }
+    /**
+     * @brief Get the mass density of the material.
+     * @param[in] stateVars Pointer to the state variable array
+     * @return Mass density
+     */
+    virtual double getDensity( const double* stateVars ) const = 0;
+  };
 
-  /**
-   * @brief Get the mass density of the material.
-   * @param[in] stateVars Pointer to the state variable array
-   * @return Mass density
-   */
-  virtual double getDensity( const double* stateVars ) const = 0;
-};
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainAD.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainAD.h
@@ -29,164 +29,169 @@
 #include <Eigen/Core>
 #include <functional>
 
-/**
- * @brief Base class for finite strain materials using automatic differentiation.
- *
- * This class extends MarmotMaterialFiniteStrain by providing an interface for
- * computing stresses and algorithmic tangent moduli using automatic
- * differentiation. Derived material models implement computeStressAD() to
- * supply the AD-based constitutive response.
- */
-class MarmotMaterialFiniteStrainAD : public MarmotMaterialFiniteStrain {
+namespace Marmot {
 
-public:
   /**
-   * @brief Construct a MarmotMaterialFiniteStrainAD.
-   * @param[in] matProperties_       Pointer to the array of material property values.
-   * @param[in] nMaterialProperties_ Number of material property values.
-   * @param[in] materialNumber_      Unique identifier for this material instance.
-   */
-  MarmotMaterialFiniteStrainAD( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
-    : MarmotMaterialFiniteStrain( matProperties_, nMaterialProperties_, materialNumber_ )
-  {
-  }
-  /**
-   * @struct ConstitutiveResponseAD
-   * @brief Constitutive response of a material at given state.
-   * @tparam nDim Number of spatial dimensions (2 or 3).
+   * @brief Base class for finite strain materials using automatic differentiation.
    *
-   *  Contains stress, density and elastic energy density.
+   * This class extends MarmotMaterialFiniteStrain by providing an interface for
+   * computing stresses and algorithmic tangent moduli using automatic
+   * differentiation. Derived material models implement computeStressAD() to
+   * supply the AD-based constitutive response.
    */
-  template < int nDim >
-  struct ConstitutiveResponseAD {
-    Fastor::Tensor< autodiff::dual, nDim, nDim > tau;                  ///< Kirchhoff stress
-    double                                       elasticEnergyDensity; ///< elastic energy per unit volume
-    double                                       dissipation; ///< dissipation per unit volume (for inelastic materials)
-    double*                                      stateVars;   ///< pointer to state variables
+  class MarmotMaterialFiniteStrainAD : public MarmotMaterialFiniteStrain {
+
+  public:
+    /**
+     * @brief Construct a MarmotMaterialFiniteStrainAD.
+     * @param[in] matProperties_       Pointer to the array of material property values.
+     * @param[in] nMaterialProperties_ Number of material property values.
+     * @param[in] materialNumber_      Unique identifier for this material instance.
+     */
+    MarmotMaterialFiniteStrainAD( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : MarmotMaterialFiniteStrain( matProperties_, nMaterialProperties_, materialNumber_ )
+    {
+    }
+    /**
+     * @struct ConstitutiveResponseAD
+     * @brief Constitutive response of a material at given state.
+     * @tparam nDim Number of spatial dimensions (2 or 3).
+     *
+     *  Contains stress, density and elastic energy density.
+     */
+    template < int nDim >
+    struct ConstitutiveResponseAD {
+      Fastor::Tensor< autodiff::dual, nDim, nDim > tau;                  ///< Kirchhoff stress
+      double                                       elasticEnergyDensity; ///< elastic energy per unit volume
+      double  dissipation; ///< dissipation per unit volume (for inelastic materials)
+      double* stateVars;   ///< pointer to state variables
+
+      /**
+       * @brief Default constructor.
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      ConstitutiveResponseAD()
+        : tau( Fastor::Tensor< autodiff::dual, nDim, nDim >( 0.0 ) ),
+          elasticEnergyDensity( 0.0 ),
+          dissipation( 0.0 ),
+          stateVars( nullptr )
+      {
+      }
+
+      /**
+       * @brief Constructor for initializing the AD constitutive response.
+       * @param response ConstitutiveResponse instance to initialize from.
+       */
+      ConstitutiveResponseAD( const ConstitutiveResponse< nDim >& response )
+        : tau( Marmot::makeDual( response.tau ) ),
+          elasticEnergyDensity( response.elasticEnergyDensity ),
+          dissipation( response.dissipation ),
+          stateVars( response.stateVars )
+      {
+      }
+    };
 
     /**
-     * @brief Default constructor.
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+     * @struct DeformationAD
+     * @brief Represents the deformation state of a material.
+     *
+     * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
+     * material.
      */
-    ConstitutiveResponseAD()
-      : tau( Fastor::Tensor< autodiff::dual, nDim, nDim >( 0.0 ) ),
-        elasticEnergyDensity( 0.0 ),
-        dissipation( 0.0 ),
-        stateVars( nullptr )
+    template < int nDim >
+    struct DeformationAD {
+      Fastor::Tensor< autodiff::dual, nDim, nDim > F; ///< deformation gradient
+    };
+
+    /**
+     * @brief Compute Kirchhoff stress and algorithmic tangent using automatic differentiation.
+     *
+     * This method overrides MarmotMaterialFiniteStrain::computeStress() and provides a generic
+     * AD-based implementation for finite strain material models.
+     *
+     * The child class must implement computeStressAD(), which evaluates the constitutive response
+     * (Kirchhoff stress and any state updates) for a dual-valued deformation gradient. This base
+     * implementation then uses Marmot::AutomaticDifferentiation::dF_dT() to:
+     *  - compute the Kirchhoff stress \f$\boldsymbol{\tau}\f$ for the given deformation, and
+     *  - compute the consistent algorithmic tangent \f$\partial \boldsymbol{\tau} / \partial \boldsymbol{F}\f$.
+     *
+     * @note Automatic differentiation requires multiple seeded evaluations of computeStressAD().
+     *       Therefore, the state variables are reset to their "old" values before each seeded call.
+     *       Implementations of computeStressAD() must update state based only on primal values of
+     *       the dual inputs and must not branch or accumulate history based on derivative components.
+     *
+     * @param[out] response     Constitutive response container (stress, density, energy, state variables).
+     * @param[out] tangents     Algorithmic moduli container; filled with \f$\partial \tau / \partial F\f$.
+     * @param[in]  deformation  Deformation state (deformation gradient \f$\boldsymbol{F}\f$).
+     * @param[in]  timeIncrement Time increment information for rate-/history-dependent models.
+     */
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&    deformation,
+                        const TimeIncrement&       timeIncrement ) const override
     {
+      using namespace Marmot;
+      using namespace FastorStandardTensors;
+      using scalar = autodiff::dual;
+
+      Eigen::Map< Eigen::VectorXd > stateVars( response.stateVars, this->getNumberOfRequiredStateVars() );
+
+      // Remember old state to reset during potential multiple AD evaluations
+      const Eigen::VectorXd stateVarsOld = stateVars;
+      const Tensor33d       tauOld       = response.tau;
+
+      ConstitutiveResponseAD< 3 > responseAD( response );
+
+      std::function< Tensor33t< scalar >( const Tensor33t< scalar >& ) > computeTauAD =
+        [&]( const Tensor33t< scalar >& F_ ) {
+          // Reset stateVars to old state
+          stateVars = stateVarsOld;
+
+          // Construct AD state
+          DeformationAD< 3 > deformationAD;
+          deformationAD.F = F_;
+
+          responseAD.tau                  = Marmot::makeDual( tauOld ); // Initialize tau with old value for consistency
+          responseAD.elasticEnergyDensity = response.elasticEnergyDensity; // Initialize energy density
+          responseAD.dissipation          = response.dissipation;          // Initialize dissipation
+
+          // Compute stress utilizing the child class's AD implementation
+          this->computeStressAD( responseAD, deformationAD, timeIncrement );
+
+          // Extract and return the dual stress tensor for differentiation
+          Tensor33t< scalar > res = responseAD.tau;
+
+          return res;
+        };
+
+      // Compute Kirchhoff stress (tau) and algorithmic tangent (dTau_dF) with autodiff
+      std::tie( response.tau, tangents.dTau_dF ) = Marmot::AutomaticDifferentiation::dF_dT( computeTauAD,
+                                                                                            deformation.F );
+      response.elasticEnergyDensity              = responseAD.elasticEnergyDensity;
+      response.dissipation                       = responseAD.dissipation;
     }
 
     /**
-     * @brief Constructor for initializing the AD constitutive response.
-     * @param response ConstitutiveResponse instance to initialize from.
+     * @brief Compute the constitutive response in automatic differentiation (AD) form.
+     *
+     * This pure virtual function must be implemented by derived material models to compute
+     * the Kirchhoff stress tensor in \p response.tau for a given deformation in dual number
+     * form. The base class uses this AD formulation together with
+     * Marmot::AutomaticDifferentiation utilities to obtain algorithmic tangents by
+     * differentiating the stress with respect to the deformation gradient.
+     *
+     * Implementations may update the provided state variables via \p response.stateVars
+     * according to the given time increment.
+     *
+     * @param[out] response    Constitutive response in AD form (3D), with \p response.tau
+     *                         to be filled with the computed Kirchhoff stress.
+     * @param[in]  deformation Deformation state in AD form (3D), providing the deformation
+     *                         gradient \f$\boldsymbol{F}\f$ as dual numbers.
+     * @param[in]  timeIncrement Current time increment information for the constitutive update.
      */
-    ConstitutiveResponseAD( const ConstitutiveResponse< nDim >& response )
-      : tau( Marmot::makeDual( response.tau ) ),
-        elasticEnergyDensity( response.elasticEnergyDensity ),
-        dissipation( response.dissipation ),
-        stateVars( response.stateVars )
-    {
-    }
+    virtual void computeStressAD( ConstitutiveResponseAD< 3 >& response,
+                                  const DeformationAD< 3 >&    deformation,
+                                  const TimeIncrement&         timeIncrement ) const = 0;
   };
 
-  /**
-   * @struct DeformationAD
-   * @brief Represents the deformation state of a material.
-   *
-   * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
-   * material.
-   */
-  template < int nDim >
-  struct DeformationAD {
-    Fastor::Tensor< autodiff::dual, nDim, nDim > F; ///< deformation gradient
-  };
-
-  /**
-   * @brief Compute Kirchhoff stress and algorithmic tangent using automatic differentiation.
-   *
-   * This method overrides MarmotMaterialFiniteStrain::computeStress() and provides a generic
-   * AD-based implementation for finite strain material models.
-   *
-   * The child class must implement computeStressAD(), which evaluates the constitutive response
-   * (Kirchhoff stress and any state updates) for a dual-valued deformation gradient. This base
-   * implementation then uses Marmot::AutomaticDifferentiation::dF_dT() to:
-   *  - compute the Kirchhoff stress \f$\boldsymbol{\tau}\f$ for the given deformation, and
-   *  - compute the consistent algorithmic tangent \f$\partial \boldsymbol{\tau} / \partial \boldsymbol{F}\f$.
-   *
-   * @note Automatic differentiation requires multiple seeded evaluations of computeStressAD().
-   *       Therefore, the state variables are reset to their "old" values before each seeded call.
-   *       Implementations of computeStressAD() must update state based only on primal values of
-   *       the dual inputs and must not branch or accumulate history based on derivative components.
-   *
-   * @param[out] response     Constitutive response container (stress, density, energy, state variables).
-   * @param[out] tangents     Algorithmic moduli container; filled with \f$\partial \tau / \partial F\f$.
-   * @param[in]  deformation  Deformation state (deformation gradient \f$\boldsymbol{F}\f$).
-   * @param[in]  timeIncrement Time increment information for rate-/history-dependent models.
-   */
-  void computeStress( ConstitutiveResponse< 3 >& response,
-                      AlgorithmicModuli< 3 >&    tangents,
-                      const Deformation< 3 >&    deformation,
-                      const TimeIncrement&       timeIncrement ) const override
-  {
-    using namespace Marmot;
-    using namespace FastorStandardTensors;
-    using scalar = autodiff::dual;
-
-    Eigen::Map< Eigen::VectorXd > stateVars( response.stateVars, this->getNumberOfRequiredStateVars() );
-
-    // Remember old state to reset during potential multiple AD evaluations
-    const Eigen::VectorXd stateVarsOld = stateVars;
-    const Tensor33d       tauOld       = response.tau;
-
-    ConstitutiveResponseAD< 3 > responseAD( response );
-
-    std::function< Tensor33t< scalar >( const Tensor33t< scalar >& ) > computeTauAD =
-      [&]( const Tensor33t< scalar >& F_ ) {
-        // Reset stateVars to old state
-        stateVars = stateVarsOld;
-
-        // Construct AD state
-        DeformationAD< 3 > deformationAD;
-        deformationAD.F = F_;
-
-        responseAD.tau                  = Marmot::makeDual( tauOld ); // Initialize tau with old value for consistency
-        responseAD.elasticEnergyDensity = response.elasticEnergyDensity; // Initialize energy density
-        responseAD.dissipation          = response.dissipation;          // Initialize dissipation
-
-        // Compute stress utilizing the child class's AD implementation
-        this->computeStressAD( responseAD, deformationAD, timeIncrement );
-
-        // Extract and return the dual stress tensor for differentiation
-        Tensor33t< scalar > res = responseAD.tau;
-
-        return res;
-      };
-
-    // Compute Kirchhoff stress (tau) and algorithmic tangent (dTau_dF) with autodiff
-    std::tie( response.tau, tangents.dTau_dF ) = Marmot::AutomaticDifferentiation::dF_dT( computeTauAD, deformation.F );
-    response.elasticEnergyDensity              = responseAD.elasticEnergyDensity;
-    response.dissipation                       = responseAD.dissipation;
-  }
-
-  /**
-   * @brief Compute the constitutive response in automatic differentiation (AD) form.
-   *
-   * This pure virtual function must be implemented by derived material models to compute
-   * the Kirchhoff stress tensor in \p response.tau for a given deformation in dual number
-   * form. The base class uses this AD formulation together with
-   * Marmot::AutomaticDifferentiation utilities to obtain algorithmic tangents by
-   * differentiating the stress with respect to the deformation gradient.
-   *
-   * Implementations may update the provided state variables via \p response.stateVars
-   * according to the given time increment.
-   *
-   * @param[out] response    Constitutive response in AD form (3D), with \p response.tau
-   *                         to be filled with the computed Kirchhoff stress.
-   * @param[in]  deformation Deformation state in AD form (3D), providing the deformation
-   *                         gradient \f$\boldsymbol{F}\f$ as dual numbers.
-   * @param[in]  timeIncrement Current time increment information for the constitutive update.
-   */
-  virtual void computeStressAD( ConstitutiveResponseAD< 3 >& response,
-                                const DeformationAD< 3 >&    deformation,
-                                const TimeIncrement&         timeIncrement ) const = 0;
-};
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
@@ -43,7 +43,9 @@ namespace MarmotLibrary {
   public:
     /// Factory function type: creates a MarmotMaterialFiniteStrain from properties and a material number.
     using materialFactoryFunction = std::function<
-      MarmotMaterialFiniteStrain*( const double* materialProperties, int nMaterialProperties, int materialNumber ) >;
+      Marmot::MarmotMaterialFiniteStrain*( const double* materialProperties,
+                                           int           nMaterialProperties,
+                                           int           materialNumber ) >;
 
     MarmotMaterialFiniteStrainFactory() = delete;
 
@@ -55,10 +57,10 @@ namespace MarmotLibrary {
      * @param[in] materialNumber Unique identifier for the material instance.
      * @return Pointer to the created MarmotMaterialFiniteStrain instance.
      */
-    static MarmotMaterialFiniteStrain* createMaterial( const std::string& materialName,
-                                                       const double*      materialProperties,
-                                                       int                nMaterialProperties,
-                                                       int                materialNumber );
+    static Marmot::MarmotMaterialFiniteStrain* createMaterial( const std::string& materialName,
+                                                               const double*      materialProperties,
+                                                               int                nMaterialProperties,
+                                                               int                materialNumber );
 
     /**
      * @brief Register a material type with its name.
@@ -74,8 +76,11 @@ namespace MarmotLibrary {
 
       assert( map.find( materialName ) == map.end() && "Material already registered!" );
 
-      map[materialName] = []( const double* materialProperties, int nMaterialProperties, int materialNumber )
-        -> MarmotMaterialFiniteStrain* { return new T( materialProperties, nMaterialProperties, materialNumber ); };
+      map[materialName] = []( const double* materialProperties,
+                              int           nMaterialProperties,
+                              int           materialNumber ) -> Marmot::MarmotMaterialFiniteStrain* {
+        return new T( materialProperties, nMaterialProperties, materialNumber );
+      };
       return true;
     }
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @class MarmotMaterialFiniteStrainFactory
@@ -88,4 +88,4 @@ namespace MarmotLibrary {
     using MaterialFactoryMap = std::unordered_map< std::string, materialFactoryFunction >;
     static MaterialFactoryMap& materialFactoryFunctionByName();
   };
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrain.cpp
@@ -2,141 +2,148 @@
 #include "Marmot/MarmotJournal.h"
 #include "Marmot/MarmotTypedefs.h"
 
-void applyEigenDeformation_( Fastor::Tensor< double, 3, 3 >& F, double F0_XX, double F0_YY, double F0_ZZ )
-{
-  F( 0, 0 ) *= F0_XX;
-  F( 1, 1 ) *= F0_YY;
-  F( 2, 2 ) *= F0_ZZ;
-}
+namespace Marmot {
 
-void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3 >& dT0_dF, double F0_XX, double F0_YY, double F0_ZZ )
-{
-  dT0_dF( 0, 0 ) *= F0_XX;
-  dT0_dF( 1, 1 ) *= F0_YY;
-  dT0_dF( 2, 2 ) *= F0_ZZ;
-}
+  void applyEigenDeformation_( Fastor::Tensor< double, 3, 3 >& F, double F0_XX, double F0_YY, double F0_ZZ )
+  {
+    F( 0, 0 ) *= F0_XX;
+    F( 1, 1 ) *= F0_YY;
+    F( 2, 2 ) *= F0_ZZ;
+  }
 
-void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3, 3, 3 >& dT2_dF,
-                                      double                                F0_XX,
-                                      double                                F0_YY,
-                                      double                                F0_ZZ )
-{
-  for ( int i = 0; i < 3; i++ ) {
-    for ( int j = 0; j < 3; j++ ) {
-      dT2_dF( i, j, 0, 0 ) *= F0_XX;
-      dT2_dF( i, j, 1, 1 ) *= F0_YY;
-      dT2_dF( i, j, 2, 2 ) *= F0_ZZ;
+  void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3 >& dT0_dF,
+                                        double                          F0_XX,
+                                        double                          F0_YY,
+                                        double                          F0_ZZ )
+  {
+    dT0_dF( 0, 0 ) *= F0_XX;
+    dT0_dF( 1, 1 ) *= F0_YY;
+    dT0_dF( 2, 2 ) *= F0_ZZ;
+  }
+
+  void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3, 3, 3 >& dT2_dF,
+                                        double                                F0_XX,
+                                        double                                F0_YY,
+                                        double                                F0_ZZ )
+  {
+    for ( int i = 0; i < 3; i++ ) {
+      for ( int j = 0; j < 3; j++ ) {
+        dT2_dF( i, j, 0, 0 ) *= F0_XX;
+        dT2_dF( i, j, 1, 1 ) *= F0_YY;
+        dT2_dF( i, j, 2, 2 ) *= F0_ZZ;
+      }
     }
   }
-}
-void MarmotMaterialFiniteStrain::computeStress( ConstitutiveResponse< 3 >&                  response,
-                                                AlgorithmicModuli< 3 >&                     tangents,
-                                                const Deformation< 3 >&                     deformation,
-                                                const TimeIncrement&                        timeIncrement,
-                                                const std::tuple< double, double, double >& eigenDeformation ) const
-{
-  // TODO: Think about if we simply modify the input increment.
+  void MarmotMaterialFiniteStrain::computeStress( ConstitutiveResponse< 3 >&                  response,
+                                                  AlgorithmicModuli< 3 >&                     tangents,
+                                                  const Deformation< 3 >&                     deformation,
+                                                  const TimeIncrement&                        timeIncrement,
+                                                  const std::tuple< double, double, double >& eigenDeformation ) const
+  {
+    // TODO: Think about if we simply modify the input increment.
 
-  const auto& [F0_XX, F0_YY, F0_ZZ]    = eigenDeformation;
-  auto deformationWithEigenDeformation = deformation;
-  applyEigenDeformation_( deformationWithEigenDeformation.F, F0_XX, F0_YY, F0_ZZ );
+    const auto& [F0_XX, F0_YY, F0_ZZ]    = eigenDeformation;
+    auto deformationWithEigenDeformation = deformation;
+    applyEigenDeformation_( deformationWithEigenDeformation.F, F0_XX, F0_YY, F0_ZZ );
 
-  computeStress( response, tangents, deformationWithEigenDeformation, timeIncrement );
+    computeStress( response, tangents, deformationWithEigenDeformation, timeIncrement );
 
-  applyEigenDeformationToTangent_( tangents.dTau_dF, F0_XX, F0_YY, F0_ZZ );
+    applyEigenDeformationToTangent_( tangents.dTau_dF, F0_XX, F0_YY, F0_ZZ );
 
-  return;
-}
-
-void MarmotMaterialFiniteStrain::computePlaneStrain( ConstitutiveResponse< 3 >& response,
-                                                     AlgorithmicModuli< 3 >&    algorithmicModuli,
-                                                     const Deformation< 3 >&    deformation,
-                                                     const TimeIncrement&       timeIncrement ) const
-{
-  return computeStress( response, algorithmicModuli, deformation, timeIncrement );
-}
-
-void MarmotMaterialFiniteStrain::computePlaneStrain(
-  ConstitutiveResponse< 3 >&                  response,
-  AlgorithmicModuli< 3 >&                     algorithmicModuli,
-  const Deformation< 3 >&                     deformation,
-  const TimeIncrement&                        timeIncrement,
-  const std::tuple< double, double, double >& eigenDeformation ) const
-{
-  return computeStress( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
-}
-
-void MarmotMaterialFiniteStrain::computePlaneStress( ConstitutiveResponse< 2 >& response,
-                                                     AlgorithmicModuli< 2 >&    algorithmicModuli,
-                                                     const Deformation< 2 >&    deformation,
-                                                     const TimeIncrement&       timeIncrement ) const
-{
-  throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented." );
-}
-
-/** The basic implementation here assumes non-chirial, isotropic elastic behavior.
- */
-std::tuple< double, double, double > MarmotMaterialFiniteStrain::findEigenDeformationForEigenStress(
-  const std::tuple< double, double, double >& initialGuess,
-  const std::tuple< double, double, double >& eigenStressComponents,
-  double*                                     stateVars ) const
-{
-  using namespace Marmot;
-
-  Deformation< 3 >          deformation = { 0.0 };
-  ConstitutiveResponse< 3 > response;
-  response.stateVars = stateVars;
-  AlgorithmicModuli< 3 > tangents;
-
-  const double        time[] = { 0.0, 0.0 };
-  const TimeIncrement timeIncrement{ time[0], 0.0 };
-
-  Eigen::Map< Eigen::VectorXd > theStateVars( stateVars, stateLayout.totalSize() );
-
-  auto evaluateStress = [&]( const Vector3d& F0 ) {
-    deformation.F( 0, 0 ) = F0( 0 );
-    deformation.F( 1, 1 ) = F0( 1 );
-    deformation.F( 2, 2 ) = F0( 2 );
-
-    computeStress( response, tangents, deformation, timeIncrement );
-
-    Vector3d tau = { response.tau( 0, 0 ), response.tau( 1, 1 ), response.tau( 2, 2 ) };
-    Matrix3d dTau_dF;
-    dTau_dF << tangents.dTau_dF( 0, 0, 0, 0 ), tangents.dTau_dF( 0, 0, 1, 1 ), tangents.dTau_dF( 0, 0, 2, 2 ),
-      tangents.dTau_dF( 1, 1, 0, 0 ), tangents.dTau_dF( 1, 1, 1, 1 ), tangents.dTau_dF( 1, 1, 2, 2 ),
-      tangents.dTau_dF( 2, 2, 0, 0 ), tangents.dTau_dF( 2, 2, 1, 1 ), tangents.dTau_dF( 2, 2, 2, 2 );
-
-    return std::tuple< Eigen::Vector3d, Eigen::Matrix3d >( tau, dTau_dF );
-  };
-
-  const auto& [F0_XX, F0_YY, F0_ZZ] = initialGuess;
-  const auto& [S_XX, S_YY, S_ZZ]    = eigenStressComponents;
-  Eigen::Vector3d def               = { F0_XX, F0_YY, F0_ZZ };
-  Eigen::Vector3d eigenNormalStress = { S_XX, S_YY, S_ZZ };
-  Eigen::Vector3d R, dF;
-
-  Eigen::VectorXd materialStateVarsBackup = theStateVars;
-
-  int itCounter = 0;
-  while ( true ) {
-    auto [normalStress, dNormalStress_dF] = evaluateStress( def );
-    theStateVars                          = materialStateVarsBackup;
-
-    R = normalStress - eigenNormalStress;
-
-    if ( R.norm() / std::min( normalStress.norm(), 1.0 ) <= 1e-10 )
-      break;
-
-    if ( itCounter > 5 )
-      throw std::invalid_argument( MakeString()
-                                   << __PRETTY_FUNCTION__ << ": failed to find eigen deformation within 5 iterations" );
-
-    itCounter++;
-
-    dF = -dNormalStress_dF.inverse() * R;
-
-    def += dF;
+    return;
   }
 
-  return { def( 0 ), def( 1 ), def( 2 ) };
-}
+  void MarmotMaterialFiniteStrain::computePlaneStrain( ConstitutiveResponse< 3 >& response,
+                                                       AlgorithmicModuli< 3 >&    algorithmicModuli,
+                                                       const Deformation< 3 >&    deformation,
+                                                       const TimeIncrement&       timeIncrement ) const
+  {
+    return computeStress( response, algorithmicModuli, deformation, timeIncrement );
+  }
+
+  void MarmotMaterialFiniteStrain::computePlaneStrain(
+    ConstitutiveResponse< 3 >&                  response,
+    AlgorithmicModuli< 3 >&                     algorithmicModuli,
+    const Deformation< 3 >&                     deformation,
+    const TimeIncrement&                        timeIncrement,
+    const std::tuple< double, double, double >& eigenDeformation ) const
+  {
+    return computeStress( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
+  }
+
+  void MarmotMaterialFiniteStrain::computePlaneStress( ConstitutiveResponse< 2 >& response,
+                                                       AlgorithmicModuli< 2 >&    algorithmicModuli,
+                                                       const Deformation< 2 >&    deformation,
+                                                       const TimeIncrement&       timeIncrement ) const
+  {
+    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented." );
+  }
+
+  /** The basic implementation here assumes non-chirial, isotropic elastic behavior.
+   */
+  std::tuple< double, double, double > MarmotMaterialFiniteStrain::findEigenDeformationForEigenStress(
+    const std::tuple< double, double, double >& initialGuess,
+    const std::tuple< double, double, double >& eigenStressComponents,
+    double*                                     stateVars ) const
+  {
+    using namespace Marmot;
+
+    Deformation< 3 >          deformation = { 0.0 };
+    ConstitutiveResponse< 3 > response;
+    response.stateVars = stateVars;
+    AlgorithmicModuli< 3 > tangents;
+
+    const double        time[] = { 0.0, 0.0 };
+    const TimeIncrement timeIncrement{ time[0], 0.0 };
+
+    Eigen::Map< Eigen::VectorXd > theStateVars( stateVars, stateLayout.totalSize() );
+
+    auto evaluateStress = [&]( const Vector3d& F0 ) {
+      deformation.F( 0, 0 ) = F0( 0 );
+      deformation.F( 1, 1 ) = F0( 1 );
+      deformation.F( 2, 2 ) = F0( 2 );
+
+      computeStress( response, tangents, deformation, timeIncrement );
+
+      Vector3d tau = { response.tau( 0, 0 ), response.tau( 1, 1 ), response.tau( 2, 2 ) };
+      Matrix3d dTau_dF;
+      dTau_dF << tangents.dTau_dF( 0, 0, 0, 0 ), tangents.dTau_dF( 0, 0, 1, 1 ), tangents.dTau_dF( 0, 0, 2, 2 ),
+        tangents.dTau_dF( 1, 1, 0, 0 ), tangents.dTau_dF( 1, 1, 1, 1 ), tangents.dTau_dF( 1, 1, 2, 2 ),
+        tangents.dTau_dF( 2, 2, 0, 0 ), tangents.dTau_dF( 2, 2, 1, 1 ), tangents.dTau_dF( 2, 2, 2, 2 );
+
+      return std::tuple< Eigen::Vector3d, Eigen::Matrix3d >( tau, dTau_dF );
+    };
+
+    const auto& [F0_XX, F0_YY, F0_ZZ] = initialGuess;
+    const auto& [S_XX, S_YY, S_ZZ]    = eigenStressComponents;
+    Eigen::Vector3d def               = { F0_XX, F0_YY, F0_ZZ };
+    Eigen::Vector3d eigenNormalStress = { S_XX, S_YY, S_ZZ };
+    Eigen::Vector3d R, dF;
+
+    Eigen::VectorXd materialStateVarsBackup = theStateVars;
+
+    int itCounter = 0;
+    while ( true ) {
+      auto [normalStress, dNormalStress_dF] = evaluateStress( def );
+      theStateVars                          = materialStateVarsBackup;
+
+      R = normalStress - eigenNormalStress;
+
+      if ( R.norm() / std::min( normalStress.norm(), 1.0 ) <= 1e-10 )
+        break;
+
+      if ( itCounter > 5 )
+        throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__
+                                                  << ": failed to find eigen deformation within 5 iterations" );
+
+      itCounter++;
+
+      dF = -dNormalStress_dF.inverse() * R;
+
+      def += dF;
+    }
+
+    return { def( 0 ), def( 1 ), def( 2 ) };
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
@@ -3,10 +3,10 @@
 
 using namespace MarmotLibrary;
 
-MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( const std::string& materialName,
-                                                                               const double*      materialProperties,
-                                                                               int                nMaterialProperties,
-                                                                               int                materialNumber )
+Marmot::MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( const std::string& materialName,
+                                                                                       const double* materialProperties,
+                                                                                       int nMaterialProperties,
+                                                                                       int materialNumber )
 {
   auto& map = materialFactoryFunctionByName();
   auto  it  = map.find( materialName );
@@ -15,7 +15,7 @@ MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( c
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
@@ -1,7 +1,7 @@
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 #include "Marmot/MarmotJournal.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 Marmot::MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( const std::string& materialName,
                                                                                        const double* materialProperties,

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialPointSolverFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialPointSolverFiniteStrain.cpp
@@ -20,7 +20,7 @@ namespace Marmot {
                                                                                   const SolverOptions& options )
       : options( options )
     {
-      using namespace MarmotLibrary;
+      using namespace Marmot::Registration;
 
       // create material instance
       material = std::unique_ptr< MarmotMaterialFiniteStrain >( dynamic_cast< MarmotMaterialFiniteStrain* >(

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotEnergyDensityFunctions.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotEnergyDensityFunctions.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotEnergyDensityFunctions.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainPlasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainPlasticity.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotFiniteStrainPlasticity.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainViscoelasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainViscoelasticity.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstring>
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 using namespace Marmot::ContinuumMechanics::FiniteStrain::Viscoelasticity;

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
@@ -32,316 +32,324 @@
 #include <cmath>
 #include <vector>
 
-/**
- * @brief Base class for general gradient-enhanced hypoelastic material models.
- * @details This class defines the interface for general gradient-enhanced hypoelastic material models,
- * including methods for computing stress, plane stress response, and managing state variables.
- * The template parameter `nNonlocalVariables` specifies the number of nonlocal variables used in the material model.
- *
- * In addition to the standard balance of linear momentum each nonlocal variable introduces an additional balance
- * equation, which is solved simultaneously with the balance of linear momentum. This balance equation is defined as:
- * \f[ \knl_i - \nabla ( c( \knl_i )\, \nabla \knl_i ) = s_i (\boldsymbol \varepsilon,\, \knl_i ) \f]
- * where \f$ \knl_i \f$ is the nonlocal variable, \f$ c( \knl_i ) \f$ is the nonlocal interaction parameter, and
- * \f$ s_i \f$ is the local driving variable for the nonlocal variable \f$ \knl_i \f$. The interaction
- * parameter
- * \f$ c( \knl_i ) \f$ defines the influence of the nonlocal variable on its own gradient and can be used to model
- * phenomena such as damage-dependent interactions. Also phase-field models can be implemented in this framework by
- * defining the nonlocal variable as the phase-field variable and the local driving variable as a function of the strain
- * tensor.
- */
-template < int nNonlocalVariables >
-class MarmotMaterialGeneralGradientEnhancedHypoElastic {
-
-protected:
-  /// @brief Pointer to the array of material properties.
-  const double* materialProperties;
-  /// @brief Number of material properties.
-  const int nMaterialProperties;
-
-public:
-  /// @brief Material number (identifier for the material).
-  const int materialNumber;
+namespace Marmot {
 
   /**
-   * @brief Constructor for the general gradient-enhanced hypoelastic material model.
-   * @param matProperties_ Pointer to the array of material properties.
-   * @param nMaterialProperties_ Number of material properties.
-   * @param materialNumber_ Material number (identifier for the material).
-   */
-  MarmotMaterialGeneralGradientEnhancedHypoElastic( const double* matProperties_,
-                                                    int           nMaterialProperties_,
-                                                    int           materialNumber_ )
-    : materialProperties( matProperties_ ),
-      nMaterialProperties( nMaterialProperties_ ),
-      materialNumber( materialNumber_ )
-  {
-  }
-
-  /**
-   * @brief Virtual destructor.
+   * @brief Base class for general gradient-enhanced hypoelastic material models.
+   * @details This class defines the interface for general gradient-enhanced hypoelastic material models,
+   * including methods for computing stress, plane stress response, and managing state variables.
+   * The template parameter `nNonlocalVariables` specifies the number of nonlocal variables used in the material model.
    *
-   * This class is abstract and instances are owned through base-class pointers
-   * (e.g. the std::unique_ptr held by the gradient-enhanced elements), so the
-   * destructor must be virtual — destroying a derived object through a base
-   * pointer with a non-virtual destructor is undefined behaviour. libstdc++
-   * silently invokes the wrong destructor, while libc++/clang diagnoses it
-   * (-Wdelete-abstract-non-virtual-dtor) and emits a trap instruction, which
-   * aborted every simulation using such a material on macOS/arm64.
+   * In addition to the standard balance of linear momentum each nonlocal variable introduces an additional balance
+   * equation, which is solved simultaneously with the balance of linear momentum. This balance equation is defined as:
+   * \f[ \knl_i - \nabla ( c( \knl_i )\, \nabla \knl_i ) = s_i (\boldsymbol \varepsilon,\, \knl_i ) \f]
+   * where \f$ \knl_i \f$ is the nonlocal variable, \f$ c( \knl_i ) \f$ is the nonlocal interaction parameter, and
+   * \f$ s_i \f$ is the local driving variable for the nonlocal variable \f$ \knl_i \f$. The interaction
+   * parameter
+   * \f$ c( \knl_i ) \f$ defines the influence of the nonlocal variable on its own gradient and can be used to model
+   * phenomena such as damage-dependent interactions. Also phase-field models can be implemented in this framework by
+   * defining the nonlocal variable as the phase-field variable and the local driving variable as a function of the
+   * strain tensor.
    */
-  virtual ~MarmotMaterialGeneralGradientEnhancedHypoElastic() = default;
+  template < int nNonlocalVariables >
+  class MarmotMaterialGeneralGradientEnhancedHypoElastic {
 
-  /// @brief Struct to hold the increment information.
-  struct increment {
-    Marmot::Vector6d                            dStrain; ///< Increment of the strain tensor in Voigt notation
-    Eigen::Vector< double, nNonlocalVariables > K;       ///< Nonlocal variables at the current increment
-    Eigen::Vector< double, nNonlocalVariables > dK;      ///< Increment of the nonlocal variables
-    double                                      time;    ///< Current time
-    double                                      dT;      ///< Time increment
-  };
+  protected:
+    /// @brief Pointer to the array of material properties.
+    const double* materialProperties;
+    /// @brief Number of material properties.
+    const int nMaterialProperties;
 
-  /// @brief Struct to hold the material response information.
-  struct response {
-    Marmot::Vector6d                            stress;    ///< Stress tensor in Voigt notation
-    Eigen::Vector< double, nNonlocalVariables > KLocal;    ///< Local driving variables at the current increment
-    Eigen::Vector< double, nNonlocalVariables > c;         ///< Nonlocal interaction parameters at the current increment
-    double*                                     stateVars; ///< Pointer to the array of state variables
-    double                                      elasticEnergyDensity; ///< Elastic strain energy density
-    double                                      dissipation;          ///< Dissipation (if applicable)
-  };
+  public:
+    /// @brief Material number (identifier for the material).
+    const int materialNumber;
 
-  /// @brief Struct to hold the algorithmic tangent matrices for the material model.
-  struct tangents {
-    /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of strain.
-    Marmot::Matrix6d dStressddStrain = Marmot::Matrix6d::Zero();
-    /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of nonlocal variables.
-    Eigen::Matrix< double, 6, nNonlocalVariables > dStressddK = Eigen::Matrix< double, 6, nNonlocalVariables >::Zero();
-    /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of strain.
-    Eigen::Matrix< double, nNonlocalVariables, 6 >
-      dKLocalddStrain = Eigen::Matrix< double, nNonlocalVariables, 6 >::Zero();
-    /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of nonlocal
-    /// variables.
-    Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
-      dKLocalddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
-    /// @brief First derivative of nonlocal interaction parameters with respect to nonlocal variables.
-    Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
-      dcddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
-    /// @brief Second derivative of nonlocal interaction parameters with respect to nonlocal variables.
-    Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
-      d2cddK2 = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
-  };
-
-  /**
-   * @brief Layout of the state variables for the material model.
-   * @note Must be defined in derived classes to specify the structure and organization of the state variables used in
-   * the material model.
-   */
-  MarmotStateLayoutDynamic stateLayout;
-
-  /**
-   * @brief Compute the stress response of the material model including the algorithmic tangents.
-   * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
-   * variables.
-   * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method must be implemented in derived classes to compute the stress response based on the specific material
-   * model.
-   */
-  virtual void computeStress( response& res, tangents& tan, const increment& inc ) const = 0;
-
-  /**
-   * @brief Compute the stress response of the material model.
-   * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
-   * variables.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method can be used when only the stress response is needed without the tangents, e.g., for explicit dynamics.
-   * The default implementation calls the `computeStress` method and ignores the tangents, which can be computationally
-   * expensive to compute.
-   */
-  virtual void computeStressExplicit( response& res, const increment& inc ) const
-  {
-    tangents tan;
-    computeStress( res, tan, inc );
-  }
-
-  /**
-   * @brief Compute the plane stress response of the material model.
-   * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other response
-   * variables.
-   * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices for
-   * plane stress.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method provides a default implementation for computing the plane stress response using an iterative approach.
-   * It assumes an initial guess of isochoric deformation and iteratively corrects the out-of-plane strain until
-   * convergence is achieved. Derived classes can override this method if a different approach for plane stress
-   * computation is desired.
-   */
-  virtual void computePlaneStress( response& res, tangents& tan, const increment& inc ) const
-  {
-    using namespace Marmot;
-    using namespace Eigen;
-
-    Map< VectorXd > stateVars( res.stateVars, stateLayout.totalSize() );
-
-    VectorXd  stateVarsOld = stateVars;
-    response  resTemp = { res.stress, res.KLocal, res.c, res.stateVars, res.elasticEnergyDensity, res.dissipation };
-    increment incTemp = { inc.dStrain, inc.K, inc.dK, inc.time, inc.dT };
-
-    double residual          = 1;
-    double tangentCompliance = 1.;
-    // assumption of isochoric deformation for initial guess
-    double strainIncrement = ( -incTemp.dStrain( 0 ) - incTemp.dStrain( 1 ) );
-    incTemp.dStrain( 2 )   = strainIncrement;
-
-    int planeStressCount = 1;
-    while ( true ) {
-
-      // set old response
-      resTemp = { .stress               = res.stress,
-                  .KLocal               = res.KLocal,
-                  .c                    = res.c,
-                  .stateVars            = res.stateVars,
-                  .elasticEnergyDensity = res.elasticEnergyDensity,
-                  .dissipation          = res.dissipation };
-      // set old state variables
-      stateVars = stateVarsOld;
-      // compute stress
-      computeStress( resTemp, tan, incTemp );
-
-      // evauate residual
-      residual = std::abs( resTemp.stress.array().abs()[2] / std::max( resTemp.stress.array().abs().maxCoeff(), 1. ) );
-      if ( ( residual < 1e-10 && std::abs( strainIncrement ) < 1e-8 ) || ( planeStressCount > 7 && residual < 1e-5 ) ) {
-        break;
-      }
-
-      // correct strain increment
-      tangentCompliance = 1. / tan.dStressddStrain( 2, 2 );
-      if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 ) {
-        tangentCompliance = 1e10;
-      }
-
-      strainIncrement = -resTemp.stress( 2 ) * tangentCompliance;
-      incTemp.dStrain( 2 ) += strainIncrement;
-
-      planeStressCount += 1;
-      if ( planeStressCount > 13 ) {
-        throw Marmot::StressUpdateFailed( "PlaneStressWrapper requires cutback" );
-      }
+    /**
+     * @brief Constructor for the general gradient-enhanced hypoelastic material model.
+     * @param matProperties_ Pointer to the array of material properties.
+     * @param nMaterialProperties_ Number of material properties.
+     * @param materialNumber_ Material number (identifier for the material).
+     */
+    MarmotMaterialGeneralGradientEnhancedHypoElastic( const double* matProperties_,
+                                                      int           nMaterialProperties_,
+                                                      int           materialNumber_ )
+      : materialProperties( matProperties_ ),
+        nMaterialProperties( nMaterialProperties_ ),
+        materialNumber( materialNumber_ )
+    {
     }
 
-    res = resTemp;
-  }
+    /**
+     * @brief Virtual destructor.
+     *
+     * This class is abstract and instances are owned through base-class pointers
+     * (e.g. the std::unique_ptr held by the gradient-enhanced elements), so the
+     * destructor must be virtual — destroying a derived object through a base
+     * pointer with a non-virtual destructor is undefined behaviour. libstdc++
+     * silently invokes the wrong destructor, while libc++/clang diagnoses it
+     * (-Wdelete-abstract-non-virtual-dtor) and emits a trap instruction, which
+     * aborted every simulation using such a material on macOS/arm64.
+     */
+    virtual ~MarmotMaterialGeneralGradientEnhancedHypoElastic() = default;
 
-  /**
-   * @brief Compute the plane stress response of the material model without computing tangents.
-   * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other response
-   * variables.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method can be used when only the plane stress response is needed without the tangents, e.g., for explicit
-   * dynamics. The default implementation calls the `computePlaneStress` method ignoring the tangents.
-   * This method maybe overridden in derived classes if a different approach for plane stress computation is desired.
-   */
-  virtual void computePlaneStressExplicit( response& res, const increment& inc ) const
-  {
-    tangents tan;
-    computePlaneStress( res, tan, inc );
-  }
+    /// @brief Struct to hold the increment information.
+    struct increment {
+      Marmot::Vector6d                            dStrain; ///< Increment of the strain tensor in Voigt notation
+      Eigen::Vector< double, nNonlocalVariables > K;       ///< Nonlocal variables at the current increment
+      Eigen::Vector< double, nNonlocalVariables > dK;      ///< Increment of the nonlocal variables
+      double                                      time;    ///< Current time
+      double                                      dT;      ///< Time increment
+    };
 
-  /**
-   * @brief Get a view to the state variables.
-   * @param stateName Name of the state variable
-   * @param stateVars Pointer to the state variable array
-   * @return StatView to access the state variable
-   */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
-  {
-    return stateLayout.getStateView( stateVars, stateName );
-  }
+    /// @brief Struct to hold the material response information.
+    struct response {
+      Marmot::Vector6d                            stress; ///< Stress tensor in Voigt notation
+      Eigen::Vector< double, nNonlocalVariables > KLocal; ///< Local driving variables at the current increment
+      Eigen::Vector< double, nNonlocalVariables > c;      ///< Nonlocal interaction parameters at the current increment
+      double*                                     stateVars;            ///< Pointer to the array of state variables
+      double                                      elasticEnergyDensity; ///< Elastic strain energy density
+      double                                      dissipation;          ///< Dissipation (if applicable)
+    };
 
-  /**
-   * @brief Get the total number of required state variables.
-   * @return Total number of required state variables
-   */
-  int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
+    /// @brief Struct to hold the algorithmic tangent matrices for the material model.
+    struct tangents {
+      /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of strain.
+      Marmot::Matrix6d dStressddStrain = Marmot::Matrix6d::Zero();
+      /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of nonlocal variables.
+      Eigen::Matrix< double, 6, nNonlocalVariables >
+        dStressddK = Eigen::Matrix< double, 6, nNonlocalVariables >::Zero();
+      /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of
+      /// strain.
+      Eigen::Matrix< double, nNonlocalVariables, 6 >
+        dKLocalddStrain = Eigen::Matrix< double, nNonlocalVariables, 6 >::Zero();
+      /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of
+      /// nonlocal variables.
+      Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
+        dKLocalddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
+      /// @brief First derivative of nonlocal interaction parameters with respect to nonlocal variables.
+      Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
+        dcddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
+      /// @brief Second derivative of nonlocal interaction parameters with respect to nonlocal variables.
+      Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
+        d2cddK2 = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
+    };
 
-  /**
-   * @brief Initialize the state variables at a material point.
-   * @param stateVars Pointer to the state variable array
-   * @param nStateVars Number of state variables
-   *
-   * @note The default implementation initializes all state variables to zero.
-   */
-  virtual void initializeYourself( double* stateVars, int nStateVars )
-  {
-    for ( int i = 0; i < nStateVars; ++i ) {
-      stateVars[i] = 0.0;
+    /**
+     * @brief Layout of the state variables for the material model.
+     * @note Must be defined in derived classes to specify the structure and organization of the state variables used in
+     * the material model.
+     */
+    MarmotStateLayoutDynamic stateLayout;
+
+    /**
+     * @brief Compute the stress response of the material model including the algorithmic tangents.
+     * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
+     * variables.
+     * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method must be implemented in derived classes to compute the stress response based on the specific material
+     * model.
+     */
+    virtual void computeStress( response& res, tangents& tan, const increment& inc ) const = 0;
+
+    /**
+     * @brief Compute the stress response of the material model.
+     * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
+     * variables.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method can be used when only the stress response is needed without the tangents, e.g., for explicit
+     * dynamics. The default implementation calls the `computeStress` method and ignores the tangents, which can be
+     * computationally expensive to compute.
+     */
+    virtual void computeStressExplicit( response& res, const increment& inc ) const
+    {
+      tangents tan;
+      computeStress( res, tan, inc );
     }
-  }
-  /**
-   * @brief Get the density of the material.
-   * @param stateVars Pointer to the array of state variables
-   * @return Density of the material
-   *
-   * This method must be implemented in derived classes to return the density of the material, which is required for
-   * dynamic analyses.
-   */
-  virtual double getDensity( const double* stateVars ) const = 0;
 
-  /**
-   * @brief Get the maximum wave speed for the current response state.
-   * @param currentResponse Current response state
-   * @return Maximum wave speed
-   * @details The default implementation computes the 3D algorithmic tangent and returns
-   *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
-   */
-  virtual double getMaximumWaveSpeed( const response& currentResponse ) const
-  {
-    const int nStateVars = getNumberOfRequiredStateVars();
+    /**
+     * @brief Compute the plane stress response of the material model.
+     * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other
+     * response variables.
+     * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices
+     * for plane stress.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method provides a default implementation for computing the plane stress response using an iterative
+     * approach. It assumes an initial guess of isochoric deformation and iteratively corrects the out-of-plane strain
+     * until convergence is achieved. Derived classes can override this method if a different approach for plane stress
+     * computation is desired.
+     */
+    virtual void computePlaneStress( response& res, tangents& tan, const increment& inc ) const
+    {
+      using namespace Marmot;
+      using namespace Eigen;
 
-    std::vector< double > stateVarsCopy( nStateVars, 0.0 );
-    if ( currentResponse.stateVars != nullptr && nStateVars > 0 ) {
-      std::copy_n( currentResponse.stateVars, nStateVars, stateVarsCopy.begin() );
+      Map< VectorXd > stateVars( res.stateVars, stateLayout.totalSize() );
+
+      VectorXd  stateVarsOld = stateVars;
+      response  resTemp = { res.stress, res.KLocal, res.c, res.stateVars, res.elasticEnergyDensity, res.dissipation };
+      increment incTemp = { inc.dStrain, inc.K, inc.dK, inc.time, inc.dT };
+
+      double residual          = 1;
+      double tangentCompliance = 1.;
+      // assumption of isochoric deformation for initial guess
+      double strainIncrement = ( -incTemp.dStrain( 0 ) - incTemp.dStrain( 1 ) );
+      incTemp.dStrain( 2 )   = strainIncrement;
+
+      int planeStressCount = 1;
+      while ( true ) {
+
+        // set old response
+        resTemp = { .stress               = res.stress,
+                    .KLocal               = res.KLocal,
+                    .c                    = res.c,
+                    .stateVars            = res.stateVars,
+                    .elasticEnergyDensity = res.elasticEnergyDensity,
+                    .dissipation          = res.dissipation };
+        // set old state variables
+        stateVars = stateVarsOld;
+        // compute stress
+        computeStress( resTemp, tan, incTemp );
+
+        // evauate residual
+        residual = std::abs( resTemp.stress.array().abs()[2] /
+                             std::max( resTemp.stress.array().abs().maxCoeff(), 1. ) );
+        if ( ( residual < 1e-10 && std::abs( strainIncrement ) < 1e-8 ) ||
+             ( planeStressCount > 7 && residual < 1e-5 ) ) {
+          break;
+        }
+
+        // correct strain increment
+        tangentCompliance = 1. / tan.dStressddStrain( 2, 2 );
+        if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 ) {
+          tangentCompliance = 1e10;
+        }
+
+        strainIncrement = -resTemp.stress( 2 ) * tangentCompliance;
+        incTemp.dStrain( 2 ) += strainIncrement;
+
+        planeStressCount += 1;
+        if ( planeStressCount > 13 ) {
+          throw Marmot::StressUpdateFailed( "PlaneStressWrapper requires cutback" );
+        }
+      }
+
+      res = resTemp;
     }
 
-    response responseCopy  = currentResponse;
-    responseCopy.stateVars = stateVarsCopy.data();
+    /**
+     * @brief Compute the plane stress response of the material model without computing tangents.
+     * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other
+     * response variables.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method can be used when only the plane stress response is needed without the tangents, e.g., for explicit
+     * dynamics. The default implementation calls the `computePlaneStress` method ignoring the tangents.
+     * This method maybe overridden in derived classes if a different approach for plane stress computation is desired.
+     */
+    virtual void computePlaneStressExplicit( response& res, const increment& inc ) const
+    {
+      tangents tan;
+      computePlaneStress( res, tan, inc );
+    }
 
-    tangents  tan;
-    increment inc;
-    inc.dStrain = Marmot::Vector6d::Zero();
-    inc.K       = Eigen::Vector< double, nNonlocalVariables >::Zero();
-    inc.dK      = Eigen::Vector< double, nNonlocalVariables >::Zero();
-    inc.time    = 0.0;
-    inc.dT      = 1.0;
+    /**
+     * @brief Get a view to the state variables.
+     * @param stateName Name of the state variable
+     * @param stateVars Pointer to the state variable array
+     * @return StatView to access the state variable
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const
+    {
+      return stateLayout.getStateView( stateVars, stateName );
+    }
 
-    computeStress( responseCopy, tan, inc );
+    /**
+     * @brief Get the total number of required state variables.
+     * @return Total number of required state variables
+     */
+    int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
 
-    const double maxStiffnessDiagonal = std::max( { tan.dStressddStrain( 0, 0 ),
-                                                    tan.dStressddStrain( 1, 1 ),
-                                                    tan.dStressddStrain( 2, 2 ),
-                                                    tan.dStressddStrain( 3, 3 ),
-                                                    tan.dStressddStrain( 4, 4 ),
-                                                    tan.dStressddStrain( 5, 5 ) } );
-    const double density              = getDensity( responseCopy.stateVars );
+    /**
+     * @brief Initialize the state variables at a material point.
+     * @param stateVars Pointer to the state variable array
+     * @param nStateVars Number of state variables
+     *
+     * @note The default implementation initializes all state variables to zero.
+     */
+    virtual void initializeYourself( double* stateVars, int nStateVars )
+    {
+      for ( int i = 0; i < nStateVars; ++i ) {
+        stateVars[i] = 0.0;
+      }
+    }
+    /**
+     * @brief Get the density of the material.
+     * @param stateVars Pointer to the array of state variables
+     * @return Density of the material
+     *
+     * This method must be implemented in derived classes to return the density of the material, which is required for
+     * dynamic analyses.
+     */
+    virtual double getDensity( const double* stateVars ) const = 0;
 
-    return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
-  }
+    /**
+     * @brief Get the maximum wave speed for the current response state.
+     * @param currentResponse Current response state
+     * @return Maximum wave speed
+     * @details The default implementation computes the 3D algorithmic tangent and returns
+     *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
+     */
+    virtual double getMaximumWaveSpeed( const response& currentResponse ) const
+    {
+      const int nStateVars = getNumberOfRequiredStateVars();
 
-  /**
-   * @brief Get the nonlocal viscosity of the material.
-   * @param stateVars Pointer to the array of state variables
-   * @return Vector containing the nonlocal viscosity values for each nonlocal variable
-   *
-   * This method must be implemented in derived classes to return the nonlocal viscosity values, which are required for
-   * dynamic analyses involving nonlocal variables. The returned vector should have a length equal to
-   * `nNonlocalVariables`.
-   */
-  virtual std::vector< double > getNonlocalViscosity( const double* stateVars ) const = 0;
-};
+      std::vector< double > stateVarsCopy( nStateVars, 0.0 );
+      if ( currentResponse.stateVars != nullptr && nStateVars > 0 ) {
+        std::copy_n( currentResponse.stateVars, nStateVars, stateVarsCopy.begin() );
+      }
+
+      response responseCopy  = currentResponse;
+      responseCopy.stateVars = stateVarsCopy.data();
+
+      tangents  tan;
+      increment inc;
+      inc.dStrain = Marmot::Vector6d::Zero();
+      inc.K       = Eigen::Vector< double, nNonlocalVariables >::Zero();
+      inc.dK      = Eigen::Vector< double, nNonlocalVariables >::Zero();
+      inc.time    = 0.0;
+      inc.dT      = 1.0;
+
+      computeStress( responseCopy, tan, inc );
+
+      const double maxStiffnessDiagonal = std::max( { tan.dStressddStrain( 0, 0 ),
+                                                      tan.dStressddStrain( 1, 1 ),
+                                                      tan.dStressddStrain( 2, 2 ),
+                                                      tan.dStressddStrain( 3, 3 ),
+                                                      tan.dStressddStrain( 4, 4 ),
+                                                      tan.dStressddStrain( 5, 5 ) } );
+      const double density              = getDensity( responseCopy.stateVars );
+
+      return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
+    }
+
+    /**
+     * @brief Get the nonlocal viscosity of the material.
+     * @param stateVars Pointer to the array of state variables
+     * @return Vector containing the nonlocal viscosity values for each nonlocal variable
+     *
+     * This method must be implemented in derived classes to return the nonlocal viscosity values, which are required
+     * for dynamic analyses involving nonlocal variables. The returned vector should have a length equal to
+     * `nNonlocalVariables`.
+     */
+    virtual std::vector< double > getNonlocalViscosity( const double* stateVars ) const = 0;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
@@ -41,7 +41,7 @@ namespace MarmotLibrary {
   public:
     /// Type alias for the material factory function, which creates instances of
     /// MarmotMaterialGeneralGradientEnhancedHypoElastic.
-    using materialFactoryFunction = std::function< MarmotMaterialGeneralGradientEnhancedHypoElastic<
+    using materialFactoryFunction = std::function< Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic<
       nNonlocalVariables >*( const double* materialProperties, int nMaterialProperties, int materialNumber ) >;
 
     MarmotMaterialGeneralGradientEnhancedHypoElasticFactory() = delete;
@@ -54,7 +54,7 @@ namespace MarmotLibrary {
      * @param[in] materialNumber Unique identifier for the material instance.
      * @return Pointer to the created MarmotMaterial instance, or nullptr if creation failed.
      */
-    static MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* createMaterial(
+    static Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* createMaterial(
       const std::string& materialName,
       const double*      materialProperties,
       int                nMaterialProperties,
@@ -73,7 +73,7 @@ namespace MarmotLibrary {
       assert( map.find( materialName ) == map.end() && "Material already registered!" );
 
       map[materialName] = []( const double* materialProperties, int nMaterialProperties, int materialNumber )
-        -> MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* {
+        -> Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* {
         return new T( materialProperties, nMaterialProperties, materialNumber );
       };
       return true;

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @brief Factory class for creating MarmotMaterialGeneralGradientEnhancedHypoElastic instances.
@@ -83,4 +83,4 @@ namespace MarmotLibrary {
     /// @brief Get the map of material factory functions by material name.
     static MaterialFactoryMap& materialFactoryFunctionByName();
   };
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
@@ -12,7 +12,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 1 >::MaterialFactoryMap
 }
 
 template <>
-MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
   1 >::createMaterial( const std::string& materialName,
                        const double*      materialProperties,
                        int                nMaterialProperties,
@@ -25,7 +25,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >* MarmotMaterialGeneralGrad
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 
@@ -41,7 +41,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 2 >::MaterialFactoryMap
 }
 
 template <>
-MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
   2 >::createMaterial( const std::string& materialName,
                        const double*      materialProperties,
                        int                nMaterialProperties,
@@ -54,7 +54,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 >* MarmotMaterialGeneralGrad
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 
@@ -70,7 +70,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 6 >::MaterialFactoryMap
 }
 
 template <>
-MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
   6 >::createMaterial( const std::string& materialName,
                        const double*      materialProperties,
                        int                nMaterialProperties,
@@ -83,7 +83,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 >* MarmotMaterialGeneralGrad
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 

--- a/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
@@ -1,7 +1,7 @@
 #include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h"
 #include "Marmot/MarmotJournal.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 template <>
 MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 1 >::MaterialFactoryMap& MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<

--- a/modules/core/MarmotGradientMechanicsCore/test/TestMarmotDecreasingInteractions.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/test/TestMarmotDecreasingInteractions.cpp
@@ -4,6 +4,7 @@
 #include "Marmot/MarmotTesting.h"
 #include <cmath>
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::NumericalAlgorithms::Differentiation;
 using namespace Marmot::GradientDamage::DecreasingInteractions;

--- a/modules/core/MarmotGradientMechanicsCore/test/TestMarmotPhaseFieldEnergyDegradation.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/test/TestMarmotPhaseFieldEnergyDegradation.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotPhaseFieldEnergyDegradation.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::NumericalAlgorithms::Differentiation;
 using namespace Marmot::PhaseField::EnergyDegradationFunctions;

--- a/modules/core/MarmotMathCore/test/TestMarmotAutomaticDifferentiationForFastor.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotAutomaticDifferentiationForFastor.cpp
@@ -6,6 +6,7 @@
 #include "Marmot/MarmotTesting.h"
 
 using namespace Fastor;
+using Marmot::MakeString;
 using namespace Marmot::AutomaticDifferentiation;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;

--- a/modules/core/MarmotMathCore/test/TestMarmotEigenSystems.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotEigenSystems.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 using namespace Marmot::Math;

--- a/modules/core/MarmotMathCore/test/TestMarmotMath.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotMath.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Math;
 using namespace Marmot::Testing;
 

--- a/modules/core/MarmotMathCore/test/TestMarmotNumericalDifferentiation.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotNumericalDifferentiation.cpp
@@ -4,6 +4,7 @@
 
 #include "Marmot/MarmotConstants.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::NumericalAlgorithms::Differentiation;
 

--- a/modules/core/MarmotMathCore/test/TestMarmotTensor.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotTensor.cpp
@@ -1,6 +1,7 @@
 #include "Marmot/MarmotTensor.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::ContinuumMechanics::CommonTensors;
 using namespace Marmot::ContinuumMechanics::TensorUtility;
 using namespace Marmot::Testing;

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElastic.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElastic.h
@@ -30,220 +30,226 @@
 #include <cmath>
 #include <vector>
 
-/**
- *
- * Derived abstract base class for elastic materials expressed purely in rate form.
- *
- * In general, the nominal stress rate tensor \f$ \sigRate \f$ can be written as a function of the nominal stress tensor
- * \f$ \sig \f$, the stretching rate tensor \f$ \epsRate \f$ and the time \f$ t \f$.
- *
- * \f[  \displaystyle \sigRate = f( \sig, \epsRate, t, ...) \f]
- *
- * In course of numerical time integration, this relation will be formulated incrementally as
- *
- * \f[  \displaystyle \Delta \sig = f ( \sig_n, \Delta\eps, \Delta t, t_n, ...) \f]
- *
- * with
- *
- * \f[  \displaystyle \Delta\eps =  \epsRate\, \Delta t \f]
- *
- * and the algorithmic tangent
- *
- * \f[ \displaystyle \frac{d \sig }{d \eps } =  \frac{d \Delta \sig }{d \Delta \eps } \f]
- *
- * This formulation is compatible with an Abaqus interface.
- */
-class MarmotMaterialHypoElastic {
+namespace Marmot {
 
-protected:
-  const double* materialProperties;  ///< Pointer to the array of material properties
-  const int     nMaterialProperties; ///< Number of material properties
-
-public:
-  const int materialNumber; ///< Integer identifier for this material instance
   /**
-   * @brief Constructs the material with a given set of material properties and an identifier.
-   * @param[in] matProperties_       Pointer to the array of material properties.
-   * @param[in] nMaterialProperties_ Number of entries in @p matProperties_.
-   * @param[in] materialNumber_      Integer identifying this material instance.
+   *
+   * Derived abstract base class for elastic materials expressed purely in rate form.
+   *
+   * In general, the nominal stress rate tensor \f$ \sigRate \f$ can be written as a function of the nominal stress
+   * tensor \f$ \sig \f$, the stretching rate tensor \f$ \epsRate \f$ and the time \f$ t \f$.
+   *
+   * \f[  \displaystyle \sigRate = f( \sig, \epsRate, t, ...) \f]
+   *
+   * In course of numerical time integration, this relation will be formulated incrementally as
+   *
+   * \f[  \displaystyle \Delta \sig = f ( \sig_n, \Delta\eps, \Delta t, t_n, ...) \f]
+   *
+   * with
+   *
+   * \f[  \displaystyle \Delta\eps =  \epsRate\, \Delta t \f]
+   *
+   * and the algorithmic tangent
+   *
+   * \f[ \displaystyle \frac{d \sig }{d \eps } =  \frac{d \Delta \sig }{d \Delta \eps } \f]
+   *
+   * This formulation is compatible with an Abaqus interface.
    */
-  MarmotMaterialHypoElastic( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
-    : materialProperties( matProperties_ ),
-      nMaterialProperties( nMaterialProperties_ ),
-      materialNumber( materialNumber_ )
-  {
-  }
+  class MarmotMaterialHypoElastic {
 
-  /// Default destructor
-  virtual ~MarmotMaterialHypoElastic() = default;
+  protected:
+    const double* materialProperties;  ///< Pointer to the array of material properties
+    const int     nMaterialProperties; ///< Number of material properties
 
-  /// Layout of the state variables
-  MarmotStateLayoutDynamic stateLayout;
-
-  /// Structure to hold the material state at a material point in 3D
-  struct state3D {
-    Marmot::Vector6d stress;               ///< Cauchy stress tensor in Voigt notation
-    double           elasticEnergyDensity; ///< Elastic strain energy density
-    double           dissipation;          ///< Dissipation
-    double*          stateVars;            ///< Pointer to array of state variables
+  public:
+    const int materialNumber; ///< Integer identifier for this material instance
     /**
-     * @brief Default constructor for state3D
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+     * @brief Constructs the material with a given set of material properties and an identifier.
+     * @param[in] matProperties_       Pointer to the array of material properties.
+     * @param[in] nMaterialProperties_ Number of entries in @p matProperties_.
+     * @param[in] materialNumber_      Integer identifying this material instance.
      */
-    state3D()
-      : stress( Marmot::Vector6d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+    MarmotMaterialHypoElastic( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : materialProperties( matProperties_ ),
+        nMaterialProperties( nMaterialProperties_ ),
+        materialNumber( materialNumber_ )
     {
     }
+
+    /// Default destructor
+    virtual ~MarmotMaterialHypoElastic() = default;
+
+    /// Layout of the state variables
+    MarmotStateLayoutDynamic stateLayout;
+
+    /// Structure to hold the material state at a material point in 3D
+    struct state3D {
+      Marmot::Vector6d stress;               ///< Cauchy stress tensor in Voigt notation
+      double           elasticEnergyDensity; ///< Elastic strain energy density
+      double           dissipation;          ///< Dissipation
+      double*          stateVars;            ///< Pointer to array of state variables
+      /**
+       * @brief Default constructor for state3D
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      state3D()
+        : stress( Marmot::Vector6d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+      {
+      }
+      /**
+       * @brief Constructor for initializing state3D
+       * @param stress_ Cauchy stress tensor in Voigt notation
+       * @param elasticEnergyDensity_ Elastic strain energy density
+       * @param dissipation_ Dissipation
+       * @param stateVars_ Pointer to array of state variables
+       */
+      state3D( Marmot::Vector6d stress_, double elasticEnergyDensity_, double dissipation_, double* stateVars_ )
+        : stress( stress_ ),
+          elasticEnergyDensity( elasticEnergyDensity_ ),
+          dissipation( dissipation_ ),
+          stateVars( stateVars_ )
+      {
+      }
+    };
+
+    // Structure to hold the material state at a material point for 2D plane stress
+    /// @brief Structure holding the material state at a material point for 2D plane stress.
+    struct state2D {
+      Marmot::Vector3d stress;               ///< 2D Cauchy stress tensor in Voigt notation
+      double           elasticEnergyDensity; ///< Elastic strain energy density
+      double           dissipation;          ///< Dissipation
+      double*          stateVars;            ///< Pointer to array of state variables
+
+      state2D()
+        : stress( Marmot::Vector3d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+      {
+      }
+    };
+
+    // Structure to hold the material state at a material point for 1D uniaxial stress
+    /// @brief Structure holding the material state at a material point for 1D uniaxial stress.
+    struct state1D {
+      double  stress;               ///< 1D Cauchy stress
+      double  elasticEnergyDensity; ///< Elastic strain energy density
+      double  dissipation;          ///< Dissipation
+      double* stateVars;            ///< Pointer to array of state variables
+
+      state1D() : stress( 0.0 ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr ) {}
+    };
+
+    /// @brief Structure carrying (pseudo-)time information passed to the material routines.
+    struct timeInfo {
+      double time; ///< Current (pseudo-)time
+      double dT;   ///< (Pseudo-)time increment from the old (pseudo-)time to the current (pseudo-)time
+    };
+
+    /// Characteristic element length
+    double characteristicElementLength;
     /**
-     * @brief Constructor for initializing state3D
-     * @param stress_ Cauchy stress tensor in Voigt notation
-     * @param elasticEnergyDensity_ Elastic strain energy density
-     * @param dissipation_ Dissipation
-     * @param stateVars_ Pointer to array of state variables
+     * Set the characteristic element length at the considered quadrature point.
+     * It is needed for the regularization of materials with softening behavior based on the mesh-adjusted softening
+     * modulus.
+     *
+     * @param[in] length characteristic length; will be assigned to @ref characteristicElementLength
      */
-    state3D( Marmot::Vector6d stress_, double elasticEnergyDensity_, double dissipation_, double* stateVars_ )
-      : stress( stress_ ),
-        elasticEnergyDensity( elasticEnergyDensity_ ),
-        dissipation( dissipation_ ),
-        stateVars( stateVars_ )
+    void setCharacteristicElementLength( double length );
+
+    /**
+     * For a given linearized strain increment \f$\Delta\boldsymbol{\varepsilon}\f$ at the old and the current time,
+     * compute the Cauchy stress and the algorithmic tangent
+     * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$.
+     *
+     * @param[in,out]	state  A state3D instance carrying stress, strain energy, and state variables
+     * @param[in,out]	dStress_dStrain	Algorithmic tangent representing the derivative of the Cauchy stress tensor with
+     * respect to the linearized strain
+     * @param[in]	dStrain linearized strain increment
+     * @param[in]	timeInfo Structure carrying the current (pseudo-)time and the (pseudo-)time increment
+     */
+    virtual void computeStress( state3D&                state,
+                                Marmot::Matrix6d&       dStress_dStrain,
+                                const Marmot::Vector6d& dStrain,
+                                const timeInfo&         timeInfo ) const = 0;
+
+    /**
+     * Explicit version of @ref computeStress for use in explicit time integration schemes.
+     * The algorithmic tangent is not needed in explicit schemes and will therefore not be computed.
+     * @param[in,out] state  A state3D instance carrying stress, strain energy, and state variables
+     * @param[in]   dStrain linearized strain increment
+     * @param[in]   timeInfo Structure carrying time information
+     *
+     * @note The default implementation calls @ref computeStress and ignores the algorithmic tangent.
+     * @note Derived classes may override this method for efficiency reasons.
+     */
+    virtual void computeStressExplicit( state3D&                state,
+                                        const Marmot::Vector6d& dStrain,
+                                        const timeInfo&         timeInfo ) const
     {
+      Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
+      computeStress( state, dStress_dStrain, dStrain, timeInfo );
     }
-  };
 
-  // Structure to hold the material state at a material point for 2D plane stress
-  /// @brief Structure holding the material state at a material point for 2D plane stress.
-  struct state2D {
-    Marmot::Vector3d stress;               ///< 2D Cauchy stress tensor in Voigt notation
-    double           elasticEnergyDensity; ///< Elastic strain energy density
-    double           dissipation;          ///< Dissipation
-    double*          stateVars;            ///< Pointer to array of state variables
+    /**
+     * Plane stress implementation of @ref computeStress.
+     */
+    virtual void computePlaneStress( state2D&                stress2D,
+                                     Marmot::Matrix3d&       dStress_dStrain2D,
+                                     const Marmot::Vector3d& dStrain2D,
+                                     const timeInfo&         timeInfo ) const;
 
-    state2D()
-      : stress( Marmot::Vector3d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+    /**
+     * Uniaxial stress implementation of @ref computeStress.
+     */
+    virtual void computeUniaxialStress( state1D&        stress1D,
+                                        double&         dStress_dStrain1D,
+                                        const double    dStrain,
+                                        const timeInfo& timeInfo ) const;
+
+    /**
+     * @brief Get a view to the state variables.
+     * @param stateName Name of the state variable
+     * @param stateVars Pointer to the state variable array
+     * @return StatView to access the state variable
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const
     {
+      return stateLayout.getStateView( stateVars, stateName );
     }
-  };
 
-  // Structure to hold the material state at a material point for 1D uniaxial stress
-  /// @brief Structure holding the material state at a material point for 1D uniaxial stress.
-  struct state1D {
-    double  stress;               ///< 1D Cauchy stress
-    double  elasticEnergyDensity; ///< Elastic strain energy density
-    double  dissipation;          ///< Dissipation
-    double* stateVars;            ///< Pointer to array of state variables
+    /**
+     * @brief Get the total number of required state variables.
+     * @return Total number of required state variables
+     */
+    int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
 
-    state1D() : stress( 0.0 ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr ) {}
-  };
-
-  /// @brief Structure carrying (pseudo-)time information passed to the material routines.
-  struct timeInfo {
-    double time; ///< Current (pseudo-)time
-    double dT;   ///< (Pseudo-)time increment from the old (pseudo-)time to the current (pseudo-)time
-  };
-
-  /// Characteristic element length
-  double characteristicElementLength;
-  /**
-   * Set the characteristic element length at the considered quadrature point.
-   * It is needed for the regularization of materials with softening behavior based on the mesh-adjusted softening
-   * modulus.
-   *
-   * @param[in] length characteristic length; will be assigned to @ref characteristicElementLength
-   */
-  void setCharacteristicElementLength( double length );
-
-  /**
-   * For a given linearized strain increment \f$\Delta\boldsymbol{\varepsilon}\f$ at the old and the current time,
-   * compute the Cauchy stress and the algorithmic tangent
-   * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$.
-   *
-   * @param[in,out]	state  A state3D instance carrying stress, strain energy, and state variables
-   * @param[in,out]	dStress_dStrain	Algorithmic tangent representing the derivative of the Cauchy stress tensor with
-   * respect to the linearized strain
-   * @param[in]	dStrain linearized strain increment
-   * @param[in]	timeInfo Structure carrying the current (pseudo-)time and the (pseudo-)time increment
-   */
-  virtual void computeStress( state3D&                state,
-                              Marmot::Matrix6d&       dStress_dStrain,
-                              const Marmot::Vector6d& dStrain,
-                              const timeInfo&         timeInfo ) const = 0;
-
-  /**
-   * Explicit version of @ref computeStress for use in explicit time integration schemes.
-   * The algorithmic tangent is not needed in explicit schemes and will therefore not be computed.
-   * @param[in,out] state  A state3D instance carrying stress, strain energy, and state variables
-   * @param[in]   dStrain linearized strain increment
-   * @param[in]   timeInfo Structure carrying time information
-   *
-   * @note The default implementation calls @ref computeStress and ignores the algorithmic tangent.
-   * @note Derived classes may override this method for efficiency reasons.
-   */
-  virtual void computeStressExplicit( state3D& state, const Marmot::Vector6d& dStrain, const timeInfo& timeInfo ) const
-  {
-    Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
-    computeStress( state, dStress_dStrain, dStrain, timeInfo );
-  }
-
-  /**
-   * Plane stress implementation of @ref computeStress.
-   */
-  virtual void computePlaneStress( state2D&                stress2D,
-                                   Marmot::Matrix3d&       dStress_dStrain2D,
-                                   const Marmot::Vector3d& dStrain2D,
-                                   const timeInfo&         timeInfo ) const;
-
-  /**
-   * Uniaxial stress implementation of @ref computeStress.
-   */
-  virtual void computeUniaxialStress( state1D&        stress1D,
-                                      double&         dStress_dStrain1D,
-                                      const double    dStrain,
-                                      const timeInfo& timeInfo ) const;
-
-  /**
-   * @brief Get a view to the state variables.
-   * @param stateName Name of the state variable
-   * @param stateVars Pointer to the state variable array
-   * @return StatView to access the state variable
-   */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
-  {
-    return stateLayout.getStateView( stateVars, stateName );
-  }
-
-  /**
-   * @brief Get the total number of required state variables.
-   * @return Total number of required state variables
-   */
-  int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
-
-  /**
-   * @brief Initialize the state variables at a material point.
-   * @param stateVars Pointer to the state variable array
-   * @param nStateVars Number of state variables
-   *
-   * @note The default implementation initializes all state variables to zero.
-   */
-  virtual void initializeYourself( double* stateVars, int nStateVars )
-  {
-    for ( int i = 0; i < nStateVars; ++i ) {
-      stateVars[i] = 0.0;
+    /**
+     * @brief Initialize the state variables at a material point.
+     * @param stateVars Pointer to the state variable array
+     * @param nStateVars Number of state variables
+     *
+     * @note The default implementation initializes all state variables to zero.
+     */
+    virtual void initializeYourself( double* stateVars, int nStateVars )
+    {
+      for ( int i = 0; i < nStateVars; ++i ) {
+        stateVars[i] = 0.0;
+      }
     }
-  }
 
-  /**
-   * @brief Get the maximum wave speed of the material.
-   * @param[in] state Current material state
-   * @return Maximum wave speed
-   * @details The default implementation computes the 3D algorithmic tangent and returns
-   *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
-   */
-  virtual double getMaximumWaveSpeed( const state3D& state ) const;
+    /**
+     * @brief Get the maximum wave speed of the material.
+     * @param[in] state Current material state
+     * @return Maximum wave speed
+     * @details The default implementation computes the 3D algorithmic tangent and returns
+     *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
+     */
+    virtual double getMaximumWaveSpeed( const state3D& state ) const;
 
-  /**
-   * @brief Get the mass density of the material.
-   * @param stateVars Pointer to the state variable array
-   * @return Mass density of the material
-   */
-  virtual double getDensity( const double* stateVars ) const = 0;
-};
+    /**
+     * @brief Get the mass density of the material.
+     * @param stateVars Pointer to the state variable array
+     * @return Mass density of the material
+     */
+    virtual double getDensity( const double* stateVars ) const = 0;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticAD.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticAD.h
@@ -26,58 +26,65 @@
 #pragma once
 #include "Marmot/MarmotMaterialHypoElastic.h"
 
-/**
- * @brief Derived class of MarmotMaterialHypoElastic providing automatic differentiation support
- *        for computing the algorithmic tangent via dual numbers.
- */
-class MarmotMaterialHypoElasticAD : public MarmotMaterialHypoElastic {
+namespace Marmot {
 
-public:
-  /// @brief Inherits the base-class constructor; see MarmotMaterialHypoElastic::MarmotMaterialHypoElastic().
-  using MarmotMaterialHypoElastic::MarmotMaterialHypoElastic;
-
-  /// @brief Structure holding the material state for 3D using dual numbers (for automatic differentiation).
-  struct state3DAD {
-    Marmot::Vector6dual stress;               ///< Cauchy stress tensor in Voigt notation
-    double              elasticEnergyDensity; ///< Elastic strain energy density
-    double              dissipation;          ///< Dissipation
-    double*             stateVars;            ///< Pointer to array of state variables
-    /**
-     * @brief Default constructor for initializing state3DAD
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
-     */
-    state3DAD()
-      : stress( Marmot::Vector6dual::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr ){};
-    /**
-     * @brief Constructor for initializing state3DAD
-     *@param state A state3D object containing the initial values for stress, energy density, dissipation, and state
-     *variables.
-     */
-    state3DAD( const state3D& state )
-      : stress( state.stress ),
-        elasticEnergyDensity( state.elasticEnergyDensity ),
-        dissipation( state.dissipation ),
-        stateVars( state.stateVars ){};
-  };
   /**
-   * @brief Compute the Cauchy stress tensor \f$\boldsymbol{\sigma}\f$ given an increment of the linearized strain
-   * tensor \f$\Delta\boldsymbol{\varepsilon}\f$.
-   *
-   * Dual numbers are used for both the Cauchy stress tensor and the linearized strain increment, such that the
-   * algorithmic tangent operator
-   * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$ can be obtained by means
-   * of automatic differentiation.
-   *
-   * @param[in,out] state  State carrying the dual Cauchy stress, strain energy, and state variables
-   * @param[in]             dStrain linearized strain increment
-   * @param[in]             timeInfo Old (pseudo-)time
+   * @brief Derived class of MarmotMaterialHypoElastic providing automatic differentiation support
+   *        for computing the algorithmic tangent via dual numbers.
    */
-  virtual void computeStressAD( state3DAD&                 state,
-                                const Marmot::Vector6dual& dStrain,
-                                const timeInfo&            timeInfo ) const = 0;
+  class MarmotMaterialHypoElasticAD : public MarmotMaterialHypoElastic {
 
-  virtual void computeStress( state3D&                state,
-                              Marmot::Matrix6d&       dStressDDStrain,
-                              const Marmot::Vector6d& dStrain,
-                              const timeInfo&         timeInfo ) const override;
-};
+  public:
+    /// @brief Inherits the base-class constructor; see MarmotMaterialHypoElastic::MarmotMaterialHypoElastic().
+    using MarmotMaterialHypoElastic::MarmotMaterialHypoElastic;
+
+    /// @brief Structure holding the material state for 3D using dual numbers (for automatic differentiation).
+    struct state3DAD {
+      Marmot::Vector6dual stress;               ///< Cauchy stress tensor in Voigt notation
+      double              elasticEnergyDensity; ///< Elastic strain energy density
+      double              dissipation;          ///< Dissipation
+      double*             stateVars;            ///< Pointer to array of state variables
+      /**
+       * @brief Default constructor for initializing state3DAD
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      state3DAD()
+        : stress( Marmot::Vector6dual::Zero() ),
+          elasticEnergyDensity( 0.0 ),
+          dissipation( 0.0 ),
+          stateVars( nullptr ){};
+      /**
+       * @brief Constructor for initializing state3DAD
+       *@param state A state3D object containing the initial values for stress, energy density, dissipation, and state
+       *variables.
+       */
+      state3DAD( const state3D& state )
+        : stress( state.stress ),
+          elasticEnergyDensity( state.elasticEnergyDensity ),
+          dissipation( state.dissipation ),
+          stateVars( state.stateVars ){};
+    };
+    /**
+     * @brief Compute the Cauchy stress tensor \f$\boldsymbol{\sigma}\f$ given an increment of the linearized strain
+     * tensor \f$\Delta\boldsymbol{\varepsilon}\f$.
+     *
+     * Dual numbers are used for both the Cauchy stress tensor and the linearized strain increment, such that the
+     * algorithmic tangent operator
+     * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$ can be obtained by
+     * means of automatic differentiation.
+     *
+     * @param[in,out] state  State carrying the dual Cauchy stress, strain energy, and state variables
+     * @param[in]             dStrain linearized strain increment
+     * @param[in]             timeInfo Old (pseudo-)time
+     */
+    virtual void computeStressAD( state3DAD&                 state,
+                                  const Marmot::Vector6dual& dStrain,
+                                  const timeInfo&            timeInfo ) const = 0;
+
+    virtual void computeStress( state3D&                state,
+                                Marmot::Matrix6d&       dStressDDStrain,
+                                const Marmot::Vector6d& dStrain,
+                                const timeInfo&         timeInfo ) const override;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
@@ -42,8 +42,9 @@ namespace MarmotLibrary {
   class MarmotMaterialHypoElasticFactory {
   public:
     /// Function signature for material factory functions registered in the map.
-    using materialFactoryFunction = std::function<
-      MarmotMaterialHypoElastic*( const double* materialProperties, int nMaterialProperties, int materialNumber ) >;
+    using materialFactoryFunction = std::function< Marmot::MarmotMaterialHypoElastic*( const double* materialProperties,
+                                                                                       int nMaterialProperties,
+                                                                                       int materialNumber ) >;
 
     MarmotMaterialHypoElasticFactory() = delete;
 
@@ -55,10 +56,10 @@ namespace MarmotLibrary {
      * @param[in] materialNumber Unique identifier for the material instance.
      * @return Pointer to the created MarmotMaterial instance, or nullptr if creation failed.
      */
-    static MarmotMaterialHypoElastic* createMaterial( const std::string& materialName,
-                                                      const double*      materialProperties,
-                                                      int                nMaterialProperties,
-                                                      int                materialNumber );
+    static Marmot::MarmotMaterialHypoElastic* createMaterial( const std::string& materialName,
+                                                              const double*      materialProperties,
+                                                              int                nMaterialProperties,
+                                                              int                materialNumber );
 
     /**
      * @brief Register a material with its name and an auto-generated factory function.
@@ -72,8 +73,11 @@ namespace MarmotLibrary {
 
       assert( map.find( materialName ) == map.end() && "Material already registered!" );
 
-      map[materialName] = []( const double* materialProperties, int nMaterialProperties, int materialNumber )
-        -> MarmotMaterialHypoElastic* { return new T( materialProperties, nMaterialProperties, materialNumber ); };
+      map[materialName] = []( const double* materialProperties,
+                              int           nMaterialProperties,
+                              int           materialNumber ) -> Marmot::MarmotMaterialHypoElastic* {
+        return new T( materialProperties, nMaterialProperties, materialNumber );
+      };
       return true;
     }
 

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @class MarmotMaterialHypoElasticFactory
@@ -85,4 +85,4 @@ namespace MarmotLibrary {
     using MaterialFactoryMap = std::unordered_map< std::string, materialFactoryFunction >;
     static MaterialFactoryMap& materialFactoryFunctionByName();
   };
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotStateVarVectorManager.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotStateVarVectorManager.h
@@ -30,66 +30,70 @@
 #include <unordered_map>
 #include <vector>
 
-/// @brief A convenience auxiliary class for managing multiple statevars with arbitrary length in a single consecutive
-/// double array
-class MarmotStateVarVectorManager {
+namespace Marmot {
 
-public:
-  /// get a StateView for a statevar entry
-  inline StateView getStateView( const std::string& name ) const
-  {
-    auto entry = theLayout.entries.at( name );
-    return { theStateVars + entry.index, entry.length };
-  }
+  /// @brief A convenience auxiliary class for managing multiple statevars with arbitrary length in a single consecutive
+  /// double array
+  class MarmotStateVarVectorManager {
 
-  /// get the reference to the first array element of an entry in the statevar vector
-  inline double& find( const std::string& name ) const { return theStateVars[theLayout.entries.at( name ).index]; }
-
-  /// check if the entry with name is managed
-  inline bool contains( const std::string& name ) const { return theLayout.entries.count( name ); }
-
-protected:
-  /// An entry in the statevar vector consists of the name and a certain length
-  struct StateVarEntryDefinition {
-    std::string name;   ///< Unique name identifying the state variable entry
-    int         length; ///< Number of consecutive doubles occupied by this entry
-  };
-
-  /// The location in the statevar vector consists of the index and its certain length
-  struct StateVarEntryLocation {
-    int index;  ///< Zero-based offset into the statevar array where the entry begins
-    int length; ///< Number of consecutive doubles occupied by this entry
-  };
-
-  /// The layout is defined by a map of names to Locations, and the resulting required total length of the statevar
-  /// vector
-  struct StateVarVectorLayout {
-    std::unordered_map< std::string, StateVarEntryLocation > entries; ///< Map from entry name to its location
-    int                                                      nRequiredStateVars; ///< Total number of doubles required
-  };
-
-  /// generate the statevar vector layout from a list of entries, defined by name and length
-  static StateVarVectorLayout makeLayout( const std::vector< StateVarEntryDefinition >& theEntries )
-  {
-    std::unordered_map< std::string, StateVarEntryLocation > theMap;
-    int                                                      sizeOccupied = 0;
-    for ( const auto& theEntry : theEntries ) {
-      const auto nextLocation = sizeOccupied;
-      theMap[theEntry.name]   = { nextLocation, theEntry.length };
-      sizeOccupied += theEntry.length;
+  public:
+    /// get a StateView for a statevar entry
+    inline StateView getStateView( const std::string& name ) const
+    {
+      auto entry = theLayout.entries.at( name );
+      return { theStateVars + entry.index, entry.length };
     }
-    return { theMap, sizeOccupied };
-  }
 
-  /// pointer to the first element in the statevar vector
-  double* theStateVars;
+    /// get the reference to the first array element of an entry in the statevar vector
+    inline double& find( const std::string& name ) const { return theStateVars[theLayout.entries.at( name ).index]; }
 
-  /// a const reference to the respective layout
-  const StateVarVectorLayout& theLayout;
+    /// check if the entry with name is managed
+    inline bool contains( const std::string& name ) const { return theLayout.entries.count( name ); }
 
-  /// @brief Constructs the manager from an existing statevar array and a pre-built layout.
-  /// @param theStateVars Pointer to the first element of the statevar array.
-  /// @param theLayout_ Layout describing the offsets and lengths of each named entry.
-  MarmotStateVarVectorManager( double* theStateVars, const StateVarVectorLayout& theLayout_ )
-    : theStateVars( theStateVars ), theLayout( theLayout_ ){};
-};
+  protected:
+    /// An entry in the statevar vector consists of the name and a certain length
+    struct StateVarEntryDefinition {
+      std::string name;   ///< Unique name identifying the state variable entry
+      int         length; ///< Number of consecutive doubles occupied by this entry
+    };
+
+    /// The location in the statevar vector consists of the index and its certain length
+    struct StateVarEntryLocation {
+      int index;  ///< Zero-based offset into the statevar array where the entry begins
+      int length; ///< Number of consecutive doubles occupied by this entry
+    };
+
+    /// The layout is defined by a map of names to Locations, and the resulting required total length of the statevar
+    /// vector
+    struct StateVarVectorLayout {
+      std::unordered_map< std::string, StateVarEntryLocation > entries; ///< Map from entry name to its location
+      int                                                      nRequiredStateVars; ///< Total number of doubles required
+    };
+
+    /// generate the statevar vector layout from a list of entries, defined by name and length
+    static StateVarVectorLayout makeLayout( const std::vector< StateVarEntryDefinition >& theEntries )
+    {
+      std::unordered_map< std::string, StateVarEntryLocation > theMap;
+      int                                                      sizeOccupied = 0;
+      for ( const auto& theEntry : theEntries ) {
+        const auto nextLocation = sizeOccupied;
+        theMap[theEntry.name]   = { nextLocation, theEntry.length };
+        sizeOccupied += theEntry.length;
+      }
+      return { theMap, sizeOccupied };
+    }
+
+    /// pointer to the first element in the statevar vector
+    double* theStateVars;
+
+    /// a const reference to the respective layout
+    const StateVarVectorLayout& theLayout;
+
+    /// @brief Constructs the manager from an existing statevar array and a pre-built layout.
+    /// @param theStateVars Pointer to the first element of the statevar array.
+    /// @param theLayout_ Layout describing the offsets and lengths of each named entry.
+    MarmotStateVarVectorManager( double* theStateVars, const StateVarVectorLayout& theLayout_ )
+      : theStateVars( theStateVars ), theLayout( theLayout_ ){};
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElastic.cpp
@@ -5,156 +5,160 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotVoigt.h"
 
-using namespace Eigen;
+namespace Marmot {
 
-void MarmotMaterialHypoElastic::setCharacteristicElementLength( double length )
-{
-  characteristicElementLength = length;
-}
+  using namespace Eigen;
 
-void MarmotMaterialHypoElastic::computePlaneStress( state2D&                state2D_,
-                                                    Marmot::Matrix3d&       dStress_dStrain2D_,
-                                                    const Marmot::Vector3d& dStrain2D_,
-                                                    const timeInfo&         timeInfo ) const
-{
-  using namespace Marmot;
-  using namespace ContinuumMechanics::VoigtNotation;
-
-  Map< const Matrix< double, 3, 1 > > dStrain2D( dStrain2D_.data() );
-  Map< Matrix< double, 3, 1 > >       stress2D( state2D_.stress.data() );
-  Map< Matrix< double, 3, 3 > >       dStress_dStrain2D( dStress_dStrain2D_.data() );
-  Map< VectorXd >                     stateVars( state2D_.stateVars, this->getNumberOfRequiredStateVars() );
-
-  Matrix6d dStress_dStrain3D;
-
-  VectorXd stateVarsOld  = stateVars;
-  Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( dStrain2D );
-
-  // assumption of isochoric deformation for initial guess
-  dStrain3DTemp( 2 ) = ( -dStrain2D( 0 ) - dStrain2D( 1 ) );
-
-  state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D ),
-                 state2D_.elasticEnergyDensity,
-                 state2D_.dissipation,
-                 stateVars.data() );
-
-  int planeStressCount = 1;
-  while ( true ) {
-
-    stateVars = stateVarsOld;
-
-    state.stress               = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D );
-    state.elasticEnergyDensity = state2D_.elasticEnergyDensity;
-    state.dissipation          = state2D_.dissipation;
-
-    computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
-
-    double residual = state.stress.array().abs()[2];
-
-    if ( residual < 1.e-10 || ( planeStressCount > 7 && residual < 1e-8 ) ) {
-      break;
-    }
-
-    double tangentCompliance = 1. / dStress_dStrain3D( 2, 2 );
-    if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 )
-      tangentCompliance = 1e10;
-
-    dStrain3DTemp( 2 ) -= tangentCompliance * state.stress( 2 );
-
-    planeStressCount += 1;
-    if ( planeStressCount > 13 ) {
-      MarmotJournal::warningToMSG( "PlaneStressWrapper requires cutback" );
-      throw Marmot::StressUpdateFailed( "Plane stress iteration did not converge" );
-    }
+  void MarmotMaterialHypoElastic::setCharacteristicElementLength( double length )
+  {
+    characteristicElementLength = length;
   }
 
-  state2D_.stress               = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::TwoD >( state.stress );
-  state2D_.elasticEnergyDensity = state.elasticEnergyDensity;
-  state2D_.dissipation          = state.dissipation;
-  state2D_.stateVars            = stateVars.data();
+  void MarmotMaterialHypoElastic::computePlaneStress( state2D&                state2D_,
+                                                      Marmot::Matrix3d&       dStress_dStrain2D_,
+                                                      const Marmot::Vector3d& dStrain2D_,
+                                                      const timeInfo&         timeInfo ) const
+  {
+    using namespace Marmot;
+    using namespace ContinuumMechanics::VoigtNotation;
 
-  dStress_dStrain2D_ = ContinuumMechanics::PlaneStress::getPlaneStressTangent( dStress_dStrain3D );
-}
+    Map< const Matrix< double, 3, 1 > > dStrain2D( dStrain2D_.data() );
+    Map< Matrix< double, 3, 1 > >       stress2D( state2D_.stress.data() );
+    Map< Matrix< double, 3, 3 > >       dStress_dStrain2D( dStress_dStrain2D_.data() );
+    Map< VectorXd >                     stateVars( state2D_.stateVars, this->getNumberOfRequiredStateVars() );
 
-void MarmotMaterialHypoElastic::computeUniaxialStress( state1D&        state1D_,
-                                                       double&         dStress_dStrain1D_,
-                                                       const double    dStrain1D_,
-                                                       const timeInfo& timeInfo ) const
-{
-  using namespace Marmot;
-  using namespace ContinuumMechanics::VoigtNotation;
+    Matrix6d dStress_dStrain3D;
 
-  Map< const Matrix< double, 1, 1 > > dStrain1D( &dStrain1D_ );
-  Map< Matrix< double, 1, 1 > >       stress1D( &state1D_.stress );
-  Map< VectorXd >                     stateVars( state1D_.stateVars, stateLayout.totalSize() );
+    VectorXd stateVarsOld  = stateVars;
+    Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( dStrain2D );
 
-  Matrix6d dStress_dStrain3D;
+    // assumption of isochoric deformation for initial guess
+    dStrain3DTemp( 2 ) = ( -dStrain2D( 0 ) - dStrain2D( 1 ) );
 
-  VectorXd stateVarsOld  = stateVars;
-  Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( dStrain1D );
+    state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D ),
+                   state2D_.elasticEnergyDensity,
+                   state2D_.dissipation,
+                   stateVars.data() );
 
-  state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D ),
-                 state1D_.elasticEnergyDensity,
-                 state1D_.dissipation,
-                 stateVars.data() );
+    int planeStressCount = 1;
+    while ( true ) {
 
-  int count = 1;
-  while ( true ) {
-    stateVars = stateVarsOld;
+      stateVars = stateVarsOld;
 
-    state.stress               = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D );
-    state.elasticEnergyDensity = state1D_.elasticEnergyDensity;
-    state.dissipation          = state1D_.dissipation;
+      state.stress = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D );
+      state.elasticEnergyDensity = state2D_.elasticEnergyDensity;
+      state.dissipation          = state2D_.dissipation;
 
-    computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
+      computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
 
-    const double residual = state.stress.array().abs().segment( 1, 2 ).sum();
+      double residual = state.stress.array().abs()[2];
 
-    if ( residual < 1.e-13 || ( count > 7 && residual < 1e-10 ) ) {
-      break;
+      if ( residual < 1.e-10 || ( planeStressCount > 7 && residual < 1e-8 ) ) {
+        break;
+      }
+
+      double tangentCompliance = 1. / dStress_dStrain3D( 2, 2 );
+      if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 )
+        tangentCompliance = 1e10;
+
+      dStrain3DTemp( 2 ) -= tangentCompliance * state.stress( 2 );
+
+      planeStressCount += 1;
+      if ( planeStressCount > 13 ) {
+        MarmotJournal::warningToMSG( "PlaneStressWrapper requires cutback" );
+        throw Marmot::StressUpdateFailed( "Plane stress iteration did not converge" );
+      }
     }
 
-    dStrain3DTemp.segment< 2 >( 1 ) -= dStress_dStrain3D.block< 2, 2 >( 1, 1 ).colPivHouseholderQr().solve(
-      state.stress.segment< 2 >( 1 ) );
+    state2D_.stress               = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::TwoD >( state.stress );
+    state2D_.elasticEnergyDensity = state.elasticEnergyDensity;
+    state2D_.dissipation          = state.dissipation;
+    state2D_.stateVars            = stateVars.data();
 
-    count += 1;
-    if ( count > 13 ) {
-      MarmotJournal::warningToMSG( "UniaxialStressWrapper requires cutback" );
-      throw Marmot::StressUpdateFailed( "uniaxial stress iteration did not converge" );
+    dStress_dStrain2D_ = ContinuumMechanics::PlaneStress::getPlaneStressTangent( dStress_dStrain3D );
+  }
+
+  void MarmotMaterialHypoElastic::computeUniaxialStress( state1D&        state1D_,
+                                                         double&         dStress_dStrain1D_,
+                                                         const double    dStrain1D_,
+                                                         const timeInfo& timeInfo ) const
+  {
+    using namespace Marmot;
+    using namespace ContinuumMechanics::VoigtNotation;
+
+    Map< const Matrix< double, 1, 1 > > dStrain1D( &dStrain1D_ );
+    Map< Matrix< double, 1, 1 > >       stress1D( &state1D_.stress );
+    Map< VectorXd >                     stateVars( state1D_.stateVars, stateLayout.totalSize() );
+
+    Matrix6d dStress_dStrain3D;
+
+    VectorXd stateVarsOld  = stateVars;
+    Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( dStrain1D );
+
+    state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D ),
+                   state1D_.elasticEnergyDensity,
+                   state1D_.dissipation,
+                   stateVars.data() );
+
+    int count = 1;
+    while ( true ) {
+      stateVars = stateVarsOld;
+
+      state.stress = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D );
+      state.elasticEnergyDensity = state1D_.elasticEnergyDensity;
+      state.dissipation          = state1D_.dissipation;
+
+      computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
+
+      const double residual = state.stress.array().abs().segment( 1, 2 ).sum();
+
+      if ( residual < 1.e-13 || ( count > 7 && residual < 1e-10 ) ) {
+        break;
+      }
+
+      dStrain3DTemp.segment< 2 >( 1 ) -= dStress_dStrain3D.block< 2, 2 >( 1, 1 ).colPivHouseholderQr().solve(
+        state.stress.segment< 2 >( 1 ) );
+
+      count += 1;
+      if ( count > 13 ) {
+        MarmotJournal::warningToMSG( "UniaxialStressWrapper requires cutback" );
+        throw Marmot::StressUpdateFailed( "uniaxial stress iteration did not converge" );
+      }
     }
+
+    state1D_.stress = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::OneD >( state.stress )[0];
+    state1D_.elasticEnergyDensity = state.elasticEnergyDensity;
+    state1D_.dissipation          = state.dissipation;
+    state1D_.stateVars            = stateVars.data();
+
+    dStress_dStrain1D_ = ContinuumMechanics::UniaxialStress::getUniaxialStressTangent( dStress_dStrain3D );
+  }
+  double MarmotMaterialHypoElastic::getMaximumWaveSpeed( const state3D& state ) const
+  {
+    const int nStateVars = getNumberOfRequiredStateVars();
+
+    std::vector< double > stateVarsCopy( nStateVars, 0.0 );
+    if ( state.stateVars != nullptr && nStateVars > 0 ) {
+      std::copy_n( state.stateVars, nStateVars, stateVarsCopy.begin() );
+    }
+
+    state3D stateCopy( state.stress, state.elasticEnergyDensity, state.dissipation, stateVarsCopy.data() );
+
+    Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
+    const auto       dStrain         = Marmot::Vector6d::Zero();
+    const timeInfo   timeInfo{ 0.0, 1.0 };
+
+    computeStress( stateCopy, dStress_dStrain, dStrain, timeInfo );
+
+    const double maxStiffnessDiagonal = std::max( { dStress_dStrain( 0, 0 ),
+                                                    dStress_dStrain( 1, 1 ),
+                                                    dStress_dStrain( 2, 2 ),
+                                                    dStress_dStrain( 3, 3 ),
+                                                    dStress_dStrain( 4, 4 ),
+                                                    dStress_dStrain( 5, 5 ) } );
+    const double density              = getDensity( stateCopy.stateVars );
+
+    return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
   }
 
-  state1D_.stress = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::OneD >( state.stress )[0];
-  state1D_.elasticEnergyDensity = state.elasticEnergyDensity;
-  state1D_.dissipation          = state.dissipation;
-  state1D_.stateVars            = stateVars.data();
-
-  dStress_dStrain1D_ = ContinuumMechanics::UniaxialStress::getUniaxialStressTangent( dStress_dStrain3D );
-}
-double MarmotMaterialHypoElastic::getMaximumWaveSpeed( const state3D& state ) const
-{
-  const int nStateVars = getNumberOfRequiredStateVars();
-
-  std::vector< double > stateVarsCopy( nStateVars, 0.0 );
-  if ( state.stateVars != nullptr && nStateVars > 0 ) {
-    std::copy_n( state.stateVars, nStateVars, stateVarsCopy.begin() );
-  }
-
-  state3D stateCopy( state.stress, state.elasticEnergyDensity, state.dissipation, stateVarsCopy.data() );
-
-  Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
-  const auto       dStrain         = Marmot::Vector6d::Zero();
-  const timeInfo   timeInfo{ 0.0, 1.0 };
-
-  computeStress( stateCopy, dStress_dStrain, dStrain, timeInfo );
-
-  const double maxStiffnessDiagonal = std::max( { dStress_dStrain( 0, 0 ),
-                                                  dStress_dStrain( 1, 1 ),
-                                                  dStress_dStrain( 2, 2 ),
-                                                  dStress_dStrain( 3, 3 ),
-                                                  dStress_dStrain( 4, 4 ),
-                                                  dStress_dStrain( 5, 5 ) } );
-  const double density              = getDensity( stateCopy.stateVars );
-
-  return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
-}
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticAD.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticAD.cpp
@@ -3,46 +3,50 @@
 #include "Marmot/MarmotTypedefs.h"
 #include <autodiff/forward/dual/eigen.hpp>
 
-using namespace Eigen;
-using namespace autodiff;
+namespace Marmot {
 
-void MarmotMaterialHypoElasticAD::computeStress( state3D&                state,
-                                                 Marmot::Matrix6d&       dStressDDStrain,
-                                                 const Marmot::Vector6d& dStrain,
-                                                 const timeInfo&         timeInfo
+  using namespace Eigen;
+  using namespace autodiff;
 
-) const
-{
+  void MarmotMaterialHypoElasticAD::computeStress( state3D&                state,
+                                                   Marmot::Matrix6d&       dStressDDStrain,
+                                                   const Marmot::Vector6d& dStrain,
+                                                   const timeInfo&         timeInfo
 
-  using namespace Marmot;
-  mVector6d       S( state.stress.data() );
-  const Vector6d  dEps = Map< const Vector6d >( dStrain.data() );
-  Map< VectorXd > stateVars( state.stateVars, this->getNumberOfRequiredStateVars() );
+  ) const
+  {
 
-  // remember old state
-  const VectorXd stateVarsOld = stateVars;
-  const Vector6d SOld         = S;
+    using namespace Marmot;
+    mVector6d       S( state.stress.data() );
+    const Vector6d  dEps = Map< const Vector6d >( dStrain.data() );
+    Map< VectorXd > stateVars( state.stateVars, this->getNumberOfRequiredStateVars() );
 
-  mMatrix6d C( dStressDDStrain.data() );
-  // ----------------------------------------
-  // autodiff part
-  // ----------------------------------------
-  // compute stress and tangent with autodiff
-  std::tie( S, C ) = Marmot::AutomaticDifferentiation::dF_dX(
-    [&]( const Marmot::Vector6dual dE_ ) {
-      // reset stateVars to old state
-      stateVars = stateVarsOld;
+    // remember old state
+    const VectorXd stateVarsOld = stateVars;
+    const Vector6d SOld         = S;
 
-      Marmot::Vector6dual s( SOld );
+    mMatrix6d C( dStressDDStrain.data() );
+    // ----------------------------------------
+    // autodiff part
+    // ----------------------------------------
+    // compute stress and tangent with autodiff
+    std::tie( S, C ) = Marmot::AutomaticDifferentiation::dF_dX(
+      [&]( const Marmot::Vector6dual dE_ ) {
+        // reset stateVars to old state
+        stateVars = stateVarsOld;
 
-      // construct AD state
-      state3DAD stateAD = state3DAD( state );
-      // compute stress
-      computeStressAD( stateAD, dE_, timeInfo );
+        Marmot::Vector6dual s( SOld );
 
-      Marmot::Vector6dual res = stateAD.stress;
-      return res;
-    },
-    dEps );
-  // ----------------------------------------
-}
+        // construct AD state
+        state3DAD stateAD = state3DAD( state );
+        // compute stress
+        computeStressAD( stateAD, dE_, timeInfo );
+
+        Marmot::Vector6dual res = stateAD.stress;
+        return res;
+      },
+      dEps );
+    // ----------------------------------------
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
@@ -1,7 +1,7 @@
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 #include "Marmot/MarmotJournal.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 Marmot::MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( const std::string& materialName,
                                                                                      const double* materialProperties,

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
@@ -3,10 +3,10 @@
 
 using namespace MarmotLibrary;
 
-MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( const std::string& materialName,
-                                                                             const double*      materialProperties,
-                                                                             int                nMaterialProperties,
-                                                                             int                materialNumber )
+Marmot::MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( const std::string& materialName,
+                                                                                     const double* materialProperties,
+                                                                                     int           nMaterialProperties,
+                                                                                     int           materialNumber )
 {
   auto& map = materialFactoryFunctionByName();
   auto  it  = map.find( materialName );
@@ -15,7 +15,7 @@ MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( con
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialPointSolverHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialPointSolverHypoElastic.cpp
@@ -11,7 +11,7 @@ MarmotMaterialPointSolverHypoElastic::MarmotMaterialPointSolverHypoElastic( std:
                                                                             const SolverOptions& options )
   : options( options )
 {
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration;
 
   // create material instance
   material = std::unique_ptr< MarmotMaterialHypoElastic >( dynamic_cast< MarmotMaterialHypoElastic* >(

--- a/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
@@ -1,6 +1,7 @@
 #include "Marmot/HaighWestergaard.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::ContinuumMechanics::HaighWestergaard;
 using namespace Marmot::ContinuumMechanics::VoigtNotation::Invariants;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotElasticity.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotElasticity.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotTesting.h"
 #include <Eigen/Dense>
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::ContinuumMechanics::Elasticity::Isotropic;
 using namespace Marmot::ContinuumMechanics::Elasticity::TransverseIsotropic;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotKinematics.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotKinematics.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotTesting.h"
 
 using namespace Eigen;
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::ContinuumMechanics::Kinematics::VelocityGradient;
 using namespace Marmot::ContinuumMechanics::Kinematics::Strain;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotLocalization.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotLocalization.cpp
@@ -4,6 +4,7 @@
 #include "Marmot/VonMises.h"
 
 using namespace Marmot::Testing;
+using Marmot::MarmotMaterialHypoElastic;
 
 void testMarmotLocalization()
 {

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotLowerDimensionalStress.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotLowerDimensionalStress.cpp
@@ -10,6 +10,7 @@
  */
 
 using namespace Eigen;
+using Marmot::MakeString;
 using namespace Marmot::ContinuumMechanics::Elasticity::Isotropic;
 using namespace Marmot::ContinuumMechanics::PlaneStrain;
 using namespace Marmot::ContinuumMechanics::PlaneStress;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotStateVarVectorManager.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotStateVarVectorManager.cpp
@@ -3,7 +3,7 @@
 
 using namespace Marmot::Testing;
 
-class DummyMaterialStateVarManager : public MarmotStateVarVectorManager {
+class DummyMaterialStateVarManager : public Marmot::MarmotStateVarVectorManager {
   /*
    * DummyMaterialStateVarManager is a derived class of MarmotStateVarVectorManager
    * for testing purposes. It defines a static layout with two state variables:
@@ -14,7 +14,7 @@ public:
   inline const static auto layout = makeLayout( { { .name = "var1", .length = 3 }, { .name = "var2", .length = 2 } } );
 
   // Constructor initializes the parent class
-  DummyMaterialStateVarManager( double* stateVars ) : MarmotStateVarVectorManager( stateVars, layout ){};
+  DummyMaterialStateVarManager( double* stateVars ) : Marmot::MarmotStateVarVectorManager( stateVars, layout ){};
 
   // Expose nRequiredStateVars for testing layout calculation
   static int getRequiredSize() { return layout.nRequiredStateVars; }

--- a/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotJournal.h
+++ b/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotJournal.h
@@ -27,69 +27,73 @@
 #include <sstream>
 #include <string>
 
-/** @class MakeString
- * @brief Utility class for constructing strings with stream-like syntax.
- *
- * This class allows for easy string construction using the stream insertion operator.
- * It can be used to build complex strings in a readable manner.
- */
-class MakeString {
-public:
-  std::stringstream stream; ///< Internal string stream used for building the output string.
+namespace Marmot {
 
-  /// Convert the accumulated stream content to a `std::string`.
-  operator std::string() const { return stream.str(); }
+  /** @class MakeString
+   * @brief Utility class for constructing strings with stream-like syntax.
+   *
+   * This class allows for easy string construction using the stream insertion operator.
+   * It can be used to build complex strings in a readable manner.
+   */
+  class MakeString {
+  public:
+    std::stringstream stream; ///< Internal string stream used for building the output string.
+
+    /// Convert the accumulated stream content to a `std::string`.
+    operator std::string() const { return stream.str(); }
+
+    /**
+     * @brief Append a value to the internal stream.
+     * @tparam T   Type of the value to append.
+     * @param VAR  Value to insert into the stream.
+     * @return     Reference to `*this` for chaining.
+     */
+    template < class T >
+    MakeString& operator<<( T const& VAR )
+    {
+      stream << VAR;
+      return *this;
+    }
+  };
 
   /**
-   * @brief Append a value to the internal stream.
-   * @tparam T   Type of the value to append.
-   * @param VAR  Value to insert into the stream.
-   * @return     Reference to `*this` for chaining.
+   * @class MarmotJournal
+   * @brief Singleton class for managing output messages in the Marmot framework.
+   *
+   * This class provides a centralized way to handle warning and notification messages,
+   * allowing them to be directed to a specified output stream (e.g., console, file).
    */
-  template < class T >
-  MakeString& operator<<( T const& VAR )
-  {
-    stream << VAR;
-    return *this;
-  }
-};
+  class MarmotJournal {
+  private:
+    static MarmotJournal& getInstance();
 
-/**
- * @class MarmotJournal
- * @brief Singleton class for managing output messages in the Marmot framework.
- *
- * This class provides a centralized way to handle warning and notification messages,
- * allowing them to be directed to a specified output stream (e.g., console, file).
- */
-class MarmotJournal {
-private:
-  static MarmotJournal& getInstance();
+    std::ostream output;
 
-  std::ostream output;
+    MarmotJournal();
 
-  MarmotJournal();
+  public:
+    MarmotJournal( MarmotJournal const& )  = delete;
+    void operator=( MarmotJournal const& ) = delete;
 
-public:
-  MarmotJournal( MarmotJournal const& )  = delete;
-  void operator=( MarmotJournal const& ) = delete;
+    /**
+     * @brief Redirect all subsequent journal output to @p newOutputStream.
+     * @param newOutputStream  The output stream that warnings and notifications are written to.
+     */
+    static void setMSGOutputDirection( std::ostream& newOutputStream );
 
-  /**
-   * @brief Redirect all subsequent journal output to @p newOutputStream.
-   * @param newOutputStream  The output stream that warnings and notifications are written to.
-   */
-  static void setMSGOutputDirection( std::ostream& newOutputStream );
+    /**
+     * @brief Write a warning message to the journal output stream.
+     * @param message  The warning text to emit.
+     * @return `true` after the message has been written.
+     */
+    static bool warningToMSG( const std::string& message );
 
-  /**
-   * @brief Write a warning message to the journal output stream.
-   * @param message  The warning text to emit.
-   * @return `true` after the message has been written.
-   */
-  static bool warningToMSG( const std::string& message );
+    /**
+     * @brief Write a notification message to the journal output stream.
+     * @param message  The notification text to emit.
+     * @return `true` after the message has been written.
+     */
+    static bool notificationToMSG( const std::string& message );
+  };
 
-  /**
-   * @brief Write a notification message to the journal output stream.
-   * @param message  The notification text to emit.
-   * @return `true` after the message has been written.
-   */
-  static bool notificationToMSG( const std::string& message );
-};
+} // namespace Marmot

--- a/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotStateHelpers.h
+++ b/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotStateHelpers.h
@@ -34,292 +34,296 @@
 #include <unordered_map>
 #include <vector>
 
-/**
- * @struct StateMapper
- * @brief Template struct to map raw double pointers and sizes to specific views.
- * Specializations of this struct should provide a static `map` method that
- * takes a `double*` and a `std::size_t` size, returning the desired view type.
- */
-template < class View, int... Args >
-struct StateMapper;
+namespace Marmot {
 
-/// \cond DOXYGEN_SKIP
-// Template specialisations of StateMapper are hidden from Doxygen because
-// Sphinx's C++ domain parser cannot handle deeply nested template arguments
-// (e.g. StateMapper< Eigen::Map< Eigen::MatrixXd > >) and would emit
-// "Invalid C++ declaration" warnings for every specialisation.
-
-/**
- * @struct StateMapper<double>
- * @brief Specialization of StateMapper for single double values.
- * This allows mapping a raw double pointer and size to a single double reference.
- */
-template <>
-struct StateMapper< double& > {
-  static double& map( double* ptr, std::size_t n )
-  {
-    if ( n != 1 )
-      throw std::runtime_error( "Size mismatch for double." );
-    return *ptr;
-  }
-};
-
-/**
- * @struct StateMapper<const double>
- * @brief Specialization of StateMapper for single const double values.
- * This allows mapping a raw const double pointer and size to a single const double reference.
- */
-template <>
-struct StateMapper< const double& > {
-  static const double& map( const double* ptr, std::size_t n )
-  {
-    if ( n != 1 )
-      throw std::runtime_error( "Size mismatch for double." );
-    return *ptr;
-  }
-};
-/**
- * @struct StateMapper<Fastor::Tensor<double,3,3>>
- * @brief Specialization of StateMapper for Fastor::Tensor<double,3,3>.
- * This allows mapping a raw double pointer and size to a Fastor 3x3 tensor.
- */
-template <>
-struct StateMapper< Fastor::TensorMap< double, 3, 3 > > {
-  static Fastor::TensorMap< double, 3, 3 > map( double* ptr, std::size_t n )
-  {
-    if ( n != 9 )
-      throw std::runtime_error( "Size mismatch for Fastor::Tensor<double,3,3>." );
-    return Fastor::TensorMap< double, 3, 3 >( ptr );
-  }
-};
-
-/**
- * @struct StateMapper<Eigen::Map<Eigen::MatrixXd>>
- * @brief Specialization of StateMapper for Eigen::Map<Eigen::MatrixXd>.
- * This allows mapping a raw double pointer and size to an Eigen dynamic matrix map.
- */
-template <>
-struct StateMapper< Eigen::Map< Eigen::MatrixXd > > {
-  template < class... Args >
-  static Eigen::Map< Eigen::MatrixXd > map( double* ptr, std::size_t n, int Rows, int Cols )
-  {
-    // read size form Args
-    if ( int( n ) != Rows * Cols )
-      throw std::runtime_error( "Size mismatch for Eigen::Map." );
-    return Eigen::Map< Eigen::MatrixXd >( ptr, Rows, n / Rows );
-  }
-};
-
-/**
- * @struct StateMapper<Eigen::Map<Eigen::Matrix<Scalar, Rows, Cols>>>
- * @brief Specialization of StateMapper for fixed-size Eigen::Map types.
- */
-template < typename Scalar, int Rows, int Cols >
-struct StateMapper< Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > > {
-  template < class... Args >
-  static Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > map( double* ptr, std::size_t n, Args&&... )
-  {
-    // Check if the expected total size matches the provided size 'n'
-    if ( int( n ) != Rows * Cols )
-      throw std::runtime_error( "Size mismatch for fixed-size Eigen::Map." );
-
-    // Map the raw pointer to the Eigen fixed-size matrix map
-    return Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > >( ptr, Rows, Cols );
-  }
-};
-/// \endcond
-
-/**
- * @class MarmotStateLayoutDynamic
- * @brief Runtime-defined layout for a flat array of named `double` state variables.
- *
- * Variables are registered by name and size via add(), then the layout is locked
- * with finalize(), which assigns contiguous offsets. After finalization the
- * various `get*` accessors can be used to reach individual variables inside any
- * conforming state vector.
- */
-class MarmotStateLayoutDynamic {
-public:
   /**
-   * @brief Describes a single named state variable registered in the layout.
+   * @struct StateMapper
+   * @brief Template struct to map raw double pointers and sizes to specific views.
+   * Specializations of this struct should provide a static `map` method that
+   * takes a `double*` and a `std::size_t` size, returning the desired view type.
    */
-  struct VarInfo {
-    std::string name;   ///< Unique name of the state variable.
-    std::size_t size;   ///< Number of `double` values occupied by this variable.
-    std::size_t offset; ///< Byte-offset (in units of `double`) from the beginning of the state vector.
+  template < class View, int... Args >
+  struct StateMapper;
+
+  /// \cond DOXYGEN_SKIP
+  // Template specialisations of StateMapper are hidden from Doxygen because
+  // Sphinx's C++ domain parser cannot handle deeply nested template arguments
+  // (e.g. StateMapper< Eigen::Map< Eigen::MatrixXd > >) and would emit
+  // "Invalid C++ declaration" warnings for every specialisation.
+
+  /**
+   * @struct StateMapper<double>
+   * @brief Specialization of StateMapper for single double values.
+   * This allows mapping a raw double pointer and size to a single double reference.
+   */
+  template <>
+  struct StateMapper< double& > {
+    static double& map( double* ptr, std::size_t n )
+    {
+      if ( n != 1 )
+        throw std::runtime_error( "Size mismatch for double." );
+      return *ptr;
+    }
   };
 
   /**
-   * @brief Register a new named state variable.
-   *
-   * Must be called before finalize(). Adding a variable with an already-registered name
-   * or calling this method after finalize() throws @c std::runtime_error.
-   *
-   * @param name  Unique name for the state variable.
-   * @param size  Number of `double` values required by the variable.
+   * @struct StateMapper<const double>
+   * @brief Specialization of StateMapper for single const double values.
+   * This allows mapping a raw const double pointer and size to a single const double reference.
    */
-  void add( std::string name, std::size_t size )
-  {
-    if ( finalized )
-      throw std::runtime_error( "Cannot add variables after finalize()." );
-
-    if ( name_to_index.contains( name ) )
-      throw std::runtime_error( "Duplicate state variable: " + name );
-
-    name_to_index[name] = variables.size();
-    variables.push_back( { std::move( name ), size, 0 } );
-  }
-
-  /**
-   * @brief Compute and lock the offsets of all registered variables.
-   *
-   * Iterates over the registered variables in registration order, assigns each a
-   * contiguous offset, and sets the total size. After this call no further variables
-   * may be added. Calling finalize() a second time throws @c std::runtime_error.
-   */
-  void finalize()
-  {
-    if ( finalized )
-      throw std::runtime_error( "State layout already finalized." );
-    std::size_t offset = 0;
-    for ( auto& v : variables ) {
-      v.offset = offset;
-      offset += v.size;
+  template <>
+  struct StateMapper< const double& > {
+    static const double& map( const double* ptr, std::size_t n )
+    {
+      if ( n != 1 )
+        throw std::runtime_error( "Size mismatch for double." );
+      return *ptr;
     }
-    total_sz  = offset;
-    finalized = true;
-  }
+  };
+  /**
+   * @struct StateMapper<Fastor::Tensor<double,3,3>>
+   * @brief Specialization of StateMapper for Fastor::Tensor<double,3,3>.
+   * This allows mapping a raw double pointer and size to a Fastor 3x3 tensor.
+   */
+  template <>
+  struct StateMapper< Fastor::TensorMap< double, 3, 3 > > {
+    static Fastor::TensorMap< double, 3, 3 > map( double* ptr, std::size_t n )
+    {
+      if ( n != 9 )
+        throw std::runtime_error( "Size mismatch for Fastor::Tensor<double,3,3>." );
+      return Fastor::TensorMap< double, 3, 3 >( ptr );
+    }
+  };
 
   /**
-   * @brief Return the @ref VarInfo record for a registered variable.
+   * @struct StateMapper<Eigen::Map<Eigen::MatrixXd>>
+   * @brief Specialization of StateMapper for Eigen::Map<Eigen::MatrixXd>.
+   * This allows mapping a raw double pointer and size to an Eigen dynamic matrix map.
+   */
+  template <>
+  struct StateMapper< Eigen::Map< Eigen::MatrixXd > > {
+    template < class... Args >
+    static Eigen::Map< Eigen::MatrixXd > map( double* ptr, std::size_t n, int Rows, int Cols )
+    {
+      // read size form Args
+      if ( int( n ) != Rows * Cols )
+        throw std::runtime_error( "Size mismatch for Eigen::Map." );
+      return Eigen::Map< Eigen::MatrixXd >( ptr, Rows, n / Rows );
+    }
+  };
+
+  /**
+   * @struct StateMapper<Eigen::Map<Eigen::Matrix<Scalar, Rows, Cols>>>
+   * @brief Specialization of StateMapper for fixed-size Eigen::Map types.
+   */
+  template < typename Scalar, int Rows, int Cols >
+  struct StateMapper< Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > > {
+    template < class... Args >
+    static Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > map( double* ptr, std::size_t n, Args&&... )
+    {
+      // Check if the expected total size matches the provided size 'n'
+      if ( int( n ) != Rows * Cols )
+        throw std::runtime_error( "Size mismatch for fixed-size Eigen::Map." );
+
+      // Map the raw pointer to the Eigen fixed-size matrix map
+      return Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > >( ptr, Rows, Cols );
+    }
+  };
+  /// \endcond
+
+  /**
+   * @class MarmotStateLayoutDynamic
+   * @brief Runtime-defined layout for a flat array of named `double` state variables.
    *
-   * @param name  Name of the variable to look up.
-   * @return      Const reference to the corresponding @ref VarInfo.
-   * @throws std::runtime_error if @p name is not registered.
+   * Variables are registered by name and size via add(), then the layout is locked
+   * with finalize(), which assigns contiguous offsets. After finalization the
+   * various `get*` accessors can be used to reach individual variables inside any
+   * conforming state vector.
    */
-  const VarInfo& getInfo( const std::string& name ) const
-  {
-    auto it = name_to_index.find( name );
-    if ( it == name_to_index.end() )
-      throw std::runtime_error( "Unknown state variable: " + name );
-    return variables[it->second];
-  }
+  class MarmotStateLayoutDynamic {
+  public:
+    /**
+     * @brief Describes a single named state variable registered in the layout.
+     */
+    struct VarInfo {
+      std::string name;   ///< Unique name of the state variable.
+      std::size_t size;   ///< Number of `double` values occupied by this variable.
+      std::size_t offset; ///< Byte-offset (in units of `double`) from the beginning of the state vector.
+    };
 
-  /**
-   * @brief Return the {offset, size} pair for a registered variable.
-   *
-   * @param name  Name of the variable.
-   * @return      A pair `{offset, size}` (both in units of `double`).
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  std::pair< std::size_t, std::size_t > get( const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return { v.offset, v.size };
-  }
+    /**
+     * @brief Register a new named state variable.
+     *
+     * Must be called before finalize(). Adding a variable with an already-registered name
+     * or calling this method after finalize() throws @c std::runtime_error.
+     *
+     * @param name  Unique name for the state variable.
+     * @param size  Number of `double` values required by the variable.
+     */
+    void add( std::string name, std::size_t size )
+    {
+      if ( finalized )
+        throw std::runtime_error( "Cannot add variables after finalize()." );
 
-  /**
-   * @brief Return a raw pointer to a variable inside a state vector.
-   *
-   * @param base  Pointer to the beginning of the state vector.
-   * @param name  Name of the variable.
-   * @return      `base + offset` for the named variable.
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  double* getPtr( double* base, const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return base + v.offset;
-  }
+      if ( name_to_index.contains( name ) )
+        throw std::runtime_error( "Duplicate state variable: " + name );
 
-  /**
-   * @brief Return a `std::span<double>` view of a variable inside a state vector.
-   *
-   * @param base  Pointer to the beginning of the state vector.
-   * @param name  Name of the variable.
-   * @return      A span covering `[base + offset, base + offset + size)`.
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  std::span< double > getSpan( double* base, const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return { base + v.offset, v.size };
-  }
+      name_to_index[name] = variables.size();
+      variables.push_back( { std::move( name ), size, 0 } );
+    }
 
-  /**
-   * @brief Return a @ref StateView for a variable inside a state vector.
-   *
-   * @param base  Pointer to the beginning of the state vector.
-   * @param name  Name of the variable.
-   * @return      A @ref StateView with `stateLocation = base + offset` and `stateSize = size`.
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  StateView getStateView( double* base, const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return StateView{ base + v.offset, static_cast< int >( v.size ) };
-  }
+    /**
+     * @brief Compute and lock the offsets of all registered variables.
+     *
+     * Iterates over the registered variables in registration order, assigns each a
+     * contiguous offset, and sets the total size. After this call no further variables
+     * may be added. Calling finalize() a second time throws @c std::runtime_error.
+     */
+    void finalize()
+    {
+      if ( finalized )
+        throw std::runtime_error( "State layout already finalized." );
+      std::size_t offset = 0;
+      for ( auto& v : variables ) {
+        v.offset = offset;
+        offset += v.size;
+      }
+      total_sz  = offset;
+      finalized = true;
+    }
 
-  /**
-   * @brief Map a variable inside a state vector to a typed view via `StateMapper`.
-   *
-   * Delegates to `StateMapper<View>::map(base + offset, size, args...)`.
-   * The layout must have been finalized before calling this method.
-   *
-   * @tparam View   Target view type (must have a matching `StateMapper` specialization).
-   * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
-   * @param base    Pointer to the beginning of the state vector.
-   * @param name    Name of the variable.
-   * @param args    Extra arguments forwarded to `StateMapper::map`.
-   * @return        The mapped view of the requested variable.
-   * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
-   */
-  template < class View, class... Args >
-  View getAs( double* base, const std::string& name, Args&&... args ) const
-  {
-    if ( !finalized )
-      throw std::runtime_error( "State layout not finalized." );
+    /**
+     * @brief Return the @ref VarInfo record for a registered variable.
+     *
+     * @param name  Name of the variable to look up.
+     * @return      Const reference to the corresponding @ref VarInfo.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    const VarInfo& getInfo( const std::string& name ) const
+    {
+      auto it = name_to_index.find( name );
+      if ( it == name_to_index.end() )
+        throw std::runtime_error( "Unknown state variable: " + name );
+      return variables[it->second];
+    }
 
-    const auto& v = getInfo( name );
-    return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
-  }
+    /**
+     * @brief Return the {offset, size} pair for a registered variable.
+     *
+     * @param name  Name of the variable.
+     * @return      A pair `{offset, size}` (both in units of `double`).
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    std::pair< std::size_t, std::size_t > get( const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return { v.offset, v.size };
+    }
 
-  /**
-   * @brief Const version of @ref getAs.
-   * @tparam View   Target view type (must have a matching `StateMapper` specialization).
-   * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
-   * @param base    Pointer to the beginning of the state vector.
-   * @param name    Name of the variable.
-   * @param args    Extra arguments forwarded to `StateMapper::map`.
-   * @return        The mapped view of the requested variable.
-   * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
-   */
-  template < class View, class... Args >
-  View getAs( const double* base, const std::string& name, Args&&... args ) const
-  {
-    if ( !finalized )
-      throw std::runtime_error( "State layout not finalized." );
+    /**
+     * @brief Return a raw pointer to a variable inside a state vector.
+     *
+     * @param base  Pointer to the beginning of the state vector.
+     * @param name  Name of the variable.
+     * @return      `base + offset` for the named variable.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    double* getPtr( double* base, const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return base + v.offset;
+    }
 
-    const auto& v = getInfo( name );
-    return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
-  }
+    /**
+     * @brief Return a `std::span<double>` view of a variable inside a state vector.
+     *
+     * @param base  Pointer to the beginning of the state vector.
+     * @param name  Name of the variable.
+     * @return      A span covering `[base + offset, base + offset + size)`.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    std::span< double > getSpan( double* base, const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return { base + v.offset, v.size };
+    }
 
-  /**
-   * @brief Return the total size (in units of `double`) of the state layout.
-   * This is the size of the state vector required to hold all registered variables.
-   */
-  int totalSize() const { return total_sz; }
+    /**
+     * @brief Return a @ref StateView for a variable inside a state vector.
+     *
+     * @param base  Pointer to the beginning of the state vector.
+     * @param name  Name of the variable.
+     * @return      A @ref StateView with `stateLocation = base + offset` and `stateSize = size`.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    StateView getStateView( double* base, const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return StateView{ base + v.offset, static_cast< int >( v.size ) };
+    }
 
-  /**
-   * @brief Check if the layout has been finalized.
-   * @return `true` if finalize() has been called, `false` otherwise.
-   */
-  bool isFinalized() const { return finalized; }
+    /**
+     * @brief Map a variable inside a state vector to a typed view via `StateMapper`.
+     *
+     * Delegates to `StateMapper<View>::map(base + offset, size, args...)`.
+     * The layout must have been finalized before calling this method.
+     *
+     * @tparam View   Target view type (must have a matching `StateMapper` specialization).
+     * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
+     * @param base    Pointer to the beginning of the state vector.
+     * @param name    Name of the variable.
+     * @param args    Extra arguments forwarded to `StateMapper::map`.
+     * @return        The mapped view of the requested variable.
+     * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
+     */
+    template < class View, class... Args >
+    View getAs( double* base, const std::string& name, Args&&... args ) const
+    {
+      if ( !finalized )
+        throw std::runtime_error( "State layout not finalized." );
 
-private:
-  std::vector< VarInfo >                         variables;
-  std::unordered_map< std::string, std::size_t > name_to_index;
+      const auto& v = getInfo( name );
+      return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
+    }
 
-  bool finalized = false;
-  int  total_sz  = 0;
-};
+    /**
+     * @brief Const version of @ref getAs.
+     * @tparam View   Target view type (must have a matching `StateMapper` specialization).
+     * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
+     * @param base    Pointer to the beginning of the state vector.
+     * @param name    Name of the variable.
+     * @param args    Extra arguments forwarded to `StateMapper::map`.
+     * @return        The mapped view of the requested variable.
+     * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
+     */
+    template < class View, class... Args >
+    View getAs( const double* base, const std::string& name, Args&&... args ) const
+    {
+      if ( !finalized )
+        throw std::runtime_error( "State layout not finalized." );
+
+      const auto& v = getInfo( name );
+      return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
+    }
+
+    /**
+     * @brief Return the total size (in units of `double`) of the state layout.
+     * This is the size of the state vector required to hold all registered variables.
+     */
+    int totalSize() const { return total_sz; }
+
+    /**
+     * @brief Check if the layout has been finalized.
+     * @return `true` if finalize() has been called, `false` otherwise.
+     */
+    bool isFinalized() const { return finalized; }
+
+  private:
+    std::vector< VarInfo >                         variables;
+    std::unordered_map< std::string, std::size_t > name_to_index;
+
+    bool finalized = false;
+    int  total_sz  = 0;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotUtils.h
+++ b/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotUtils.h
@@ -24,13 +24,17 @@
  */
 #pragma once
 
-/** @struct StateView
- * @brief Structure to hold a pointer to the state location and its size.
- *
- * This structure is used to provide a view of the state variables in a finite element or material,
- * allowing access to the state data without copying it.
- */
-struct StateView {
-  double* stateLocation; ///< Pointer to the first element of the state variable block.
-  int     stateSize;     ///< Number of `double` values in the state variable block.
-};
+namespace Marmot {
+
+  /** @struct StateView
+   * @brief Structure to hold a pointer to the state location and its size.
+   *
+   * This structure is used to provide a view of the state variables in a finite element or material,
+   * allowing access to the state data without copying it.
+   */
+  struct StateView {
+    double* stateLocation; ///< Pointer to the first element of the state variable block.
+    int     stateSize;     ///< Number of `double` values in the state variable block.
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotUtilitiesCore/src/MarmotJournal.cpp
+++ b/modules/core/MarmotUtilitiesCore/src/MarmotJournal.cpp
@@ -1,27 +1,31 @@
 #include "Marmot/MarmotJournal.h"
 
-MarmotJournal& MarmotJournal::getInstance()
-{
-  static MarmotJournal instance;
+namespace Marmot {
 
-  return instance;
-}
+  MarmotJournal& MarmotJournal::getInstance()
+  {
+    static MarmotJournal instance;
 
-MarmotJournal::MarmotJournal() : output( nullptr ) {}
+    return instance;
+  }
 
-void MarmotJournal::setMSGOutputDirection( std::ostream& newOutputStream )
-{
-  getInstance().output.rdbuf( newOutputStream.rdbuf() );
-}
+  MarmotJournal::MarmotJournal() : output( nullptr ) {}
 
-bool MarmotJournal::warningToMSG( const std::string& message )
-{
-  getInstance().output << message;
-  return false;
-}
+  void MarmotJournal::setMSGOutputDirection( std::ostream& newOutputStream )
+  {
+    getInstance().output.rdbuf( newOutputStream.rdbuf() );
+  }
 
-bool MarmotJournal::notificationToMSG( const std::string& message )
-{
-  getInstance().output << message;
-  return true;
-}
+  bool MarmotJournal::warningToMSG( const std::string& message )
+  {
+    getInstance().output << message;
+    return false;
+  }
+
+  bool MarmotJournal::notificationToMSG( const std::string& message )
+  {
+    getInstance().output << message;
+    return true;
+  }
+
+} // namespace Marmot

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -431,10 +431,10 @@ namespace Marmot::Elements {
   {
     for ( auto& qp : qps ) {
       qp.material = std::unique_ptr< MarmotMaterialHypoElastic >(
-        MarmotLibrary::MarmotMaterialHypoElasticFactory::createMaterial( section.materialName,
-                                                                         section.materialProperties,
-                                                                         section.nMaterialProperties,
-                                                                         elLabel ) );
+        Marmot::Registration::MarmotMaterialHypoElasticFactory::createMaterial( section.materialName,
+                                                                                section.materialProperties,
+                                                                                section.nMaterialProperties,
+                                                                                elLabel ) );
 
       if ( !qp.material )
         throw std::invalid_argument( MakeString()

--- a/modules/elements/DisplacementFiniteElement/src/DisplacementFiniteElementRegistration.cpp
+++ b/modules/elements/DisplacementFiniteElement/src/DisplacementFiniteElementRegistration.cpp
@@ -8,12 +8,13 @@ namespace Marmot::Elements::Registration {
   template < class T,
              Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
              typename T::SectionType                             sectionType >
-  MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+  Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
   {
     return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
   }
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
   using namespace Marmot::FiniteElement::Quadrature;
 
   const static bool CPS4_isRegistered = MarmotElementFactory::
@@ -46,19 +47,19 @@ namespace Marmot::Elements::Registration {
                                           FullIntegration,
                                           DisplacementFiniteElement< 2, 8 >::PlaneStrain >() );
 
-  const static bool C3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D8",
                      makeFactoryFunction< DisplacementFiniteElement< 3, 8 >,
                                           FullIntegration,
                                           DisplacementFiniteElement< 3, 8 >::SectionType::Solid >() );
 
-  const static bool C3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20",
                      makeFactoryFunction< DisplacementFiniteElement< 3, 20 >,
                                           FullIntegration,
                                           DisplacementFiniteElement< 3, 20 >::SectionType::Solid >() );
 
-  const static bool C3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20R",
                      makeFactoryFunction< DisplacementFiniteElement< 3, 20 >,
                                           ReducedIntegration,
@@ -74,5 +75,6 @@ namespace Marmot::Elements::Registration {
     constexpr static int nIndicesToBeWrapped  = 2;
     return new MarmotElementSpatialWrapper( 2, 1, 2, 2, indicesToBeWrapped, nIndicesToBeWrapped, std::move( uelT2D2 ) );
   }
-  const static bool T2D2_isRegistered = MarmotLibrary::MarmotElementFactory::registerElement( "T2D2", generateT2D2 );
+  const static bool T2D2_isRegistered = Marmot::Registration::MarmotElementFactory::registerElement( "T2D2",
+                                                                                                     generateT2D2 );
 } // namespace Marmot::Elements::Registration

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -496,10 +496,10 @@ namespace Marmot::Elements {
 
     for ( auto& qp : qps ) {
       qp.material = std::unique_ptr< Material >(
-        MarmotLibrary::MarmotMaterialFiniteStrainFactory::createMaterial( section.materialName,
-                                                                          section.materialProperties,
-                                                                          section.nMaterialProperties,
-                                                                          elLabel ) );
+        Marmot::Registration::MarmotMaterialFiniteStrainFactory::createMaterial( section.materialName,
+                                                                                 section.materialProperties,
+                                                                                 section.nMaterialProperties,
+                                                                                 elLabel ) );
     }
   }
 

--- a/modules/elements/DisplacementFiniteStrainULElement/src/DisplacementFiniteStrainULElement.cpp
+++ b/modules/elements/DisplacementFiniteStrainULElement/src/DisplacementFiniteStrainULElement.cpp
@@ -7,12 +7,13 @@ namespace Marmot::Elements::Registration {
   template < class T,
              Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
              typename T::SectionType                             sectionType >
-  MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+  Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
   {
     return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
   }
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
   using namespace Marmot::FiniteElement::Quadrature;
 
   const static bool CX8RUL_isRegistered = MarmotElementFactory::
@@ -39,19 +40,19 @@ namespace Marmot::Elements::Registration {
                                           FullIntegration,
                                           DisplacementFiniteStrainULElement< 2, 8 >::PlaneStrain >() );
 
-  const static bool C3D8UL_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D8UL_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D8UL",
                      makeFactoryFunction< DisplacementFiniteStrainULElement< 3, 8 >,
                                           FullIntegration,
                                           DisplacementFiniteStrainULElement< 3, 8 >::SectionType::Solid >() );
 
-  const static bool C3D20RUL_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20RUL_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20RUL",
                      makeFactoryFunction< DisplacementFiniteStrainULElement< 3, 20 >,
                                           ReducedIntegration,
                                           DisplacementFiniteStrainULElement< 3, 20 >::SectionType::Solid >() );
 
-  const static bool C3D20UL_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20UL_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20UL",
                      makeFactoryFunction< DisplacementFiniteStrainULElement< 3, 20 >,
                                           FullIntegration,

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -472,7 +472,7 @@ namespace Marmot::Elements {
   {
     for ( auto& qp : qps ) {
       qp.material = std::unique_ptr< MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables > >(
-        MarmotLibrary::MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< nNonlocalVariables >::
+        Marmot::Registration::MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< nNonlocalVariables >::
           createMaterial( section.materialName, section.materialProperties, section.nMaterialProperties, elLabel ) );
     }
   }

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/src/GeneralGradientEnhancedDisplacementFiniteElementRegistration.cpp
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/src/GeneralGradientEnhancedDisplacementFiniteElementRegistration.cpp
@@ -7,12 +7,13 @@ namespace Marmot::Elements::Registration {
   template < class T,
              Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
              typename T::SectionType                             sectionType >
-  MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+  Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
   {
     return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
   }
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
   using namespace Marmot::FiniteElement::Quadrature;
 
   const static bool GCPS4_isRegistered = MarmotElementFactory::
@@ -49,21 +50,21 @@ namespace Marmot::Elements::Registration {
                                           ReducedIntegration,
                                           GeneralGradientEnhancedDisplacementFiniteElement< 2, 8 >::PlaneStrain >() );
 
-  const static bool GC3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool GC3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "GC3D8",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8 >::SectionType::Solid >() );
 
-  const static bool GC3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool GC3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "GC3D20",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20 >::SectionType::Solid >() );
 
-  const static bool GC3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool GC3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "GC3D20R",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20 >,
@@ -91,21 +92,21 @@ namespace Marmot::Elements::Registration {
                        ReducedIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 2, 8, 2 >::PlaneStress >() );
 
-  const static bool G2GC3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G2GC3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G2GC3D8",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 2 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 2 >::SectionType::Solid >() );
 
-  const static bool G2GC3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G2GC3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G2GC3D20",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 2 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 2 >::SectionType::Solid >() );
 
-  const static bool G2GC3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G2GC3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G2GC3D20R",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 2 >,
@@ -119,21 +120,21 @@ namespace Marmot::Elements::Registration {
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 2, 8, 6 >::PlaneStress >() );
 
-  const static bool G6GC3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D8",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 6 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 6 >::SectionType::Solid >() );
 
-  const static bool G6GC3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6 >::SectionType::Solid >() );
 
-  const static bool G6GC3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20R",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6 >,
@@ -147,14 +148,14 @@ namespace Marmot::Elements::Registration {
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 2, 8, 6, 4 >::PlaneStress >() );
 
-  const static bool G6GC3D20RM_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20RM_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20RM",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6, 8 >,
                        ReducedIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6, 8 >::SectionType::Solid >() );
 
-  const static bool G6GC3D20M_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20M_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20M",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6, 8 >,

--- a/modules/materials/ADCompressibleNeoHooke/src/ADCompressibleNeoHookeRegistration.cpp
+++ b/modules/materials/ADCompressibleNeoHooke/src/ADCompressibleNeoHookeRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool
       ADCompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< ADCompressibleNeoHooke >(

--- a/modules/materials/ADLinearElastic/src/ADLinearElasticRegistration.cpp
+++ b/modules/materials/ADLinearElastic/src/ADLinearElasticRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool
       ADLinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADLinearElastic >(

--- a/modules/materials/ADLinearElastic/test/test.cpp
+++ b/modules/materials/ADLinearElastic/test/test.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotTesting.h"
 #include "Marmot/MarmotTypedefs.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::Solvers;
 

--- a/modules/materials/ADVonMises/src/ADVonMisesRegistration.cpp
+++ b/modules/materials/ADVonMises/src/ADVonMisesRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool ADVonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADVonMises >(
       "ADVONMISES" );

--- a/modules/materials/AT2PhaseField/src/AT2PhaseFieldRegistration.cpp
+++ b/modules/materials/AT2PhaseField/src/AT2PhaseFieldRegistration.cpp
@@ -30,11 +30,11 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool AT2PhaseFieldIsRegistered = MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
       1 >::registerMaterial< AT2PhaseField >( "AT2PHASEFIELD" );
 
   } // namespace Registration
-
 } // namespace Marmot::Materials

--- a/modules/materials/B4/src/B4Registration.cpp
+++ b/modules/materials/B4/src/B4Registration.cpp
@@ -3,7 +3,8 @@
 
 namespace Marmot::Materials::Registration {
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
   const static bool B4isRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< B4 >( "B4" );
 

--- a/modules/materials/CompressibleFiniteStrainLinearViscoelasticity/src/CompressibleFiniteStrainLinearViscoelasticityRegistration.cpp
+++ b/modules/materials/CompressibleFiniteStrainLinearViscoelasticity/src/CompressibleFiniteStrainLinearViscoelasticityRegistration.cpp
@@ -6,7 +6,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool CompressibleFiniteStrainLinearViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
       registerMaterial< CompressibleFiniteStrainLinearViscoelasticity >(

--- a/modules/materials/CompressibleNeoHooke/src/CompressibleNeoHookeRegistration.cpp
+++ b/modules/materials/CompressibleNeoHooke/src/CompressibleNeoHookeRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool
       CompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< CompressibleNeoHooke >(

--- a/modules/materials/FiniteStrainIsotropicBiotViscoelasticity/src/FiniteStrainIsotropicBiotViscoelasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainIsotropicBiotViscoelasticity/src/FiniteStrainIsotropicBiotViscoelasticityRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool FiniteStrainIsotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
       registerMaterial< FiniteStrainIsotropicBiotViscoelasticity >( "FINITESTRAINISOTROPICBIOTVISCOELASTICITY" );

--- a/modules/materials/FiniteStrainJ2Plasticity/src/FiniteStrainJ2PlasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainJ2Plasticity/src/FiniteStrainJ2PlasticityRegistration.cpp
@@ -6,7 +6,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool FiniteStrainJ2PlasticityRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
       FiniteStrainJ2Plasticity >( "FINITESTRAINJ2PLASTICITY" );

--- a/modules/materials/FiniteStrainOrthotropicBiotViscoelasticity/src/FinitStrainOrthotropicBiotViscoelasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainOrthotropicBiotViscoelasticity/src/FinitStrainOrthotropicBiotViscoelasticityRegistration.cpp
@@ -6,7 +6,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool FiniteStrainOrthotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
       registerMaterial< FiniteStrainOrthotropicBiotViscoelasticity >( "FINITESTRAINORTHOTROPICBIOTVISCOELASTICITY" );

--- a/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
+++ b/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool LinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< LinearElastic >(
       "LINEARELASTIC" );

--- a/modules/materials/LinearViscoelasticOrthotropicPowerLaw/src/LinearViscoelasticOrthotropicPowerLawRegistration.cpp
+++ b/modules/materials/LinearViscoelasticOrthotropicPowerLaw/src/LinearViscoelasticOrthotropicPowerLawRegistration.cpp
@@ -3,7 +3,8 @@
 
 namespace Marmot::Materials::Registration {
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
   const static bool LinearViscoelasticOrthotropicPowerLawisRegistered = MarmotMaterialHypoElasticFactory::
     registerMaterial< LinearViscoelasticOrthotropicPowerLaw >( "LINEARVISCOELASTICORTHOTROPICPOWERLAW" );

--- a/modules/materials/LinearViscoelasticPowerLaw/src/LinearViscoelasticPowerLawRegistration.cpp
+++ b/modules/materials/LinearViscoelasticPowerLaw/src/LinearViscoelasticPowerLawRegistration.cpp
@@ -3,7 +3,8 @@
 
 namespace Marmot::Materials::Registration {
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
   const static bool LinearViscoelasticPowerLawisRegistered = MarmotMaterialHypoElasticFactory::registerMaterial<
     LinearViscoelasticPowerLaw >( "LINEARVISCOELASTICPOWERLAW" );

--- a/modules/materials/VonMises/src/VonMisesRegistration.cpp
+++ b/modules/materials/VonMises/src/VonMisesRegistration.cpp
@@ -5,11 +5,11 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool VonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< VonMisesModel >(
       "VONMISES" );
 
   } // namespace Registration
-
 } // namespace Marmot::Materials


### PR DESCRIPTION
## Summary
Stage 2 of a 3-stage namespace cleanup. **Stacked on #65** -- this PR's branch is built on top of `refactor/namespace-cleanup-stage1-base-classes`, so its diff currently includes PR #65's commit too. Once #65 merges, this diff will shrink to just this stage's commit (`rename MarmotLibrary namespace to Marmot::Registration`).

- `MarmotLibrary` was the only root-level namespace that broke the single-`Marmot::` convention -- it held the element/material factory and registration machinery as a separate sibling root.
- Renames it to `Marmot::Registration`, matching the existing nested `Marmot::Materials::Registration` / `Marmot::Elements::Registration` pattern already used per-module.
- Pure rename, no behavior changes. A short comment is added at each `using namespace Marmot::Registration;` site inside a `*Registration.cpp` file, since those files also open their own `Marmot::Materials::Registration`/`Marmot::Elements::Registration` scope -- the comment clarifies the two `::Registration` namespaces are distinct.

## Stack
1. #65 -- base classes into `Marmot::`
2. **This PR** -- `MarmotLibrary` -> `Marmot::Registration`
3. `refactor/namespace-cleanup-stage3-style-cleanup` -- brace-style standardization + `using namespace` header cleanup (stacked on this PR)

## Test plan
- [x] `cmake --build .` -- clean, zero errors
- [x] `ctest --output-on-failure` -- 46/46 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)