### PR TITLE
refactor: standardize namespace brace style and remove using-namespace from headers

### DIFF
--- a/doc/pages/features/at2phasefield.rst
+++ b/doc/pages/features/at2phasefield.rst
@@ -79,7 +79,7 @@ Implementation
 --------------
 
 The model is implemented within the general gradient-enhanced hypoelastic framework
-(:cpp:class:`MarmotMaterialGeneralGradientEnhancedHypoElastic`), treating the phase-field
+(:cpp:class:`Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic`), treating the phase-field
 variable :math:`d` as the single nonlocal variable (:math:`\bar\kappa = d`).
 The gradient enhancement coefficient is constant: :math:`c = l^2`.
 

--- a/doc/pages/features/displacementfinitestrainelement.rst
+++ b/doc/pages/features/displacementfinitestrainelement.rst
@@ -5,7 +5,7 @@ Preliminaries
 -------------
 This element formulation is implemented in the class :cpp:class:`Marmot::Elements::DisplacementFiniteStrainULElement`, which represents a displacement-based finite element considering large deformations. The formulation is valid for general three-dimensional geometries and can be combined with arbitrary material models. It supports both body forces and surface tractions.
 
-This class inherits from the abstract base classes :cpp:class:`MarmotElement` and :cpp:class:`MarmotGeometryElement`, which provide common functionality for all finite elements in **Marmot**. In addition, it serves as a base class for specializations such as plane strain and axisymmetric elements.
+This class inherits from the abstract base classes :cpp:class:`Marmot::MarmotElement` and :cpp:class:`Marmot::MarmotGeometryElement`, which provide common functionality for all finite elements in **Marmot**. In addition, it serves as a base class for specializations such as plane strain and axisymmetric elements.
 
 Throughout the following derivations, Einstein summation convention is used, i.e., repeated indices imply summation. Uppercase indices refer to material coordinates, while lowercase indices refer to spatial coordinates. Accordingly, lowercase subscripts preceded by a comma denote spatial derivatives with respect to the current (deformed) configuration, e.g., :math:`(\bullet)_{,i} = \partial (\bullet)/\partial x_i`, while uppercase subscripts preceded by a comma denote material derivatives with respect to the reference (undeformed) configuration, e.g., :math:`(\bullet)_{,I} = \partial (\bullet)/\partial X_I`. Following this convention, the deformation gradient and its determinant is defined as
 

--- a/doc/pages/interfaces.md
+++ b/doc/pages/interfaces.md
@@ -27,7 +27,7 @@ A singularity container recipe is [available](https://github.com/matthiasneuner/
 
 ## Create your custom interface
 
-To create your custom interface to Marmot, you can leverage the `MarmotLibrary::MarmotMaterialHypoElasticFactory` and `MarmotLibrary::MarmotElementFactory` factories to create
+To create your custom interface to Marmot, you can leverage the `Marmot::Registration::MarmotMaterialHypoElasticFactory` and `Marmot::Registration::MarmotElementFactory` factories to create
 instances of registered material models and finite elements.
 Marmot provides two main base classes for materials:
 
@@ -43,7 +43,7 @@ which belongs to the class of `Marmot::MarmotMaterialHypoElastic` materials, and
 
 // Create the instance by material name
 auto material = std::unique_ptr<Marmot::MarmotMaterialHypoElastic>(
-        MarmotLibrary::MarmotMaterialHypoElasticFactory::createMaterial(
+        Marmot::Registration::MarmotMaterialHypoElasticFactory::createMaterial(
             "LINEARELASTIC", materialProperties, nMaterialProperties, anArbitraryIdentificationCode ));
 
 // assign a characteristic length parameter (specific to hypoelastic materials)
@@ -75,7 +75,7 @@ For instance, the `LinearElastic` material is registered as
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
 const static bool LinearElasticIsRegistered =
-    MarmotLibrary::MarmotMaterialHypoElasticFactory::registerMaterial< Marmot::Materials::LinearElastic >(
+    Marmot::Registration::MarmotMaterialHypoElasticFactory::registerMaterial< Marmot::Materials::LinearElastic >(
         "LINEARELASTIC" );
 ```
 
@@ -89,12 +89,12 @@ For instance, the 4-node plane strain displacement finite element "CPE4" is regi
 template < class T,
            Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
            typename T::SectionType                             sectionType >
-MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
 {
     return []( int elementID ) -> Marmot::MarmotElement* { return new T( elementID, integrationType, sectionType ); };
 }
 
-const static bool CPE4_isRegistered = MarmotLibrary::MarmotElementFactory::
+const static bool CPE4_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "CPE4",
                      makeFactoryFunction< DisplacementFiniteElement< 2, 4 >,
                                           FullIntegration,
@@ -111,7 +111,7 @@ int elementNumber = 1;
 
 // create the instance by element name
 auto theElement = std::unique_ptr<Marmot::MarmotElement>(
-        MarmotLibrary::MarmotElementFactory::createElement( "CPE4", elementNumber ) );
+        Marmot::Registration::MarmotElementFactory::createElement( "CPE4", elementNumber ) );
 
 // assign nodal coordinates
 theElement->assignNodeCoordinates( coordinates );

--- a/doc/pages/interfaces.md
+++ b/doc/pages/interfaces.md
@@ -31,18 +31,18 @@ To create your custom interface to Marmot, you can leverage the `MarmotLibrary::
 instances of registered material models and finite elements.
 Marmot provides two main base classes for materials:
 
-- `MarmotMaterialHypoElastic` — for small-strain materials formulated in rate form (hypoelastic constitutive relations).
-- `MarmotMaterialFiniteStrain` — for large-strain materials formulated in terms of the deformation gradient.
+- `Marmot::MarmotMaterialHypoElastic` — for small-strain materials formulated in rate form (hypoelastic constitutive relations).
+- `Marmot::MarmotMaterialFiniteStrain` — for large-strain materials formulated in terms of the deformation gradient.
 
-Finite elements are derived from the general parent class `MarmotElement`.
+Finite elements are derived from the general parent class `Marmot::MarmotElement`.
 
 For instance, the following procedure may be employed to create an instance of a `Marmot::Materials::LinearElastic` material model,
-which belongs to the class of `MarmotMaterialHypoElastic` materials, and compute the current stress state:
+which belongs to the class of `Marmot::MarmotMaterialHypoElastic` materials, and compute the current stress state:
 ```cpp
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
 // Create the instance by material name
-auto material = std::unique_ptr<MarmotMaterialHypoElastic>(
+auto material = std::unique_ptr<Marmot::MarmotMaterialHypoElastic>(
         MarmotLibrary::MarmotMaterialHypoElasticFactory::createMaterial(
             "LINEARELASTIC", materialProperties, nMaterialProperties, anArbitraryIdentificationCode ));
 
@@ -53,15 +53,15 @@ material->setCharacteristicElementLength( theCharacteristicElementLength );
 const int             nStateVars = material->getNumberOfRequiredStateVars();
 std::vector< double > stateVars( nStateVars, 0.0 );
 
-MarmotMaterialHypoElastic::state3D state = MarmotMaterialHypoElastic::state3D()
+Marmot::MarmotMaterialHypoElastic::state3D state = Marmot::MarmotMaterialHypoElastic::state3D()
 state.stateVars           = stateVars.data();
 
 // compute stresses
-Marmot::Matrix6d                          dStress_dStrain;
-const Marmot::Vector6d                    dStrain  = Marmot::Vector6d::Zero(); // strain increment
-const double                              time     = 0.0;                      // current time
-const double                              dTime    = 0.01;                     // time increment
-const MarmotMaterialHypoElastic::timeInfo timeInfo = { time, dTime };
+Marmot::Matrix6d                                  dStress_dStrain;
+const Marmot::Vector6d                            dStrain  = Marmot::Vector6d::Zero(); // strain increment
+const double                                      time     = 0.0;                      // current time
+const double                                      dTime    = 0.01;                     // time increment
+const Marmot::MarmotMaterialHypoElastic::timeInfo timeInfo = { time, dTime };
 material->computeStress( state, dStress_dStrain, dStrain, timeInfo );
 ```
 
@@ -91,7 +91,7 @@ template < class T,
            typename T::SectionType                             sectionType >
 MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
 {
-    return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
+    return []( int elementID ) -> Marmot::MarmotElement* { return new T( elementID, integrationType, sectionType ); };
 }
 
 const static bool CPE4_isRegistered = MarmotLibrary::MarmotElementFactory::
@@ -110,18 +110,18 @@ Creating a specific element instance and computing the kernel is straightforward
 int elementNumber = 1;
 
 // create the instance by element name
-auto theElement = std::unique_ptr<MarmotElement>(
+auto theElement = std::unique_ptr<Marmot::MarmotElement>(
         MarmotLibrary::MarmotElementFactory::createElement( "CPE4", elementNumber ) );
 
 // assign nodal coordinates
 theElement->assignNodeCoordinates( coordinates );
 
 // assign properties (e.g., thickness)
-theElement->assignProperty( ElementProperties( propertiesElement, nPropertiesElement ) );
+theElement->assignProperty( Marmot::ElementProperties( propertiesElement, nPropertiesElement ) );
 
 // assign a material section by material name
 // MarmotElement takes care to create the required instances of MarmotMaterial
-theElement->assignProperty( MarmotMaterialSection( "LINEARELASTIC", propertiesMaterial, nPropertiesMaterial ) );
+theElement->assignProperty( Marmot::MarmotMaterialSection( "LINEARELASTIC", propertiesMaterial, nPropertiesMaterial ) );
 
 // assign state vars to the element
 // MarmotElement automatically assigns the state vars also to MarmotMaterial instances

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotDofLayoutTools.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotDofLayoutTools.h
@@ -27,32 +27,29 @@
 #include <map>
 #include <vector>
 
-namespace Marmot {
+/**
+ * @brief Utilities for constructing DOF-layout structures in finite element assemblies.
+ */
+namespace Marmot::FiniteElement {
 
   /**
-   * @brief Utilities for constructing DOF-layout structures in finite element assemblies.
+   * @brief Builds a node-field layout from a map of field names to their DOF dimensions.
+   *
+   * @param fieldSizes Map from field name to a pair (nodesPerElement, dofsPerNode).
+   * @return A 2-D vector where each row corresponds to a node and each entry is a field name.
    */
-  namespace FiniteElement {
+  const std::vector< std::vector< std::string > > makeNodeFieldLayout(
+    const std::map< std::string, std::pair< int, int > >& fieldSizes );
 
-    /**
-     * @brief Builds a node-field layout from a map of field names to their DOF dimensions.
-     *
-     * @param fieldSizes Map from field name to a pair (nodesPerElement, dofsPerNode).
-     * @return A 2-D vector where each row corresponds to a node and each entry is a field name.
-     */
-    const std::vector< std::vector< std::string > > makeNodeFieldLayout(
-      const std::map< std::string, std::pair< int, int > >& fieldSizes );
+  /**
+   * @brief Computes the DOF permutation pattern for a blocked (field-major) layout.
+   *
+   * @param nodeFields     Node-field layout as returned by @ref makeNodeFieldLayout.
+   * @param fieldSizes     Map from field name to a pair (nodesPerElement, dofsPerNode).
+   * @return Integer permutation vector that reorders DOFs from node-major to field-major order.
+   */
+  std::vector< int > makeBlockedLayoutPermutationPattern(
+    const std::vector< std::vector< std::string > >&      nodeFields,
+    const std::map< std::string, std::pair< int, int > >& fieldSizes );
 
-    /**
-     * @brief Computes the DOF permutation pattern for a blocked (field-major) layout.
-     *
-     * @param nodeFields     Node-field layout as returned by @ref makeNodeFieldLayout.
-     * @param fieldSizes     Map from field name to a pair (nodesPerElement, dofsPerNode).
-     * @return Integer permutation vector that reorders DOFs from node-major to field-major order.
-     */
-    std::vector< int > makeBlockedLayoutPermutationPattern(
-      const std::vector< std::vector< std::string > >&      nodeFields,
-      const std::map< std::string, std::pair< int, int > >& fieldSizes );
-
-  } // namespace FiniteElement
-} // namespace Marmot
+} // namespace Marmot::FiniteElement

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElement.h
@@ -30,251 +30,255 @@
 #include <string>
 #include <vector>
 
-/**
- * @class MarmotElement
- * @brief Abstract base class for finite elements in the Marmot framework.
- *
- * This class defines the generic interface for finite elements, including
- * methods for state variable handling, geometry, degrees of freedom,
- * initialization, loading, and numerical integration. Concrete element
- * implementations must override the pure virtual functions.
- */
-class MarmotElement {
-
-public:
-  /** @brief Types of element state variables used in initialization and output. */
-  enum StateTypes {
-
-    Sigma11,                      ///< Normal stress component σ₁₁.
-    Sigma22,                      ///< Normal stress component σ₂₂.
-    Sigma33,                      ///< Normal stress component σ₃₃.
-    HydrostaticStress,            ///< Hydrostatic (mean) stress.
-    GeostaticStress,              ///< Geostatic in-situ stress state.
-    MarmotMaterialStateVars,      ///< Internal material state variables.
-    MarmotMaterialInitialization, ///< Trigger for material model initialization.
-    HasEigenDeformation,          ///< Flag indicating presence of eigen (initial) deformation.
-  };
-
-  /** @brief Types of distributed loads applicable to element boundaries. */
-  enum DistributedLoadTypes {
-    Pressure,        ///< Pressure load (normal to surface)
-    SurfaceTorsion,  ///< Surface torsional load
-    SurfaceTraction, ///< Surface traction vector
-  };
-
-  /** @brief Virtual destructor for safe polymorphic cleanup. */
-  virtual ~MarmotElement();
-
-  /** @return Number of state variables required by the element. */
-  virtual int getNumberOfRequiredStateVars() = 0;
+namespace Marmot {
 
   /**
-   * @brief Get the nodal field names (e.g. displacement, rotation).
-   * @return A 2D vector of strings representing the fields per node.
-   */
-  virtual std::vector< std::vector< std::string > > getNodeFields() = 0;
-
-  /**
-   * @brief Get permutation pattern for degrees of freedom.
-   * @return Vector of indices describing the permutation.
-   */
-  virtual std::vector< int > getDofIndicesPermutationPattern() = 0;
-
-  /** @return Number of nodes in the element. */
-  virtual int getNNodes() = 0;
-
-  /** @return Number of spatial dimensions (2D/3D). */
-  virtual int getNSpatialDimensions() = 0;
-
-  /** @return Number of degrees of freedom per element. */
-  virtual int getNDofPerElement() = 0;
-
-  /** @return String describing the element shape in Ensight Gold notation (e.g. "quad4", "hexa8"). */
-  virtual std::string getElementShape() = 0;
-
-  /**
-   * @brief Assign state variable array to element.
-   * @param[in,out] stateVars Pointer to state variable array.
-   * @param[in] nStateVars Number of state variables.
-   */
-  virtual void assignStateVars( double* stateVars, int nStateVars ) = 0;
-
-  /**
-   * @brief Assign element property set.
-   * @param[in] property Element property object containing material, geometry, etc.
-   */
-  virtual void assignProperty( const ElementProperties& property );
-
-  /**
-   * @brief Assign material section property.
-   * @param[in] property Material section definition (e.g. cross-sectional data).
-   */
-  virtual void assignProperty( const MarmotMaterialSection& property );
-
-  /**
-   * @brief Assign a single property of the element by name.
-   * @param[in] propertyName Name of the property.
-   * @param[in] properties Pointer to the array of property values.
-   * @note Default implementation throws an exception, as an element not overriding this
-   * interface does not support any named properties.
-   */
-  virtual void assignProperty( const std::string& propertyName, const double* properties )
-  {
-    throw std::invalid_argument( MakeString()
-                                 << __PRETTY_FUNCTION__ << ": unsupported named property '" << propertyName << "'" );
-  };
-
-  /**
-   * @brief Get the names of all the valid properties of the element.
-   * @return Vector of strings containing the property names.
-   * @note Default implementation returns an empty vector, as an element not overriding this
-   * interface does not expose any named properties.
-   */
-  virtual std::vector< std::string > getPropertyNames() const { return {}; };
-
-  /**
-   * @brief Assign nodal coordinates to element.
-   * @param[in] coordinates Pointer to array of nodal coordinates.
-   */
-  virtual void assignNodeCoordinates( const double* coordinates ) = 0;
-
-  /** @brief Initialize element state and internal variables. */
-  virtual void initializeYourself() = 0;
-
-  /**
-   * @brief Apply initial conditions to the element.
-   * @param[in] state State type to be set.
-   * @param[in] values Array of initial values.
-   */
-  virtual void setInitialConditions( StateTypes state, const double* values ) = 0;
-
-  /**
-   * @brief Perform element computations (stiffness, residual, etc.).
-   * @param[in] QTotal Total dof vector.
-   * @param[in] dQ Incremental dof vector.
-   * @param[out] Pint Internal force vector.
-   * @param[out] K Stiffness matrix.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
-   */
-  virtual void computeKernels( const double* QTotal,
-                               const double* dQ,
-                               double*       Pint,
-                               double*       K,
-                               double        time,
-                               double        dT ) = 0;
-
-  /**
-   * @brief Perform element computations for explicit time integration.
-   * @param[in] QTotal Total dof vector.
-   * @param[in] dQ Incremental dof vector.
-   * @param[out] Pint Internal force vector.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
+   * @class MarmotElement
+   * @brief Abstract base class for finite elements in the Marmot framework.
    *
-   * @note Default implementation throws an exception.
+   * This class defines the generic interface for finite elements, including
+   * methods for state variable handling, geometry, degrees of freedom,
+   * initialization, loading, and numerical integration. Concrete element
+   * implementations must override the pure virtual functions.
    */
-  virtual void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pint, double time, double dT )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-  /**
-   * @brief Compute contribution from distributed surface loads.
-   * @param[in] loadType Type of load.
-   * @param[out] Pext External load vector.
-   * @param[out] K Stiffness matrix.
-   * @param[in] elementFace Index of element face.
-   * @param[in] load Applied load values.
-   * @param[in] QTotal Total dof vector.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
-   */
-  virtual void computeDistributedLoad( DistributedLoadTypes loadType,
-                                       double*              Pext,
-                                       double*              K,
-                                       int                  elementFace,
-                                       const double*        load,
-                                       const double*        QTotal,
-                                       double               time,
-                                       double               dT ) = 0;
+  class MarmotElement {
 
-  /**
-   * @brief Compute contribution from body forces.
-   * @param[out] Pext External load vector.
-   * @param[out] K Stiffness matrix.
-   * @param[in] load Body force vector.
-   * @param[in] QTotal Total displacement vector.
-   * @param[in] time Current time.
-   * @param[in] dT Time step size.
-   */
-  virtual void computeBodyForce( double*       Pext,
+  public:
+    /** @brief Types of element state variables used in initialization and output. */
+    enum StateTypes {
+
+      Sigma11,                      ///< Normal stress component σ₁₁.
+      Sigma22,                      ///< Normal stress component σ₂₂.
+      Sigma33,                      ///< Normal stress component σ₃₃.
+      HydrostaticStress,            ///< Hydrostatic (mean) stress.
+      GeostaticStress,              ///< Geostatic in-situ stress state.
+      MarmotMaterialStateVars,      ///< Internal material state variables.
+      MarmotMaterialInitialization, ///< Trigger for material model initialization.
+      HasEigenDeformation,          ///< Flag indicating presence of eigen (initial) deformation.
+    };
+
+    /** @brief Types of distributed loads applicable to element boundaries. */
+    enum DistributedLoadTypes {
+      Pressure,        ///< Pressure load (normal to surface)
+      SurfaceTorsion,  ///< Surface torsional load
+      SurfaceTraction, ///< Surface traction vector
+    };
+
+    /** @brief Virtual destructor for safe polymorphic cleanup. */
+    virtual ~MarmotElement();
+
+    /** @return Number of state variables required by the element. */
+    virtual int getNumberOfRequiredStateVars() = 0;
+
+    /**
+     * @brief Get the nodal field names (e.g. displacement, rotation).
+     * @return A 2D vector of strings representing the fields per node.
+     */
+    virtual std::vector< std::vector< std::string > > getNodeFields() = 0;
+
+    /**
+     * @brief Get permutation pattern for degrees of freedom.
+     * @return Vector of indices describing the permutation.
+     */
+    virtual std::vector< int > getDofIndicesPermutationPattern() = 0;
+
+    /** @return Number of nodes in the element. */
+    virtual int getNNodes() = 0;
+
+    /** @return Number of spatial dimensions (2D/3D). */
+    virtual int getNSpatialDimensions() = 0;
+
+    /** @return Number of degrees of freedom per element. */
+    virtual int getNDofPerElement() = 0;
+
+    /** @return String describing the element shape in Ensight Gold notation (e.g. "quad4", "hexa8"). */
+    virtual std::string getElementShape() = 0;
+
+    /**
+     * @brief Assign state variable array to element.
+     * @param[in,out] stateVars Pointer to state variable array.
+     * @param[in] nStateVars Number of state variables.
+     */
+    virtual void assignStateVars( double* stateVars, int nStateVars ) = 0;
+
+    /**
+     * @brief Assign element property set.
+     * @param[in] property Element property object containing material, geometry, etc.
+     */
+    virtual void assignProperty( const ElementProperties& property );
+
+    /**
+     * @brief Assign material section property.
+     * @param[in] property Material section definition (e.g. cross-sectional data).
+     */
+    virtual void assignProperty( const MarmotMaterialSection& property );
+
+    /**
+     * @brief Assign a single property of the element by name.
+     * @param[in] propertyName Name of the property.
+     * @param[in] properties Pointer to the array of property values.
+     * @note Default implementation throws an exception, as an element not overriding this
+     * interface does not support any named properties.
+     */
+    virtual void assignProperty( const std::string& propertyName, const double* properties )
+    {
+      throw std::invalid_argument( MakeString()
+                                   << __PRETTY_FUNCTION__ << ": unsupported named property '" << propertyName << "'" );
+    };
+
+    /**
+     * @brief Get the names of all the valid properties of the element.
+     * @return Vector of strings containing the property names.
+     * @note Default implementation returns an empty vector, as an element not overriding this
+     * interface does not expose any named properties.
+     */
+    virtual std::vector< std::string > getPropertyNames() const { return {}; };
+
+    /**
+     * @brief Assign nodal coordinates to element.
+     * @param[in] coordinates Pointer to array of nodal coordinates.
+     */
+    virtual void assignNodeCoordinates( const double* coordinates ) = 0;
+
+    /** @brief Initialize element state and internal variables. */
+    virtual void initializeYourself() = 0;
+
+    /**
+     * @brief Apply initial conditions to the element.
+     * @param[in] state State type to be set.
+     * @param[in] values Array of initial values.
+     */
+    virtual void setInitialConditions( StateTypes state, const double* values ) = 0;
+
+    /**
+     * @brief Perform element computations (stiffness, residual, etc.).
+     * @param[in] QTotal Total dof vector.
+     * @param[in] dQ Incremental dof vector.
+     * @param[out] Pint Internal force vector.
+     * @param[out] K Stiffness matrix.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     */
+    virtual void computeKernels( const double* QTotal,
+                                 const double* dQ,
+                                 double*       Pint,
                                  double*       K,
-                                 const double* load,
-                                 const double* QTotal,
                                  double        time,
                                  double        dT ) = 0;
 
-  /**
-   * @brief Compute lumped inertia matrix.
-   * @param[out] I Inertia matrix.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeLumpedInertia( double* I )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    /**
+     * @brief Perform element computations for explicit time integration.
+     * @param[in] QTotal Total dof vector.
+     * @param[in] dQ Incremental dof vector.
+     * @param[out] Pint Internal force vector.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     *
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeKernelsExplicit( const double* QTotal, const double* dQ, double* Pint, double time, double dT )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+    /**
+     * @brief Compute contribution from distributed surface loads.
+     * @param[in] loadType Type of load.
+     * @param[out] Pext External load vector.
+     * @param[out] K Stiffness matrix.
+     * @param[in] elementFace Index of element face.
+     * @param[in] load Applied load values.
+     * @param[in] QTotal Total dof vector.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     */
+    virtual void computeDistributedLoad( DistributedLoadTypes loadType,
+                                         double*              Pext,
+                                         double*              K,
+                                         int                  elementFace,
+                                         const double*        load,
+                                         const double*        QTotal,
+                                         double               time,
+                                         double               dT ) = 0;
+
+    /**
+     * @brief Compute contribution from body forces.
+     * @param[out] Pext External load vector.
+     * @param[out] K Stiffness matrix.
+     * @param[in] load Body force vector.
+     * @param[in] QTotal Total displacement vector.
+     * @param[in] time Current time.
+     * @param[in] dT Time step size.
+     */
+    virtual void computeBodyForce( double*       Pext,
+                                   double*       K,
+                                   const double* load,
+                                   const double* QTotal,
+                                   double        time,
+                                   double        dT ) = 0;
+
+    /**
+     * @brief Compute lumped inertia matrix.
+     * @param[out] I Inertia matrix.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeLumpedInertia( double* I )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Compute consistent inertia matrix.
+     * @param[out] I Inertia matrix.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeConsistentInertia( double* I )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Compute critical time step for explicit dynamics.
+     * @param[out] criticalTimeStep Suggested critical time step size.
+     * @param[in] QTotal Total dof vector.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Compute internal energy of the element.
+     * @param[out] internalEnergy Computed internal energy.
+     * @note Default implementation throws an exception.
+     */
+    virtual void computeInternalEnergy( double& internalEnergy )
+    {
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
+    };
+
+    /**
+     * @brief Access element state at a quadrature point.
+     * @param[in] stateName Name of the state variable.
+     * @param[in] quadraturePoint Index of quadrature point.
+     * @return View into state variable.
+     */
+    virtual StateView getStateView( const std::string& stateName, int quadraturePoint ) = 0;
+
+    /**
+     * @brief Get coordinates of element center.
+     * @return Vector of coordinates at element centroid.
+     */
+    virtual std::vector< double > getCoordinatesAtCenter() = 0;
+
+    /**
+     * @brief Get coordinates of quadrature points.
+     * @return 2D vector of coordinates at quadrature points.
+     */
+    virtual std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints() = 0;
+
+    /** @return Number of quadrature points used by the element. */
+    virtual int getNumberOfQuadraturePoints() = 0;
   };
 
-  /**
-   * @brief Compute consistent inertia matrix.
-   * @param[out] I Inertia matrix.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeConsistentInertia( double* I )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-
-  /**
-   * @brief Compute critical time step for explicit dynamics.
-   * @param[out] criticalTimeStep Suggested critical time step size.
-   * @param[in] QTotal Total dof vector.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-
-  /**
-   * @brief Compute internal energy of the element.
-   * @param[out] internalEnergy Computed internal energy.
-   * @note Default implementation throws an exception.
-   */
-  virtual void computeInternalEnergy( double& internalEnergy )
-  {
-    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << " not yet implemented" );
-  };
-
-  /**
-   * @brief Access element state at a quadrature point.
-   * @param[in] stateName Name of the state variable.
-   * @param[in] quadraturePoint Index of quadrature point.
-   * @return View into state variable.
-   */
-  virtual StateView getStateView( const std::string& stateName, int quadraturePoint ) = 0;
-
-  /**
-   * @brief Get coordinates of element center.
-   * @return Vector of coordinates at element centroid.
-   */
-  virtual std::vector< double > getCoordinatesAtCenter() = 0;
-
-  /**
-   * @brief Get coordinates of quadrature points.
-   * @return 2D vector of coordinates at quadrature points.
-   */
-  virtual std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints() = 0;
-
-  /** @return Number of quadrature points used by the element. */
-  virtual int getNumberOfQuadraturePoints() = 0;
-};
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @class MarmotElementFactory
@@ -82,4 +82,4 @@ namespace MarmotLibrary {
     static ElementFactoryMap& elementFactoryFunctionByName();
   };
 
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementFactory.h
@@ -39,7 +39,7 @@ namespace MarmotLibrary {
   class MarmotElementFactory {
   public:
     /// @brief Factory function pointer type: takes an element number and returns a new MarmotElement.
-    using elementFactoryFunction = MarmotElement* (*)( int elementNumber );
+    using elementFactoryFunction = Marmot::MarmotElement* (*)( int elementNumber );
     MarmotElementFactory()       = delete;
 
     /**
@@ -49,12 +49,12 @@ namespace MarmotLibrary {
      * @return Pointer to the created MarmotElement instance.
      * @throws std::invalid_argument if @p elementName is not registered.
      */
-    static MarmotElement* createElement( const std::string& elementName, int elementNumber )
+    static Marmot::MarmotElement* createElement( const std::string& elementName, int elementNumber )
     {
       auto& map = elementFactoryFunctionByName();
       auto  it  = map.find( elementName );
       if ( it == map.end() ) {
-        throw std::invalid_argument( MakeString()
+        throw std::invalid_argument( Marmot::MakeString()
                                      << __PRETTY_FUNCTION__ << "Element " + elementName + " not registered!" );
       }
 

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementProperty.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotElementProperty.h
@@ -25,46 +25,50 @@
 #pragma once
 #include <string>
 
-/** @struct MarmotMaterialSection
- * @brief Structure to hold material section properties.
- *
- * This structure is used to define a material section with its code and properties,
- * allowing for flexible material definitions in finite element analysis.
- */
-class MarmotMaterialSection {
-public:
-  const std::string materialName;        ///< Name identifying the material model.
-  const double*     materialProperties;  ///< Pointer to the array of material property values.
-  int               nMaterialProperties; ///< Number of material property values.
+namespace Marmot {
 
-  /**
-   * @brief Construct a MarmotMaterialSection.
-   * @param[in] materialName       Name identifying the material model.
-   * @param[in] materialProperties Pointer to the array of material property values.
-   * @param[in] nMaterialProperties Number of material property values.
+  /** @struct MarmotMaterialSection
+   * @brief Structure to hold material section properties.
+   *
+   * This structure is used to define a material section with its code and properties,
+   * allowing for flexible material definitions in finite element analysis.
    */
-  MarmotMaterialSection( const std::string materialName, const double* materialProperties, int nMaterialProperties )
-    : materialName( materialName ),
-      materialProperties( materialProperties ),
-      nMaterialProperties( nMaterialProperties ){};
-};
+  class MarmotMaterialSection {
+  public:
+    const std::string materialName;        ///< Name identifying the material model.
+    const double*     materialProperties;  ///< Pointer to the array of material property values.
+    int               nMaterialProperties; ///< Number of material property values.
 
-/** @struct ElementProperties
- * @brief Structure to hold element properties.
- *
- * This structure is used to define properties of a finite element,
- * allowing for flexible element definitions in finite element analysis.
- */
-class ElementProperties {
-public:
-  const double* elementProperties;  ///< Pointer to the array of element property values.
-  int           nElementProperties; ///< Number of element property values.
+    /**
+     * @brief Construct a MarmotMaterialSection.
+     * @param[in] materialName       Name identifying the material model.
+     * @param[in] materialProperties Pointer to the array of material property values.
+     * @param[in] nMaterialProperties Number of material property values.
+     */
+    MarmotMaterialSection( const std::string materialName, const double* materialProperties, int nMaterialProperties )
+      : materialName( materialName ),
+        materialProperties( materialProperties ),
+        nMaterialProperties( nMaterialProperties ){};
+  };
 
-  /**
-   * @brief Construct an ElementProperties object.
-   * @param[in] elementProperties  Pointer to the array of element property values.
-   * @param[in] nElementProperties Number of element property values.
+  /** @struct ElementProperties
+   * @brief Structure to hold element properties.
+   *
+   * This structure is used to define properties of a finite element,
+   * allowing for flexible element definitions in finite element analysis.
    */
-  ElementProperties( const double* elementProperties, int nElementProperties )
-    : elementProperties( elementProperties ), nElementProperties( nElementProperties ){};
-};
+  class ElementProperties {
+  public:
+    const double* elementProperties;  ///< Pointer to the array of element property values.
+    int           nElementProperties; ///< Number of element property values.
+
+    /**
+     * @brief Construct an ElementProperties object.
+     * @param[in] elementProperties  Pointer to the array of element property values.
+     * @param[in] nElementProperties Number of element property values.
+     */
+    ElementProperties( const double* elementProperties, int nElementProperties )
+      : elementProperties( elementProperties ), nElementProperties( nElementProperties ){};
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotEnhancedAssumedStrain.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotEnhancedAssumedStrain.h
@@ -25,43 +25,41 @@
 #pragma once
 #include "Marmot/MarmotTypedefs.h"
 
-namespace Marmot {
+/**
+ * @brief Enhanced Assumed Strain (EAS) element enrichment utilities.
+ *
+ * Functions and enumerations for constructing the EAS interpolation matrices
+ * used in incompatible-mode and enhanced assumed strain finite element
+ * formulations (de Borst, Simo & Rifai variants).
+ */
+namespace Marmot::FiniteElement::EAS {
+
   /**
-   * @brief Enhanced Assumed Strain (EAS) element enrichment utilities.
-   *
-   * Functions and enumerations for constructing the EAS interpolation matrices
-   * used in incompatible-mode and enhanced assumed strain finite element
-   * formulations (de Borst, Simo & Rifai variants).
+   * @brief Supported EAS enrichment types.
    */
-  namespace FiniteElement::EAS {
+  enum EASType {
+    DeBorstEAS2,    ///< De Borst 2-parameter EAS
+    DeBorstEAS2_P2, ///< De Borst 2-parameter EAS, variant P2
+    EAS3,           ///< 3-parameter EAS
+    DeBorstEAS6b,   ///< De Borst 6-parameter EAS, variant b
+    DeBorstEAS9,    ///< De Borst 9-parameter EAS
+    SimoRifaiEAS5,  ///< Simo–Rifai 5-parameter EAS
+    SimoRifaiEAS4,  ///< Simo–Rifai 4-parameter EAS
+  };
 
-    /**
-     * @brief Supported EAS enrichment types.
-     */
-    enum EASType {
-      DeBorstEAS2,    ///< De Borst 2-parameter EAS
-      DeBorstEAS2_P2, ///< De Borst 2-parameter EAS, variant P2
-      EAS3,           ///< 3-parameter EAS
-      DeBorstEAS6b,   ///< De Borst 6-parameter EAS, variant b
-      DeBorstEAS9,    ///< De Borst 9-parameter EAS
-      SimoRifaiEAS5,  ///< Simo–Rifai 5-parameter EAS
-      SimoRifaiEAS4,  ///< Simo–Rifai 4-parameter EAS
-    };
+  /**
+   * @brief Computes the EAS transformation matrix from the element Jacobian.
+   * @param J  Element Jacobian matrix at the reference point.
+   * @return   Transformation matrix \f$\mathbf{F}\f$ for mapping EAS modes.
+   */
+  Eigen::MatrixXd F( const Eigen::MatrixXd& J );
 
-    /**
-     * @brief Computes the EAS transformation matrix from the element Jacobian.
-     * @param J  Element Jacobian matrix at the reference point.
-     * @return   Transformation matrix \f$\mathbf{F}\f$ for mapping EAS modes.
-     */
-    Eigen::MatrixXd F( const Eigen::MatrixXd& J );
+  /**
+   * @brief Evaluates the EAS interpolation matrix at a given natural coordinate.
+   * @param type EAS enrichment type.
+   * @param xi   Natural coordinates of the integration point.
+   * @return     EAS interpolation matrix \f$\mathbf{M}\f$.
+   */
+  Eigen::MatrixXd EASInterpolation( EASType type, const Eigen::VectorXd& xi );
 
-    /**
-     * @brief Evaluates the EAS interpolation matrix at a given natural coordinate.
-     * @param type EAS enrichment type.
-     * @param xi   Natural coordinates of the integration point.
-     * @return     EAS interpolation matrix \f$\mathbf{M}\f$.
-     */
-    Eigen::MatrixXd EASInterpolation( EASType type, const Eigen::VectorXd& xi );
-
-  } // namespace FiniteElement::EAS
-} // namespace Marmot
+} // namespace Marmot::FiniteElement::EAS

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
@@ -29,146 +29,150 @@
 #include <functional>
 #include <memory>
 
-/**
- * @class MarmotElementSpatialWrapper
- * @brief Wrapper that embeds a lower-dimensional child element (e.g.\ a truss) into a
- *        higher-dimensional ambient space (2-D or 3-D).
- *
- * The projection transformation is constructed automatically from the supplied
- * nodal coordinates.  The child element is created via a user-provided factory
- * functor so that the wrapper remains independent of the concrete child type.
- */
-class MarmotElementSpatialWrapper : public MarmotElement {
-
-public:
-  const int nDim;                                ///< Number of spatial dimensions of the ambient space.
-  const int nDimChild;                           ///< Number of spatial dimensions of the child element.
-  const int nNodes;                              ///< Number of nodes shared by parent and child element.
-  const int nRhsChild;                           ///< Size of the child element's right-hand-side vector.
-  const Eigen::Map< const Eigen::VectorXi >
-            rhsIndicesToBeProjected;             ///< Indices in the child RHS vector that need projection.
-  const int projectedSize;                       ///< Number of projected DOFs (child-element dimension).
-  const int unprojectedSize;                     ///< Number of unprojected DOFs (ambient-space dimension).
-
-  std::unique_ptr< MarmotElement > childElement; ///< Owned child element instance.
-  Eigen::MatrixXd                  T;            ///< Coordinate transformation matrix from child to parent space.
-  Eigen::MatrixXd                  P;            ///< Projection matrix mapping parent DOFs to child DOFs.
-  Eigen::MatrixXd                  projectedCoordinates; ///< Nodal coordinates expressed in the child (local) frame.
+namespace Marmot {
 
   /**
-   * @brief Construct the spatial wrapper.
-   * @param[in] nDim                      Number of spatial dimensions of the ambient space.
-   * @param[in] nChildDim                 Number of spatial dimensions of the child element.
-   * @param[in] nNodes                    Number of nodes.
-   * @param[in] sizeRhsChild              Size of the child element's right-hand-side vector.
-   * @param[in] rhsIndicesToBeWrapped_    Array of child-RHS indices to be projected.
-   * @param[in] nRhsIndicesToBeWrapped    Length of @p rhsIndicesToBeWrapped_.
-   * @param[in] childElement              Owning pointer to the child element instance.
+   * @class MarmotElementSpatialWrapper
+   * @brief Wrapper that embeds a lower-dimensional child element (e.g.\ a truss) into a
+   *        higher-dimensional ambient space (2-D or 3-D).
+   *
+   * The projection transformation is constructed automatically from the supplied
+   * nodal coordinates.  The child element is created via a user-provided factory
+   * functor so that the wrapper remains independent of the concrete child type.
    */
-  MarmotElementSpatialWrapper( int                              nDim,
-                               int                              nChildDim,
-                               int                              nNodes,
-                               int                              sizeRhsChild,
-                               const int                        rhsIndicesToBeWrapped_[],
-                               int                              nRhsIndicesToBeWrapped,
-                               std::unique_ptr< MarmotElement > childElement );
+  class MarmotElementSpatialWrapper : public MarmotElement {
 
-  /// @copydoc MarmotElement::getNumberOfRequiredStateVars
-  int getNumberOfRequiredStateVars();
+  public:
+    const int nDim;                                ///< Number of spatial dimensions of the ambient space.
+    const int nDimChild;                           ///< Number of spatial dimensions of the child element.
+    const int nNodes;                              ///< Number of nodes shared by parent and child element.
+    const int nRhsChild;                           ///< Size of the child element's right-hand-side vector.
+    const Eigen::Map< const Eigen::VectorXi >
+              rhsIndicesToBeProjected;             ///< Indices in the child RHS vector that need projection.
+    const int projectedSize;                       ///< Number of projected DOFs (child-element dimension).
+    const int unprojectedSize;                     ///< Number of unprojected DOFs (ambient-space dimension).
 
-  /// @copydoc MarmotElement::getNodeFields
-  std::vector< std::vector< std::string > > getNodeFields();
+    std::unique_ptr< MarmotElement > childElement; ///< Owned child element instance.
+    Eigen::MatrixXd                  T;            ///< Coordinate transformation matrix from child to parent space.
+    Eigen::MatrixXd                  P;            ///< Projection matrix mapping parent DOFs to child DOFs.
+    Eigen::MatrixXd                  projectedCoordinates; ///< Nodal coordinates expressed in the child (local) frame.
 
-  /// @copydoc MarmotElement::getDofIndicesPermutationPattern
-  std::vector< int > getDofIndicesPermutationPattern();
+    /**
+     * @brief Construct the spatial wrapper.
+     * @param[in] nDim                      Number of spatial dimensions of the ambient space.
+     * @param[in] nChildDim                 Number of spatial dimensions of the child element.
+     * @param[in] nNodes                    Number of nodes.
+     * @param[in] sizeRhsChild              Size of the child element's right-hand-side vector.
+     * @param[in] rhsIndicesToBeWrapped_    Array of child-RHS indices to be projected.
+     * @param[in] nRhsIndicesToBeWrapped    Length of @p rhsIndicesToBeWrapped_.
+     * @param[in] childElement              Owning pointer to the child element instance.
+     */
+    MarmotElementSpatialWrapper( int                              nDim,
+                                 int                              nChildDim,
+                                 int                              nNodes,
+                                 int                              sizeRhsChild,
+                                 const int                        rhsIndicesToBeWrapped_[],
+                                 int                              nRhsIndicesToBeWrapped,
+                                 std::unique_ptr< MarmotElement > childElement );
 
-  /// @copydoc MarmotElement::getNNodes
-  int getNNodes();
+    /// @copydoc MarmotElement::getNumberOfRequiredStateVars
+    int getNumberOfRequiredStateVars();
 
-  /// @copydoc MarmotElement::getNSpatialDimensions
-  int getNSpatialDimensions();
+    /// @copydoc MarmotElement::getNodeFields
+    std::vector< std::vector< std::string > > getNodeFields();
 
-  /// @copydoc MarmotElement::getNDofPerElement
-  int getNDofPerElement();
+    /// @copydoc MarmotElement::getDofIndicesPermutationPattern
+    std::vector< int > getDofIndicesPermutationPattern();
 
-  /// @copydoc MarmotElement::getElementShape
-  std::string getElementShape();
+    /// @copydoc MarmotElement::getNNodes
+    int getNNodes();
 
-  /// @copydoc MarmotElement::assignStateVars
-  void assignStateVars( double* stateVars, int nStateVars );
+    /// @copydoc MarmotElement::getNSpatialDimensions
+    int getNSpatialDimensions();
 
-  /// @copydoc MarmotElement::assignProperty(const ElementProperties&)
-  void assignProperty( const ElementProperties& property );
+    /// @copydoc MarmotElement::getNDofPerElement
+    int getNDofPerElement();
 
-  /// @copydoc MarmotElement::assignProperty(const MarmotMaterialSection&)
-  void assignProperty( const MarmotMaterialSection& property );
+    /// @copydoc MarmotElement::getElementShape
+    std::string getElementShape();
 
-  /// @copydoc MarmotElement::assignProperty(const std::string&, const double*)
-  void assignProperty( const std::string& propertyName, const double* properties ) override;
+    /// @copydoc MarmotElement::assignStateVars
+    void assignStateVars( double* stateVars, int nStateVars );
 
-  /// @copydoc MarmotElement::getPropertyNames
-  std::vector< std::string > getPropertyNames() const override;
+    /// @copydoc MarmotElement::assignProperty(const ElementProperties&)
+    void assignProperty( const ElementProperties& property );
 
-  /// @copydoc MarmotElement::assignNodeCoordinates
-  void assignNodeCoordinates( const double* coordinates );
+    /// @copydoc MarmotElement::assignProperty(const MarmotMaterialSection&)
+    void assignProperty( const MarmotMaterialSection& property );
 
-  /// @copydoc MarmotElement::initializeYourself
-  void initializeYourself();
+    /// @copydoc MarmotElement::assignProperty(const std::string&, const double*)
+    void assignProperty( const std::string& propertyName, const double* properties ) override;
 
-  /**
-   * @brief Perform element computations with coordinate transformation.
-   * @param[in]  QTotal  Total dof vector in the ambient (parent) space.
-   * @param[in]  dQ      Incremental dof vector in the ambient space.
-   * @param[out] Pe      Internal force vector in the ambient space.
-   * @param[out] Ke      Stiffness matrix in the ambient space.
-   * @param[in]  time    Current time.
-   * @param[in]  dT      Time step size.
-   */
-  void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
+    /// @copydoc MarmotElement::getPropertyNames
+    std::vector< std::string > getPropertyNames() const override;
 
-  /// @copydoc MarmotElement::setInitialConditions
-  void setInitialConditions( StateTypes state, const double* values );
+    /// @copydoc MarmotElement::assignNodeCoordinates
+    void assignNodeCoordinates( const double* coordinates );
 
-  /**
-   * @brief Compute contribution from distributed surface loads with coordinate transformation.
-   * @param[in]  loadType    Type of distributed load.
-   * @param[out] P           External load vector in the ambient space.
-   * @param[out] K           Load stiffness matrix in the ambient space.
-   * @param[in]  elementFace Index of element face.
-   * @param[in]  load        Applied load values.
-   * @param[in]  QTotal      Total dof vector.
-   * @param[in]  time        Current time.
-   * @param[in]  dT          Time step size.
-   */
-  void computeDistributedLoad( DistributedLoadTypes loadType,
-                               double*              P,
-                               double*              K,
-                               int                  elementFace,
-                               const double*        load,
-                               const double*        QTotal,
-                               double               time,
-                               double               dT );
+    /// @copydoc MarmotElement::initializeYourself
+    void initializeYourself();
 
-  /**
-   * @brief Compute body force contribution with coordinate transformation.
-   * @param[out] P      External load vector in the ambient space.
-   * @param[out] K      Load stiffness matrix in the ambient space.
-   * @param[in]  load   Applied body force values.
-   * @param[in]  QTotal Total dof vector.
-   * @param[in]  time   Current time.
-   * @param[in]  dT     Time step size.
-   */
-  void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
+    /**
+     * @brief Perform element computations with coordinate transformation.
+     * @param[in]  QTotal  Total dof vector in the ambient (parent) space.
+     * @param[in]  dQ      Incremental dof vector in the ambient space.
+     * @param[out] Pe      Internal force vector in the ambient space.
+     * @param[out] Ke      Stiffness matrix in the ambient space.
+     * @param[in]  time    Current time.
+     * @param[in]  dT      Time step size.
+     */
+    void computeKernels( const double* QTotal, const double* dQ, double* Pe, double* Ke, double time, double dT );
 
-  /// @copydoc MarmotElement::getStateView
-  StateView getStateView( const std::string& stateName, int quadraturePoint );
+    /// @copydoc MarmotElement::setInitialConditions
+    void setInitialConditions( StateTypes state, const double* values );
 
-  /// @copydoc MarmotElement::getCoordinatesAtCenter
-  std::vector< double > getCoordinatesAtCenter();
+    /**
+     * @brief Compute contribution from distributed surface loads with coordinate transformation.
+     * @param[in]  loadType    Type of distributed load.
+     * @param[out] P           External load vector in the ambient space.
+     * @param[out] K           Load stiffness matrix in the ambient space.
+     * @param[in]  elementFace Index of element face.
+     * @param[in]  load        Applied load values.
+     * @param[in]  QTotal      Total dof vector.
+     * @param[in]  time        Current time.
+     * @param[in]  dT          Time step size.
+     */
+    void computeDistributedLoad( DistributedLoadTypes loadType,
+                                 double*              P,
+                                 double*              K,
+                                 int                  elementFace,
+                                 const double*        load,
+                                 const double*        QTotal,
+                                 double               time,
+                                 double               dT );
 
-  /// @copydoc MarmotElement::getCoordinatesAtQuadraturePoints
-  std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints();
+    /**
+     * @brief Compute body force contribution with coordinate transformation.
+     * @param[out] P      External load vector in the ambient space.
+     * @param[out] K      Load stiffness matrix in the ambient space.
+     * @param[in]  load   Applied body force values.
+     * @param[in]  QTotal Total dof vector.
+     * @param[in]  time   Current time.
+     * @param[in]  dT     Time step size.
+     */
+    void computeBodyForce( double* P, double* K, const double* load, const double* QTotal, double time, double dT );
 
-  /// @copydoc MarmotElement::getNumberOfQuadraturePoints
-  int getNumberOfQuadraturePoints();
-};
+    /// @copydoc MarmotElement::getStateView
+    StateView getStateView( const std::string& stateName, int quadraturePoint );
+
+    /// @copydoc MarmotElement::getCoordinatesAtCenter
+    std::vector< double > getCoordinatesAtCenter();
+
+    /// @copydoc MarmotElement::getCoordinatesAtQuadraturePoints
+    std::vector< std::vector< double > > getCoordinatesAtQuadraturePoints();
+
+    /// @copydoc MarmotElement::getNumberOfQuadraturePoints
+    int getNumberOfQuadraturePoints();
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotGeometryElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotGeometryElement.h
@@ -29,112 +29,116 @@
 #include <iostream>
 #include <map>
 
-/**
- * @class MarmotGeometryElement
- * @brief Statically-sized geometry base class for all isoparametric Marmot elements.
- *
- * @tparam nDim   Number of spatial dimensions (1, 2 or 3).
- * @tparam nNodes Number of element nodes.
- *
- * Provides shape functions @c N, their natural-coordinate derivatives @c dNdXi,
- * the B-operator @c B, and the element Jacobian.  The element shape is determined
- * automatically from the template parameters.
- *
- * Concrete MarmotElement classes inherit from this class to access the geometric
- * infrastructure without code duplication.
- */
-template < int nDim, int nNodes >
-class MarmotGeometryElement {
+namespace Marmot {
 
-public:
-  /*Typedefs*/
-  /* static constexpr VoigtSize voigtSize = ( ( ( nDim * nDim ) + nDim ) / 2 ); */
-  /// @brief Voigt notation size for @p nDim spatial dimensions.
-  static constexpr Marmot::ContinuumMechanics::VoigtNotation::VoigtSize
-    voigtSize = Marmot::ContinuumMechanics::VoigtNotation::voigtSizeFromDimension( nDim );
+  /**
+   * @class MarmotGeometryElement
+   * @brief Statically-sized geometry base class for all isoparametric Marmot elements.
+   *
+   * @tparam nDim   Number of spatial dimensions (1, 2 or 3).
+   * @tparam nNodes Number of element nodes.
+   *
+   * Provides shape functions @c N, their natural-coordinate derivatives @c dNdXi,
+   * the B-operator @c B, and the element Jacobian.  The element shape is determined
+   * automatically from the template parameters.
+   *
+   * Concrete MarmotElement classes inherit from this class to access the geometric
+   * infrastructure without code duplication.
+   */
+  template < int nDim, int nNodes >
+  class MarmotGeometryElement {
 
-  typedef Eigen::Matrix< double, nDim, 1 >             XiSized;          ///< Natural-coordinate vector.
-  typedef Eigen::Matrix< double, nDim * nNodes, 1 >    CoordinateVector; ///< Flat nodal-coordinate vector.
-  typedef Eigen::Matrix< double, nDim, nDim >          JacobianSized;    ///< Square Jacobian matrix.
-  typedef Eigen::Matrix< double, 1, nNodes >           NSized;           ///< Row vector of shape function values.
-  typedef Eigen::Matrix< double, nDim, nNodes * nDim > NBSized;          ///< Expanded interpolation operator N_B.
-  typedef Eigen::Matrix< double, nDim, nNodes >        dNdXiSized;  ///< Matrix of shape function natural derivatives.
-  typedef Eigen::Matrix< double, voigtSize, nNodes * nDim > BSized; ///< Standard B-operator matrix.
-  typedef Eigen::Matrix< double, 4, nNodes * nDim >
-    BSizedAxisymmetric; ///< Axisymmetric B-operator matrix (4 Voigt components).
+  public:
+    /*Typedefs*/
+    /* static constexpr VoigtSize voigtSize = ( ( ( nDim * nDim ) + nDim ) / 2 ); */
+    /// @brief Voigt notation size for @p nDim spatial dimensions.
+    static constexpr Marmot::ContinuumMechanics::VoigtNotation::VoigtSize
+      voigtSize = Marmot::ContinuumMechanics::VoigtNotation::voigtSizeFromDimension( nDim );
 
-  /*Properties*/
-  Eigen::Map< const CoordinateVector >       coordinates; ///< Map into the externally-owned nodal-coordinate array.
-  const Marmot::FiniteElement::ElementShapes shape;       ///< Element shape determined from @p nDim and @p nNodes.
+    typedef Eigen::Matrix< double, nDim, 1 >             XiSized;          ///< Natural-coordinate vector.
+    typedef Eigen::Matrix< double, nDim * nNodes, 1 >    CoordinateVector; ///< Flat nodal-coordinate vector.
+    typedef Eigen::Matrix< double, nDim, nDim >          JacobianSized;    ///< Square Jacobian matrix.
+    typedef Eigen::Matrix< double, 1, nNodes >           NSized;           ///< Row vector of shape function values.
+    typedef Eigen::Matrix< double, nDim, nNodes * nDim > NBSized;          ///< Expanded interpolation operator N_B.
+    typedef Eigen::Matrix< double, nDim, nNodes >        dNdXiSized;  ///< Matrix of shape function natural derivatives.
+    typedef Eigen::Matrix< double, voigtSize, nNodes * nDim > BSized; ///< Standard B-operator matrix.
+    typedef Eigen::Matrix< double, 4, nNodes * nDim >
+      BSizedAxisymmetric; ///< Axisymmetric B-operator matrix (4 Voigt components).
 
-  /*Methods*/
-  /// @brief Default constructor. Initialises the coordinate map to @c nullptr and deduces the element shape.
-  MarmotGeometryElement()
-    : coordinates( nullptr ), shape( Marmot::FiniteElement::getElementShapeByMetric( nDim, nNodes ) ){};
+    /*Properties*/
+    Eigen::Map< const CoordinateVector >       coordinates; ///< Map into the externally-owned nodal-coordinate array.
+    const Marmot::FiniteElement::ElementShapes shape;       ///< Element shape determined from @p nDim and @p nNodes.
 
-  /// @brief Returns an Ensight Gold shape string (e.g. @c quad4, @c hexa8) for this element.
-  std::string getElementShape() const
-  {
-    using namespace Marmot::FiniteElement;
-    static std::map< ElementShapes, std::string > shapes = { { Bar2, "bar2" },
-                                                             { Quad4, "quad4" },
-                                                             { Quad8, "quad8" },
-                                                             { Tetra4, "tetra4" },
-                                                             { Tetra10, "tetra10" },
-                                                             { Hexa8, "hexa8" },
-                                                             { Hexa20, "hexa20" } };
+    /*Methods*/
+    /// @brief Default constructor. Initialises the coordinate map to @c nullptr and deduces the element shape.
+    MarmotGeometryElement()
+      : coordinates( nullptr ), shape( Marmot::FiniteElement::getElementShapeByMetric( nDim, nNodes ) ){};
 
-    return shapes[this->shape];
-  }
+    /// @brief Returns an Ensight Gold shape string (e.g. @c quad4, @c hexa8) for this element.
+    std::string getElementShape() const
+    {
+      using namespace Marmot::FiniteElement;
+      static std::map< ElementShapes, std::string > shapes = { { Bar2, "bar2" },
+                                                               { Quad4, "quad4" },
+                                                               { Quad8, "quad8" },
+                                                               { Tetra4, "tetra4" },
+                                                               { Tetra10, "tetra10" },
+                                                               { Hexa8, "hexa8" },
+                                                               { Hexa20, "hexa20" } };
 
-  /// @brief Maps the externally-owned coordinate array into the @ref coordinates member.
-  /// @param[in] coords Pointer to the flat nodal-coordinate array.
-  void assignNodeCoordinates( const double* coords )
-  {
-    new ( &coordinates ) Eigen::Map< const CoordinateVector >( coords );
-  }
+      return shapes[this->shape];
+    }
 
-  /*Please specialize these functions for each element individially
-   *.cpp file.
-   *Fully specialized templates are precompiled in marmotMechanics (rather than the unspecialized and
-   *partially specialized templates)
-   * */
-  /// @brief Evaluate the shape function row vector at natural coordinates @p xi.
-  NSized N( const XiSized& xi ) const;
-  /// @brief Evaluate the matrix of shape function natural derivatives at @p xi.
-  dNdXiSized dNdXi( const XiSized& xi ) const;
-  /// @brief Compute the standard B-operator from physical derivatives @p dNdX.
-  BSized B( const dNdXiSized& dNdX ) const;
-  /// @brief Compute the axisymmetric B-operator (4 components).
-  BSizedAxisymmetric B_axisymmetric( const dNdXiSized& dNdX, const NSized& N, const XiSized& x_gauss ) const;
-  /// @brief Compute the B̄-operator using the B-bar selective-reduced-integration method.
-  BSized B_bar( const dNdXiSized& dNdX, const dNdXiSized& dNdX0 ) const;
-  /// @brief Compute the Green–Lagrange strain operator for deformation gradient @p F.
-  BSized BGreen( const dNdXiSized& dNdX, const JacobianSized& F ) const;
+    /// @brief Maps the externally-owned coordinate array into the @ref coordinates member.
+    /// @param[in] coords Pointer to the flat nodal-coordinate array.
+    void assignNodeCoordinates( const double* coords )
+    {
+      new ( &coordinates ) Eigen::Map< const CoordinateVector >( coords );
+    }
 
-  /*These functions are equal for each element and independent of node number and  nDimension*/
-  /// @brief Compute the expanded interpolation operator N_B from shape function values @p N.
-  NBSized NB( const NSized& N ) const { return Marmot::FiniteElement::NB< nDim, nNodes >( N ); }
+    /*Please specialize these functions for each element individially
+     *.cpp file.
+     *Fully specialized templates are precompiled in marmotMechanics (rather than the unspecialized and
+     *partially specialized templates)
+     * */
+    /// @brief Evaluate the shape function row vector at natural coordinates @p xi.
+    NSized N( const XiSized& xi ) const;
+    /// @brief Evaluate the matrix of shape function natural derivatives at @p xi.
+    dNdXiSized dNdXi( const XiSized& xi ) const;
+    /// @brief Compute the standard B-operator from physical derivatives @p dNdX.
+    BSized B( const dNdXiSized& dNdX ) const;
+    /// @brief Compute the axisymmetric B-operator (4 components).
+    BSizedAxisymmetric B_axisymmetric( const dNdXiSized& dNdX, const NSized& N, const XiSized& x_gauss ) const;
+    /// @brief Compute the B̄-operator using the B-bar selective-reduced-integration method.
+    BSized B_bar( const dNdXiSized& dNdX, const dNdXiSized& dNdX0 ) const;
+    /// @brief Compute the Green–Lagrange strain operator for deformation gradient @p F.
+    BSized BGreen( const dNdXiSized& dNdX, const JacobianSized& F ) const;
 
-  /// @brief Compute the element Jacobian from natural derivatives @p dNdXi and the stored nodal coordinates.
-  JacobianSized Jacobian( const dNdXiSized& dNdXi ) const
-  {
-    return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdXi, coordinates );
-  }
+    /*These functions are equal for each element and independent of node number and  nDimension*/
+    /// @brief Compute the expanded interpolation operator N_B from shape function values @p N.
+    NBSized NB( const NSized& N ) const { return Marmot::FiniteElement::NB< nDim, nNodes >( N ); }
 
-  /// @brief Compute physical derivatives @p dN/dX from natural derivatives and the inverse Jacobian.
-  /// @param[in] dNdXi        Natural-coordinate derivatives.
-  /// @param[in] JacobianInverse  Inverse of the element Jacobian.
-  dNdXiSized dNdX( const dNdXiSized& dNdXi, const JacobianSized& JacobianInverse ) const
-  {
-    return ( dNdXi.transpose() * JacobianInverse ).transpose();
-  }
+    /// @brief Compute the element Jacobian from natural derivatives @p dNdXi and the stored nodal coordinates.
+    JacobianSized Jacobian( const dNdXiSized& dNdXi ) const
+    {
+      return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdXi, coordinates );
+    }
 
-  /// @brief Compute the deformation gradient \f$\mathbf{F}\f$ from physical derivatives and displacements @p Q.
-  /// @param[in] dNdX Physical shape function derivatives.
-  /// @param[in] Q    Element displacement vector.
-  JacobianSized F( const dNdXiSized& dNdX, const CoordinateVector& Q ) const
-  {
-    return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdX, Q ) + JacobianSized::Identity();
-  }
-};
+    /// @brief Compute physical derivatives @p dN/dX from natural derivatives and the inverse Jacobian.
+    /// @param[in] dNdXi        Natural-coordinate derivatives.
+    /// @param[in] JacobianInverse  Inverse of the element Jacobian.
+    dNdXiSized dNdX( const dNdXiSized& dNdXi, const JacobianSized& JacobianInverse ) const
+    {
+      return ( dNdXi.transpose() * JacobianInverse ).transpose();
+    }
+
+    /// @brief Compute the deformation gradient \f$\mathbf{F}\f$ from physical derivatives and displacements @p Q.
+    /// @param[in] dNdX Physical shape function derivatives.
+    /// @param[in] Q    Element displacement vector.
+    JacobianSized F( const dNdXiSized& dNdX, const CoordinateVector& Q ) const
+    {
+      return Marmot::FiniteElement::Jacobian< nDim, nNodes >( dNdX, Q ) + JacobianSized::Identity();
+    }
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotGeometryElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotGeometryElement.h
@@ -77,7 +77,7 @@ namespace Marmot {
     /// @brief Returns an Ensight Gold shape string (e.g. @c quad4, @c hexa8) for this element.
     std::string getElementShape() const
     {
-      using namespace Marmot::FiniteElement;
+      using namespace FiniteElement;
       static std::map< ElementShapes, std::string > shapes = { { Bar2, "bar2" },
                                                                { Quad4, "quad4" },
                                                                { Quad8, "quad8" },

--- a/modules/core/MarmotFiniteElementCore/src/MarmotDofLayoutTools.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotDofLayoutTools.cpp
@@ -1,62 +1,59 @@
 #include <Marmot/MarmotDofLayoutTools.h>
 #include <vector>
 
-namespace Marmot {
+namespace Marmot::FiniteElement {
 
-  namespace FiniteElement {
+  using namespace std;
 
-    using namespace std;
+  const vector< vector< string > > makeNodeFieldLayout( const map< string, pair< int, int > >& fieldSizes )
 
-    const vector< vector< string > > makeNodeFieldLayout( const map< string, pair< int, int > >& fieldSizes )
+  {
+    vector< vector< string > > nodeFields;
 
-    {
-      vector< vector< string > > nodeFields;
+    int maxNumberOfNodes = 0;
+    for ( const auto& [field, fieldSize] : fieldSizes ) {
+      const auto& [nFieldComponents, nNodesForField] = fieldSize;
+      maxNumberOfNodes                               = max( maxNumberOfNodes, nNodesForField );
+    }
 
-      int maxNumberOfNodes = 0;
+    for ( int idxNode = 0; idxNode < maxNumberOfNodes; idxNode++ ) {
+      nodeFields.push_back( vector< string >() );
+
       for ( const auto& [field, fieldSize] : fieldSizes ) {
         const auto& [nFieldComponents, nNodesForField] = fieldSize;
-        maxNumberOfNodes                               = max( maxNumberOfNodes, nNodesForField );
+        if ( idxNode < nNodesForField )
+          nodeFields[idxNode].push_back( field );
       }
-
-      for ( int idxNode = 0; idxNode < maxNumberOfNodes; idxNode++ ) {
-        nodeFields.push_back( vector< string >() );
-
-        for ( const auto& [field, fieldSize] : fieldSizes ) {
-          const auto& [nFieldComponents, nNodesForField] = fieldSize;
-          if ( idxNode < nNodesForField )
-            nodeFields[idxNode].push_back( field );
-        }
-      }
-
-      return nodeFields;
     }
 
-    vector< int > makeBlockedLayoutPermutationPattern( const vector< vector< string > >&      nodeFields,
-                                                       const map< string, pair< int, int > >& fieldSizes )
-    {
+    return nodeFields;
+  }
 
-      vector< int > permutationPattern;
+  vector< int > makeBlockedLayoutPermutationPattern( const vector< vector< string > >&      nodeFields,
+                                                     const map< string, pair< int, int > >& fieldSizes )
+  {
 
-      for ( const auto& [blockedField, fieldSize] : fieldSizes ) {
+    vector< int > permutationPattern;
 
-        int currentIdx = 0;
-        for ( size_t i = 0; i < nodeFields.size(); i++ ) {
-          for ( size_t j = 0; j < nodeFields[i].size(); j++ ) {
+    for ( const auto& [blockedField, fieldSize] : fieldSizes ) {
 
-            const auto& currentNodeField                         = nodeFields[i][j];
-            const auto [nCurrentFieldComponents, nNodesForField] = fieldSizes.at( currentNodeField );
+      int currentIdx = 0;
+      for ( size_t i = 0; i < nodeFields.size(); i++ ) {
+        for ( size_t j = 0; j < nodeFields[i].size(); j++ ) {
 
-            if ( blockedField == currentNodeField )
-              for ( int component = 0; component < nCurrentFieldComponents; component++ )
-                permutationPattern.push_back( currentIdx + component );
+          const auto& currentNodeField                         = nodeFields[i][j];
+          const auto [nCurrentFieldComponents, nNodesForField] = fieldSizes.at( currentNodeField );
 
-            currentIdx += nCurrentFieldComponents;
-          }
+          if ( blockedField == currentNodeField )
+            for ( int component = 0; component < nCurrentFieldComponents; component++ )
+              permutationPattern.push_back( currentIdx + component );
+
+          currentIdx += nCurrentFieldComponents;
         }
       }
-
-      return permutationPattern;
     }
 
-  } // namespace FiniteElement
-} // namespace Marmot
+    return permutationPattern;
+  }
+
+} // namespace Marmot::FiniteElement

--- a/modules/core/MarmotFiniteElementCore/src/MarmotElement.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotElement.cpp
@@ -1,7 +1,11 @@
 #include "Marmot/MarmotElement.h"
 
-MarmotElement::~MarmotElement() {}
+namespace Marmot {
 
-void MarmotElement::assignProperty( const ElementProperties& property ) {}
+  MarmotElement::~MarmotElement() {}
 
-void MarmotElement::assignProperty( const MarmotMaterialSection& property ) {}
+  void MarmotElement::assignProperty( const ElementProperties& property ) {}
+
+  void MarmotElement::assignProperty( const MarmotMaterialSection& property ) {}
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/src/MarmotElementFactory.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotElementFactory.cpp
@@ -1,6 +1,6 @@
 #include "Marmot/MarmotElementFactory.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 MarmotElementFactory::ElementFactoryMap& MarmotElementFactory::elementFactoryFunctionByName()
 {

--- a/modules/core/MarmotFiniteElementCore/src/MarmotEnhancedAssumedStrain.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotEnhancedAssumedStrain.cpp
@@ -1,35 +1,34 @@
 #include "Marmot/MarmotEnhancedAssumedStrain.h"
-namespace Marmot {
-  namespace FiniteElement::EAS {
+namespace Marmot::FiniteElement::EAS {
 
-    using namespace Eigen;
+  using namespace Eigen;
 
-    MatrixXd F( const MatrixXd& J )
-    {
-      // Transformation according to
-      // - Andelfinger, Ramm (1993),
-      // - 'Notes on Continuum Mechanics -  Eduardo WV Chaves' !
-      // - Lecture Notes S.Kinkel
-      // - Quy,Matzenmiller 2007
-      //
-      // Attention: Incosistent with Simo Rifai ( topleft block!)
-      // and FEAP Theory Manual!
-      // nDim == 2
-      if ( J.cols() == 2 ) {
+  MatrixXd F( const MatrixXd& J )
+  {
+    // Transformation according to
+    // - Andelfinger, Ramm (1993),
+    // - 'Notes on Continuum Mechanics -  Eduardo WV Chaves' !
+    // - Lecture Notes S.Kinkel
+    // - Quy,Matzenmiller 2007
+    //
+    // Attention: Incosistent with Simo Rifai ( topleft block!)
+    // and FEAP Theory Manual!
+    // nDim == 2
+    if ( J.cols() == 2 ) {
 
-        Matrix3d F;
-        // clang-format off
+      Matrix3d F;
+      // clang-format off
                 F <<    J(0,0)*J(0,0),    J(0,1)*J(0,1),        2*J(0,0)*J(0,1),
                         J(1,0)*J(1,0),    J(1,1)*J(1,1),        2*J(1,0)*J(1,1),
                         J(0,0)*J(1,0),    J(0,1)*J(1,1),        J(0,0)*J(1,1)+J(0,1)*J(1,0);
-        // clang-format on
+      // clang-format on
 
-        return F;
-      }
-      else if ( J.cols() == 3 ) {
+      return F;
+    }
+    else if ( J.cols() == 3 ) {
 
-        Matrix6d F;
-        // clang-format off
+      Matrix6d F;
+      // clang-format off
                 F.topLeftCorner(3,3) <<
                     J(0,0)*J(0,0),  J(0,1)*J(0,1),  J(0,2)*J(0,2),
                     J(1,0)*J(1,0),  J(1,1)*J(1,1),  J(1,2)*J(1,2),
@@ -49,42 +48,42 @@ namespace Marmot {
                     J(0,0)*J(1,1)+J(0,1)*J(1,0),  J(0,0)*J(1,2)+J(0,2)*J(1,0),  J(0,1)*J(1,2)+J(0,2)*J(1,1),
                     J(0,0)*J(2,1)+J(0,1)*J(2,0),  J(0,0)*J(2,2)+J(0,2)*J(2,0),  J(0,1)*J(2,2)+J(0,2)*J(2,1),
                     J(1,0)*J(2,1)+J(1,1)*J(2,0),  J(1,0)*J(2,2)+J(1,2)*J(2,0),  J(1,1)*J(2,2)+J(1,2)*J(2,1);
-        // clang-format on
+      // clang-format on
 
-        return F;
-      }
-      throw std::invalid_argument( "Invalid Dimension for Marmot::EnhancedAssumedStrain!" );
+      return F;
     }
+    throw std::invalid_argument( "Invalid Dimension for Marmot::EnhancedAssumedStrain!" );
+  }
 
-    MatrixXd EASInterpolation( EASType type, const VectorXd& xi )
-    {
-      // Implementation for 2D
+  MatrixXd EASInterpolation( EASType type, const VectorXd& xi )
+  {
+    // Implementation for 2D
 
-      switch ( type ) {
-      case DeBorstEAS2: {
+    switch ( type ) {
+    case DeBorstEAS2: {
 
-        Matrix< double, 3, 2 > E_;
+      Matrix< double, 3, 2 > E_;
 
-        // clang-format off
+      // clang-format off
                         E_ <<   xi[1],      0,
                                 0,          xi[0],
                                 0,          0;
-        // clang-format on
+      // clang-format on
 
-        return E_;
-      }
-      case EAS3: {
-        // Not sufficient to avoid volumetric locking, as proven in (de Borst, Groen 1999)
-        Matrix< double, 6, 3 > E_ = Matrix< double, 6, 3 >::Zero();
+      return E_;
+    }
+    case EAS3: {
+      // Not sufficient to avoid volumetric locking, as proven in (de Borst, Groen 1999)
+      Matrix< double, 6, 3 > E_ = Matrix< double, 6, 3 >::Zero();
 
-        E_.topLeftCorner( 3, 3 ).diagonal() << xi[0], xi[1], xi[2];
+      E_.topLeftCorner( 3, 3 ).diagonal() << xi[0], xi[1], xi[2];
 
-        return E_;
-      }
+      return E_;
+    }
 
-      case DeBorstEAS9: {
-        Matrix< double, 6, 9 > E_ = Matrix< double, 6, 9 >::Zero();
-        // clang-format off
+    case DeBorstEAS9: {
+      Matrix< double, 6, 9 > E_ = Matrix< double, 6, 9 >::Zero();
+      // clang-format off
 
                                        E_.topLeftCorner(3,3).diagonal() <<  xi[0], xi[1], xi[2];
 
@@ -96,15 +95,15 @@ namespace Marmot {
 
                                        E_(2,7) = xi[2] * xi[0];
                                        E_(2,8) = xi[2] * xi[1];
-        // clang-format on
+      // clang-format on
 
-        return E_;
-      }
+      return E_;
+    }
 
-      case DeBorstEAS6b: {
-        Matrix< double, 6, 6 > E_ = Matrix< double, 6, 6 >::Zero();
+    case DeBorstEAS6b: {
+      Matrix< double, 6, 6 > E_ = Matrix< double, 6, 6 >::Zero();
 
-        // clang-format off
+      // clang-format off
                                        E_.topLeftCorner(3,3).diagonal() <<  xi[0], xi[1], xi[2];
 
                                        E_(0,3) = xi[1] * xi[0];
@@ -115,37 +114,36 @@ namespace Marmot {
 
                                        E_(2,4) = xi[0] * xi[2];
                                        E_(2,5) = xi[1] * xi[2];
-        // clang-format on
+      // clang-format on
 
-        return E_;
-      }
+      return E_;
+    }
 
-      case SimoRifaiEAS5: {
+    case SimoRifaiEAS5: {
 
-        Matrix< double, 3, 5 > E_;
-        // clang-format off
+      Matrix< double, 3, 5 > E_;
+      // clang-format off
 
                         E_ <<   xi[0],      0,      0,      0,      xi[0]*xi[1],
                                 0,          xi[1],  0,      0,      -xi[0]*xi[1],
                                 0,          0,      xi[0],  xi[1],  xi[0]*xi[0]-xi[1]*xi[1];
-        // clang-format on
+      // clang-format on
 
-        return E_;
-      }
-      case SimoRifaiEAS4: {
+      return E_;
+    }
+    case SimoRifaiEAS4: {
 
-        Matrix< double, 3, 4 > E_;
+      Matrix< double, 3, 4 > E_;
 
-        // clang-format off
+      // clang-format off
                         E_ <<   xi[0],      0,      0,      0,
                                 0,          xi[1],  0,      0,
                                 0,          0,      xi[0],  xi[1];
-        // clang-format on
-        return E_;
-      }
-
-      default: throw std::invalid_argument( "Invalid EAS Type Requested" );
-      }
+      // clang-format on
+      return E_;
     }
-  } // namespace FiniteElement::EAS
-} // namespace Marmot
+
+    default: throw std::invalid_argument( "Invalid EAS Type Requested" );
+    }
+  }
+} // namespace Marmot::FiniteElement::EAS

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement1D.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement1D.cpp
@@ -1,59 +1,55 @@
 #include "Marmot/MarmotFiniteElement.h"
 #include "Marmot/MarmotTypedefs.h"
 
-namespace Marmot {
-  namespace FiniteElement {
-    namespace Spatial1D {
-      namespace Bar2 {
-        /*  (0)            (1)
-         *    o------------o
-         *
-         *    <------|-----> xi
-         *     -1    0     1
-         */
+namespace Marmot::FiniteElement::Spatial1D {
+  namespace Bar2 {
+    /*  (0)            (1)
+     *    o------------o
+     *
+     *    <------|-----> xi
+     *     -1    0     1
+     */
 
-        NSized N( double xi )
-        {
-          NSized N;
-          N << ( 1 - xi ) * 0.5, ( 1 + xi ) * 0.5;
-          return N;
-        }
+    NSized N( double xi )
+    {
+      NSized N;
+      N << ( 1 - xi ) * 0.5, ( 1 + xi ) * 0.5;
+      return N;
+    }
 
-        dNdXiSized dNdXi( double xi )
-        {
-          dNdXiSized dNdXi;
-          dNdXi << -0.5, 0.5;
-          return dNdXi;
-        }
+    dNdXiSized dNdXi( double xi )
+    {
+      dNdXiSized dNdXi;
+      dNdXi << -0.5, 0.5;
+      return dNdXi;
+    }
 
-      } // end of namespace Bar2
+  } // end of namespace Bar2
 
-      namespace Bar3 {
-        /*
-         * (0)    (2)     (1)
-         *  o------o-------o
-         *
-         *   <-----.-----> xi
-         *   -1    0    1
-         *
-         * */
+  namespace Bar3 {
+    /*
+     * (0)    (2)     (1)
+     *  o------o-------o
+     *
+     *   <-----.-----> xi
+     *   -1    0    1
+     *
+     * */
 
-        NSized N( double xi )
-        {
-          NSized N;
-          N << ( xi - 1 ) * xi / 2, ( xi + 1 ) * xi / 2, ( 1 - xi * xi );
-          return N;
-        }
+    NSized N( double xi )
+    {
+      NSized N;
+      N << ( xi - 1 ) * xi / 2, ( xi + 1 ) * xi / 2, ( 1 - xi * xi );
+      return N;
+    }
 
-        dNdXiSized dNdXi( double xi )
-        {
-          dNdXiSized dNdXi;
-          dNdXi << xi - 0.5, xi + 0.5, -2 * xi;
+    dNdXiSized dNdXi( double xi )
+    {
+      dNdXiSized dNdXi;
+      dNdXi << xi - 0.5, xi + 0.5, -2 * xi;
 
-          return dNdXi;
-        }
+      return dNdXi;
+    }
 
-      } // end of namespace Bar3
-    }   // namespace Spatial1D
-  }     // namespace FiniteElement
-} // namespace Marmot
+  } // end of namespace Bar3
+} // namespace Marmot::FiniteElement::Spatial1D

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement2D.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement2D.cpp
@@ -4,95 +4,93 @@
 
 using namespace Eigen;
 
-namespace Marmot {
-  namespace FiniteElement {
-    namespace Spatial2D {
-      namespace Quad4 {
+namespace Marmot::FiniteElement::Spatial2D {
+  namespace Quad4 {
 
-        NSized N( const Vector2d& xi )
-        {
-          /*
-           *   Shape functions
-           *    (3) _______(2)
-           *       |       |
-           *       |       |
-           *       |_______|
-           *    (0)        (1)
-           */
+    NSized N( const Vector2d& xi )
+    {
+      /*
+       *   Shape functions
+       *    (3) _______(2)
+       *       |       |
+       *       |       |
+       *       |_______|
+       *    (0)        (1)
+       */
 
-          NSized N_;
-          // clang-format off
+      NSized N_;
+      // clang-format off
                     N_ <<   1./4 * (1.-xi (0)) * (1.-xi (1)),
                             1./4 * (1.+xi (0)) * (1.-xi (1)),
                             1./4 * (1.+xi (0)) * (1.+xi (1)),
                             1./4 * (1.-xi (0)) * (1.+xi (1));
-          // clang-format on
-          return N_;
-        }
+      // clang-format on
+      return N_;
+    }
 
-        dNdXiSized dNdXi( const Vector2d& xi )
-        {
+    dNdXiSized dNdXi( const Vector2d& xi )
+    {
 
-          dNdXiSized result;
+      dNdXiSized result;
 
-          // clang-format off
+      // clang-format off
                     result <<   /*          (0)                 (1)                 (2)                 (3) */
                            /* ,xi1 */ -1./4* (1-xi (1)), +1./4* (1-xi (1)),  +1./4* (1+xi (1)),    -1./4* (1+xi (1)),
                            /*, xi2 */ -1./4* (1-xi (0)), -1./4* (1+xi (0)),  +1./4* (1+xi (0)),    +1./4* (1-xi (0));
-          // clang-format on
-          return result;
-        }
+      // clang-format on
+      return result;
+    }
 
-        Vector2i getBoundaryElementIndices( int faceID )
-        {
-          /*
-           *               face 3
-           *           (3) _______(2)
-           *              |       |
-           *       face 4 |       | face 2
-           *              |_______|
-           *           (0)        (1)
-           *               face 1
-           * */
-          switch ( faceID ) {
-          case 1: {
-            return ( Vector2i() << 0, 1 ).finished();
-          }
-          case 2: {
-            return ( Vector2i() << 1, 2 ).finished();
-          }
-          case 3: {
-            return ( Vector2i() << 2, 3 ).finished();
-          }
-          case 4: {
-            return ( Vector2i() << 3, 0 ).finished();
-          }
-          default: {
-            throw std::invalid_argument( "Quad4: invalid face ID specifed" );
-          }
-          }
-        }
+    Vector2i getBoundaryElementIndices( int faceID )
+    {
+      /*
+       *               face 3
+       *           (3) _______(2)
+       *              |       |
+       *       face 4 |       | face 2
+       *              |_______|
+       *           (0)        (1)
+       *               face 1
+       * */
+      switch ( faceID ) {
+      case 1: {
+        return ( Vector2i() << 0, 1 ).finished();
+      }
+      case 2: {
+        return ( Vector2i() << 1, 2 ).finished();
+      }
+      case 3: {
+        return ( Vector2i() << 2, 3 ).finished();
+      }
+      case 4: {
+        return ( Vector2i() << 3, 0 ).finished();
+      }
+      default: {
+        throw std::invalid_argument( "Quad4: invalid face ID specifed" );
+      }
+      }
+    }
 
-      } // end of namespace Quad4
-      namespace Quad8 {
-        NSized N( const Vector2d& xi )
-        {
-          /* Shape functions
-           *
-           *         (6)
-           *   (3) _______(2)
-           *      |       |
-           *  (7) |       | (5)
-           *      |_______|
-           *   (0)        (1)
-           *         (4)
-           *
-           * */
+  } // end of namespace Quad4
+  namespace Quad8 {
+    NSized N( const Vector2d& xi )
+    {
+      /* Shape functions
+       *
+       *         (6)
+       *   (3) _______(2)
+       *      |       |
+       *  (7) |       | (5)
+       *      |_______|
+       *   (0)        (1)
+       *         (4)
+       *
+       * */
 
-          const double                xi0 = xi( 0 );
-          const double                xi1 = xi( 1 );
-          Matrix< double, nNodes, 1 > N_;
-          // clang-format off
+      const double                xi0 = xi( 0 );
+      const double                xi1 = xi( 1 );
+      Matrix< double, nNodes, 1 > N_;
+      // clang-format off
                     N_ <<   (1.-xi0 ) * (1.-xi1 ) * (-1-xi0-xi1 ) /4,
                             (1.+xi0 ) * (1.-xi1 ) * (-1+xi0-xi1 ) /4,
                             (1.+xi0 ) * (1.+xi1 ) * (-1+xi0+xi1 ) /4,
@@ -102,18 +100,18 @@ namespace Marmot {
                             (1-xi0*xi0 )       * (1+xi1     ) /2,
                             (1-xi0      )     * (1-xi1*xi1 ) /2;
 
-          // clang-format on
-          return N_;
-        }
+      // clang-format on
+      return N_;
+    }
 
-        dNdXiSized dNdXi( const Vector2d& xi )
-        {
+    dNdXiSized dNdXi( const Vector2d& xi )
+    {
 
-          Matrix< double, nDim, nNodes > result;
+      Matrix< double, nDim, nNodes > result;
 
-          const double xi0 = xi( 0 );
-          const double xi1 = xi( 1 );
-          // clang-format off
+      const double xi0 = xi( 0 );
+      const double xi1 = xi( 1 );
+      // clang-format off
                     result <<
                            /*                  1                           2                           3                           4
                             *                  5                           6                           7                           8 */
@@ -123,50 +121,48 @@ namespace Marmot {
                             *                  5                           6                           7                           8*/
                            /* ,Xi2 */     (1-xi0) * (xi0+2*xi1) /4,      - (1+xi0) * (xi0-2*xi1) /4,     (1+xi0) * (xi0+2*xi1) /4,      (1-xi0) * (-xi0+2*xi1) /4,
                            /* ,Xi2 */     - (1-xi0*xi0) /2,             -xi1* (1+xi0),               + (1-xi0*xi0) /2,             -xi1* (1-xi0);
-          // clang-format on
+      // clang-format on
 
-          return result;
-        }
+      return result;
+    }
 
-        Vector3i getBoundaryElementIndices( int faceID )
-        {
-          switch ( faceID ) {
-          case 1: {
-            return ( Vector3i() << 0, 1, 4 ).finished();
-          }
-          case 2: {
-            return ( Vector3i() << 1, 2, 5 ).finished();
-          }
-          case 3: {
-            return ( Vector3i() << 2, 3, 6 ).finished();
-          }
-          case 4: {
-            return ( Vector3i() << 3, 0, 7 ).finished();
-          }
-          default: {
-            throw std::invalid_argument( "Quad8: invalid face ID specifed" );
-          }
-          }
-        }
-
-      } // end of namespace Quad8
-
-      void modifyCharElemLengthAbaqusLike( double& charElemLength, int intPoint )
-      {
-        switch ( intPoint ) {
-        case 0: // central node
-          charElemLength *= 2. / 3.;
-          break;
-        case 1: // corner nodes
-        case 2:
-        case 3:
-        case 4: charElemLength *= 5. / 12; break;
-        case 5: // middle nodes
-        case 6:
-        case 7:
-        case 8: charElemLength *= std::sqrt( 5. / 18. ); break;
-        }
+    Vector3i getBoundaryElementIndices( int faceID )
+    {
+      switch ( faceID ) {
+      case 1: {
+        return ( Vector3i() << 0, 1, 4 ).finished();
       }
-    } // end of namespace Spatial2D
-  }   // end of namespace FiniteElement
-} // end of namespace Marmot
+      case 2: {
+        return ( Vector3i() << 1, 2, 5 ).finished();
+      }
+      case 3: {
+        return ( Vector3i() << 2, 3, 6 ).finished();
+      }
+      case 4: {
+        return ( Vector3i() << 3, 0, 7 ).finished();
+      }
+      default: {
+        throw std::invalid_argument( "Quad8: invalid face ID specifed" );
+      }
+      }
+    }
+
+  } // end of namespace Quad8
+
+  void modifyCharElemLengthAbaqusLike( double& charElemLength, int intPoint )
+  {
+    switch ( intPoint ) {
+    case 0: // central node
+      charElemLength *= 2. / 3.;
+      break;
+    case 1: // corner nodes
+    case 2:
+    case 3:
+    case 4: charElemLength *= 5. / 12; break;
+    case 5: // middle nodes
+    case 6:
+    case 7:
+    case 8: charElemLength *= std::sqrt( 5. / 18. ); break;
+    }
+  }
+} // namespace Marmot::FiniteElement::Spatial2D

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement3D.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement3D.cpp
@@ -3,47 +3,45 @@
 #include <iostream>
 
 using namespace Eigen;
-namespace Marmot {
-  namespace FiniteElement {
-    namespace Spatial3D {
-      namespace Tetra4 {
+namespace Marmot::FiniteElement::Spatial3D {
+  namespace Tetra4 {
 
-        NSized N( const Vector3d& xi )
-        {
-          /*
-           *            xi(1)
-           *
-           *            (3)
-           *            /|  \
-           *           / |    \
-           *          /  |      \
-           *         /   |        \
-           *        /   (1)_________\(2)   xi(0)
-           *       /    ´        _-
-           *      /   ´     _-
-           *     /  ´   _-
-           *    (4)_-
-           *
-           *  xi(2)
-           *  */
+    NSized N( const Vector3d& xi )
+    {
+      /*
+       *            xi(1)
+       *
+       *            (3)
+       *            /|  \
+       *           / |    \
+       *          /  |      \
+       *         /   |        \
+       *        /   (1)_________\(2)   xi(0)
+       *       /    ´        _-
+       *      /   ´     _-
+       *     /  ´   _-
+       *    (4)_-
+       *
+       *  xi(2)
+       *  */
 
-          NSized N_;
+      NSized N_;
 
-          // clang-format off
+      // clang-format off
                     N_ << 1 - xi(0) - xi(1) - xi(2),
                        xi(0),
                        xi(1),
                        xi(2);
 
-          // clang-format on
+      // clang-format on
 
-          return N_;
-        }
-        dNdXiSized dNdXi( const Vector3d& xi )
-        {
-          dNdXiSized dNdXi_;
+      return N_;
+    }
+    dNdXiSized dNdXi( const Vector3d& xi )
+    {
+      dNdXiSized dNdXi_;
 
-          // clang-format off
+      // clang-format off
                     dNdXi_ << -1,
                            1,
                            0,
@@ -59,42 +57,42 @@ namespace Marmot {
                            0,
                            1;
 
-          // clang-format on
+      // clang-format on
 
-          return dNdXi_;
-        }
+      return dNdXi_;
+    }
 
-        Vector3i getBoundaryElementIndices( int faceID )
-        {
-          throw std::invalid_argument( "Tetra4: invalid face ID specifed" );
-        }
+    Vector3i getBoundaryElementIndices( int faceID )
+    {
+      throw std::invalid_argument( "Tetra4: invalid face ID specifed" );
+    }
 
-      } // namespace Tetra4
-      namespace Tetra10 {
+  } // namespace Tetra4
+  namespace Tetra10 {
 
-        NSized N( const Vector3d& xi )
-        {
-          /*
-           *            xi(1)
-           *
-           *            (2)
-           *            /|  \
-           *           / |    \
-           *          / (6)   (5)
-           *       (9)   |        \
-           *        /   (3)__(7)____\(1)   xi(0)
-           *       /    ´        _-
-           *      /  (10)   (8)
-           *     /  ´   _-
-           *    (4)_-
-           *
-           *  xi(2)
-           *
-           *  */
+    NSized N( const Vector3d& xi )
+    {
+      /*
+       *            xi(1)
+       *
+       *            (2)
+       *            /|  \
+       *           / |    \
+       *          / (6)   (5)
+       *       (9)   |        \
+       *        /   (3)__(7)____\(1)   xi(0)
+       *       /    ´        _-
+       *      /  (10)   (8)
+       *     /  ´   _-
+       *    (4)_-
+       *
+       *  xi(2)
+       *
+       *  */
 
-          NSized N_;
+      NSized N_;
 
-          // clang-format off
+      // clang-format off
                     N_ <<   xi( 1 ) * ( 2 * xi( 1 ) - 1 ),
                             xi( 2 ) * ( 2 * xi( 2 ) - 1 ),
                             ( 1 - xi( 0 ) - xi( 1 ) - xi( 2 ) ) * ( 1 - 2 * xi( 0 ) - 2 * xi( 1 ) - 2 * xi( 2 ) ),
@@ -105,15 +103,15 @@ namespace Marmot {
                             4 * xi( 0 ) * xi( 1 ),
                             4 * xi( 0 ) * xi( 2 ),
                             4 * xi( 0 ) * ( 1 - xi( 0 ) - xi( 1 ) - xi( 2 ) );
-          // clang-format on
+      // clang-format on
 
-          return N_;
-        }
-        dNdXiSized dNdXi( const Vector3d& xi )
-        {
-          dNdXiSized dNdXi_;
+      return N_;
+    }
+    dNdXiSized dNdXi( const Vector3d& xi )
+    {
+      dNdXiSized dNdXi_;
 
-          // clang-format off
+      // clang-format off
                     dNdXi_ <<
                             0,
                             0,
@@ -168,42 +166,42 @@ namespace Marmot {
                             4 * xi( 0 ) * 1,
                             4 * xi( 0 ) * ( -1 );
 
-          // clang-format on
+      // clang-format on
 
-          return dNdXi_;
-        }
+      return dNdXi_;
+    }
 
-        Vector3i getBoundaryElementIndices( int faceID )
-        {
-          throw std::invalid_argument( "Tetra4: invalid face ID specifed" );
-        }
+    Vector3i getBoundaryElementIndices( int faceID )
+    {
+      throw std::invalid_argument( "Tetra4: invalid face ID specifed" );
+    }
 
-      } // namespace Tetra10
+  } // namespace Tetra10
 
-      namespace Hexa8 {
+  namespace Hexa8 {
 
-        NSized N( const Vector3d& xi )
-        {
-          /*
-           *        (8)________(7)
-           *          /|      /|
-           *      (5)/_|_____(6)
-           *        |  |     | |
-           *        |(4)_____|_|(3)
-           *        | /      | /
-           *        |/_______|/
-           *     (1)        (2)
-           *
-           *
-           *     x3  x2
-           *     | /
-           *     |/___x1
-           *
-           *  */
+    NSized N( const Vector3d& xi )
+    {
+      /*
+       *        (8)________(7)
+       *          /|      /|
+       *      (5)/_|_____(6)
+       *        |  |     | |
+       *        |(4)_____|_|(3)
+       *        | /      | /
+       *        |/_______|/
+       *     (1)        (2)
+       *
+       *
+       *     x3  x2
+       *     | /
+       *     |/___x1
+       *
+       *  */
 
-          NSized N_;
+      NSized N_;
 
-          // clang-format off
+      // clang-format off
                     N_ << (1-xi (0)) * (1-xi (1)) * (1-xi (2)),
                        (1+xi (0)) * (1-xi (1)) * (1-xi (2)),
                        (1+xi (0)) * (1+xi (1)) * (1-xi (2)),
@@ -212,16 +210,16 @@ namespace Marmot {
                        (1+xi (0)) * (1-xi (1)) * (1+xi (2)),
                        (1+xi (0)) * (1+xi (1)) * (1+xi (2)),
                        (1-xi (0)) * (1+xi (1)) * (1+xi (2));
-          // clang-format on
+      // clang-format on
 
-          N_ *= 1. / 8;
-          return N_;
-        }
-        dNdXiSized dNdXi( const Vector3d& xi )
-        {
-          dNdXiSized dNdXi_;
+      N_ *= 1. / 8;
+      return N_;
+    }
+    dNdXiSized dNdXi( const Vector3d& xi )
+    {
+      dNdXiSized dNdXi_;
 
-          // clang-format off
+      // clang-format off
                     dNdXi_ <<
                         -1 * (1-xi (1)) * (1-xi (2)),
                         +1 * (1-xi (1)) * (1-xi (2)),
@@ -251,74 +249,74 @@ namespace Marmot {
                         (1-xi (0)) * (1+xi (1)) * +1;
 
                     dNdXi_ *= 1./8;
-          // clang-format on
+      // clang-format on
 
-          return dNdXi_;
-        }
+      return dNdXi_;
+    }
 
-        Vector4i getBoundaryElementIndices( int faceID )
-        {
-          switch ( faceID ) {
-          // bottom
-          case 1: {
-            return ( Vector4i() << 3, 2, 1, 0 ).finished();
-          }
-            // top
-          case 2: {
-            return ( Vector4i() << 4, 5, 6, 7 ).finished();
-          }
-            // front
-          case 3: {
-            return ( Vector4i() << 0, 1, 5, 4 ).finished();
-          }
-            // right
-          case 4: {
-            return ( Vector4i() << 6, 5, 1, 2 ).finished();
-          }
-            // back
-          case 5: {
-            return ( Vector4i() << 7, 6, 2, 3 ).finished();
-          }
-            // left
-          case 6: {
-            return ( Vector4i() << 4, 7, 3, 0 ).finished();
-          }
-          default: {
-            throw std::invalid_argument( "Hexa8: invalid face ID specifed" );
-          }
-          }
-        }
+    Vector4i getBoundaryElementIndices( int faceID )
+    {
+      switch ( faceID ) {
+      // bottom
+      case 1: {
+        return ( Vector4i() << 3, 2, 1, 0 ).finished();
+      }
+        // top
+      case 2: {
+        return ( Vector4i() << 4, 5, 6, 7 ).finished();
+      }
+        // front
+      case 3: {
+        return ( Vector4i() << 0, 1, 5, 4 ).finished();
+      }
+        // right
+      case 4: {
+        return ( Vector4i() << 6, 5, 1, 2 ).finished();
+      }
+        // back
+      case 5: {
+        return ( Vector4i() << 7, 6, 2, 3 ).finished();
+      }
+        // left
+      case 6: {
+        return ( Vector4i() << 4, 7, 3, 0 ).finished();
+      }
+      default: {
+        throw std::invalid_argument( "Hexa8: invalid face ID specifed" );
+      }
+      }
+    }
 
-      } // end of namespace Hexa8
+  } // end of namespace Hexa8
 
-      namespace Hexa20 {
-        NSized N( const Vector3d& xi )
-        {
-          /*
-           *           (8)_____(15)_____(7)
-           *            /|             /|
-           *       (16)/ |            /(14)
-           *          /  |           /  |
-           *      (5)/___|__(13)___(6)  |
-           *        |  (18)         | (17)
-           *        |    |          |   |
-           *        |  (4)___(11)___|___|(3)
-           *      (15)  /         (16)  /
-           *        |  /(12)        |  /(10)
-           *        | /             | /
-           *        |/______________|/
-           *     (1)       (9)      (2)
-           *
-           *
-           *     x3  x2
-           *     | /
-           *     |/___x1
-           *
-           *  */
+  namespace Hexa20 {
+    NSized N( const Vector3d& xi )
+    {
+      /*
+       *           (8)_____(15)_____(7)
+       *            /|             /|
+       *       (16)/ |            /(14)
+       *          /  |           /  |
+       *      (5)/___|__(13)___(6)  |
+       *        |  (18)         | (17)
+       *        |    |          |   |
+       *        |  (4)___(11)___|___|(3)
+       *      (15)  /         (16)  /
+       *        |  /(12)        |  /(10)
+       *        | /             | /
+       *        |/______________|/
+       *     (1)       (9)      (2)
+       *
+       *
+       *     x3  x2
+       *     | /
+       *     |/___x1
+       *
+       *  */
 
-          NSized N_;
-          // Taken from mpFEM - Peter Gamnitzer
-          // clang-format off
+      NSized N_;
+      // Taken from mpFEM - Peter Gamnitzer
+      // clang-format off
                     N_ <<
                         -0.125* (1-xi (0)) * (1-xi (1)) * (1-xi (2)) * (2+xi (0)+xi (1)+xi (2)),
                         -0.125* (1+xi (0)) * (1-xi (1)) * (1-xi (2)) * (2-xi (0)+xi (1)+xi (2)),
@@ -340,14 +338,14 @@ namespace Marmot {
                         0.25* (1+xi (0)) * (1-xi (1)) * (1-xi (2) *xi (2)),
                         0.25* (1+xi (0)) * (1+xi (1)) * (1-xi (2) *xi (2)),
                         0.25* (1-xi (0)) * (1+xi (1)) * (1-xi (2) *xi (2));
-          // clang-format on
-          return N_;
-        }
-        dNdXiSized dNdXi( const Vector3d& xi )
-        {
-          dNdXiSized dNdXi_;
+      // clang-format on
+      return N_;
+    }
+    dNdXiSized dNdXi( const Vector3d& xi )
+    {
+      dNdXiSized dNdXi_;
 
-          // clang-format off
+      // clang-format off
                     dNdXi_ <<
                         0.125	*	 (1-xi[1]) *	 (1-xi[2]) *	 (1+2*	xi[0]+xi[1]+xi[2]),
                         -0.125	*	 (1-xi[1]) *	 (1-xi[2]) *	 (1-2*	xi[0]+xi[1]+xi[2]),
@@ -410,37 +408,35 @@ namespace Marmot {
                         -0.5	*	 (1+xi[0]) *	 (1+xi[1]) *	xi[2],
                         -0.5	*	 (1-xi[0]) *	 (1+xi[1]) *	xi[2];
 
-          // clang-format on
-          return dNdXi_;
-        }
+      // clang-format on
+      return dNdXi_;
+    }
 
-        Vector8i getBoundaryElementIndices( int faceID )
-        {
-          switch ( faceID ) {
-          case 1: {
-            return ( Vector8i() << 3, 2, 1, 0, 10, 9, 8, 11 ).finished();
-          }
-          case 2: {
-            return ( Vector8i() << 4, 5, 6, 7, 12, 13, 14, 15 ).finished();
-          }
-          case 3: {
-            return ( Vector8i() << 0, 1, 5, 4, 8, 17, 12, 16 ).finished();
-          }
-          case 4: {
-            return ( Vector8i() << 6, 5, 1, 2, 13, 17, 9, 18 ).finished();
-          }
-          case 5: {
-            return ( Vector8i() << 7, 6, 2, 3, 14, 18, 10, 19 ).finished();
-          }
-          case 6: {
-            return ( Vector8i() << 4, 7, 3, 0, 15, 19, 11, 16 ).finished();
-          }
-          default: {
-            throw std::invalid_argument( "Hexa8: invalid face ID specifed" );
-          }
-          }
-        }
-      } // end of namespace Hexa20
-    }   // end of namespace Spatial3D
-  }     // namespace FiniteElement
-} // end of namespace Marmot
+    Vector8i getBoundaryElementIndices( int faceID )
+    {
+      switch ( faceID ) {
+      case 1: {
+        return ( Vector8i() << 3, 2, 1, 0, 10, 9, 8, 11 ).finished();
+      }
+      case 2: {
+        return ( Vector8i() << 4, 5, 6, 7, 12, 13, 14, 15 ).finished();
+      }
+      case 3: {
+        return ( Vector8i() << 0, 1, 5, 4, 8, 17, 12, 16 ).finished();
+      }
+      case 4: {
+        return ( Vector8i() << 6, 5, 1, 2, 13, 17, 9, 18 ).finished();
+      }
+      case 5: {
+        return ( Vector8i() << 7, 6, 2, 3, 14, 18, 10, 19 ).finished();
+      }
+      case 6: {
+        return ( Vector8i() << 4, 7, 3, 0, 15, 19, 11, 16 ).finished();
+      }
+      default: {
+        throw std::invalid_argument( "Hexa8: invalid face ID specifed" );
+      }
+      }
+    }
+  } // end of namespace Hexa20
+} // namespace Marmot::FiniteElement::Spatial3D

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementBoundary.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementBoundary.cpp
@@ -5,205 +5,204 @@
 #include <stdexcept>
 
 using namespace Eigen;
-namespace Marmot {
-  namespace FiniteElement {
+namespace Marmot::FiniteElement {
 
-    BoundaryElement::BoundaryElement( ElementShapes   parentShape,
-                                      int             parentFaceNumber,
-                                      int             nDim,
-                                      const VectorXd& parentCoordinates )
-      : nDim( nDim )
-    {
-      // get boundary shape dependent on parental shape
-      switch ( parentShape ) {
-        /*
-         * Extend for future elements here ... (scroll down) ..
-         *
-         * */
+  BoundaryElement::BoundaryElement( ElementShapes   parentShape,
+                                    int             parentFaceNumber,
+                                    int             nDim,
+                                    const VectorXd& parentCoordinates )
+    : nDim( nDim )
+  {
+    // get boundary shape dependent on parental shape
+    switch ( parentShape ) {
+      /*
+       * Extend for future elements here ... (scroll down) ..
+       *
+       * */
 
+    case Quad4: {
+      boundaryShape             = Bar2;
+      nNodes                    = Spatial1D::Bar2::nNodes;
+      mapBoundaryToParentScalar = VectorXi( Spatial2D::Quad4::getBoundaryElementIndices( parentFaceNumber ) );
+      break;
+    }
+
+    case Quad8: {
+      boundaryShape             = Bar3;
+      nNodes                    = Spatial1D::Bar3::nNodes;
+      mapBoundaryToParentScalar = VectorXi( Spatial2D::Quad8::getBoundaryElementIndices( parentFaceNumber ) );
+      break;
+    }
+    case Hexa8: {
+      boundaryShape             = Quad4;
+      nNodes                    = Spatial2D::Quad4::nNodes;
+      mapBoundaryToParentScalar = Spatial3D::Hexa8::getBoundaryElementIndices( parentFaceNumber );
+      break;
+    }
+    case Hexa20: {
+      boundaryShape             = Quad8;
+      nNodes                    = Spatial2D::Quad8::nNodes;
+      mapBoundaryToParentScalar = Spatial3D::Hexa20::getBoundaryElementIndices( parentFaceNumber );
+      break;
+    }
+
+    default: throw std::invalid_argument( "Boundary Element currently not implemented" );
+    }
+
+    // get the 'condensed' boundary element coordinates
+    nParentCoordinates           = parentCoordinates.size();
+    mapBoundaryToParentVectorial = expandNodeIndicesToCoordinateIndices( mapBoundaryToParentScalar, nDim );
+    coordinates                  = condenseParentToBoundaryVectorial( parentCoordinates );
+
+    // get the proper gausspoints for the boundary element
+
+    // compute for each quadraturePoint the
+    // - dNdXi
+    // - Jacobian pp(x,xi)
+    // - areaVector
+    for ( const auto& quadraturePointInfo : FiniteElement::Quadrature::
+            getGaussPointInfo( boundaryShape, FiniteElement::Quadrature::IntegrationTypes::FullIntegration ) ) {
+
+      BoundaryElementQuadraturePoint qp;
+      qp.xi     = quadraturePointInfo.xi;
+      qp.weight = quadraturePointInfo.weight;
+
+      // N
+      // dNdXi
+      switch ( boundaryShape ) {
+      /*
+       * ... and extend for future elements here!
+       *
+       * */
+      case Bar2: {
+        qp.N     = Spatial1D::Bar2::N( qp.xi( 0 ) );
+        qp.dNdXi = Spatial1D::Bar2::dNdXi( qp.xi( 0 ) );
+        break;
+      }
+      case Bar3: {
+        qp.N     = Spatial1D::Bar3::N( qp.xi( 0 ) );
+        qp.dNdXi = Spatial1D::Bar3::dNdXi( qp.xi( 0 ) );
+        break;
+      }
       case Quad4: {
-        boundaryShape             = Bar2;
-        nNodes                    = Spatial1D::Bar2::nNodes;
-        mapBoundaryToParentScalar = VectorXi( Spatial2D::Quad4::getBoundaryElementIndices( parentFaceNumber ) );
+        qp.N     = Spatial2D::Quad4::N( qp.xi );
+        qp.dNdXi = Spatial2D::Quad4::dNdXi( qp.xi );
         break;
       }
-
       case Quad8: {
-        boundaryShape             = Bar3;
-        nNodes                    = Spatial1D::Bar3::nNodes;
-        mapBoundaryToParentScalar = VectorXi( Spatial2D::Quad8::getBoundaryElementIndices( parentFaceNumber ) );
-        break;
-      }
-      case Hexa8: {
-        boundaryShape             = Quad4;
-        nNodes                    = Spatial2D::Quad4::nNodes;
-        mapBoundaryToParentScalar = Spatial3D::Hexa8::getBoundaryElementIndices( parentFaceNumber );
-        break;
-      }
-      case Hexa20: {
-        boundaryShape             = Quad8;
-        nNodes                    = Spatial2D::Quad8::nNodes;
-        mapBoundaryToParentScalar = Spatial3D::Hexa20::getBoundaryElementIndices( parentFaceNumber );
+        qp.N     = Spatial2D::Quad8::N( qp.xi );
+        qp.dNdXi = Spatial2D::Quad8::dNdXi( Vector2d( qp.xi ) );
         break;
       }
 
-      default: throw std::invalid_argument( "Boundary Element currently not implemented" );
+      default: break; // exception handling already in first switch
       }
 
-      // get the 'condensed' boundary element coordinates
-      nParentCoordinates           = parentCoordinates.size();
-      mapBoundaryToParentVectorial = expandNodeIndicesToCoordinateIndices( mapBoundaryToParentScalar, nDim );
-      coordinates                  = condenseParentToBoundaryVectorial( parentCoordinates );
+      // Jacobian
+      qp.dx_dXi = Jacobian( qp.dNdXi, coordinates );
 
-      // get the proper gausspoints for the boundary element
-
-      // compute for each quadraturePoint the
-      // - dNdXi
-      // - Jacobian pp(x,xi)
-      // - areaVector
-      for ( const auto& quadraturePointInfo : FiniteElement::Quadrature::
-              getGaussPointInfo( boundaryShape, FiniteElement::Quadrature::IntegrationTypes::FullIntegration ) ) {
-
-        BoundaryElementQuadraturePoint qp;
-        qp.xi     = quadraturePointInfo.xi;
-        qp.weight = quadraturePointInfo.weight;
-
-        // N
-        // dNdXi
-        switch ( boundaryShape ) {
-        /*
-         * ... and extend for future elements here!
-         *
-         * */
-        case Bar2: {
-          qp.N     = Spatial1D::Bar2::N( qp.xi( 0 ) );
-          qp.dNdXi = Spatial1D::Bar2::dNdXi( qp.xi( 0 ) );
-          break;
-        }
-        case Bar3: {
-          qp.N     = Spatial1D::Bar3::N( qp.xi( 0 ) );
-          qp.dNdXi = Spatial1D::Bar3::dNdXi( qp.xi( 0 ) );
-          break;
-        }
-        case Quad4: {
-          qp.N     = Spatial2D::Quad4::N( qp.xi );
-          qp.dNdXi = Spatial2D::Quad4::dNdXi( qp.xi );
-          break;
-        }
-        case Quad8: {
-          qp.N     = Spatial2D::Quad8::N( qp.xi );
-          qp.dNdXi = Spatial2D::Quad8::dNdXi( Vector2d( qp.xi ) );
-          break;
-        }
-
-        default: break; // exception handling already in first switch
-        }
-
-        // Jacobian
-        qp.dx_dXi = Jacobian( qp.dNdXi, coordinates );
-
-        // areaVector and integration area
-        if ( nDim == 2 ) {
-          // 90deg rotation
-          Vector2d n;
-          n << qp.dx_dXi( 1 ), -qp.dx_dXi( 0 );
-          qp.areaVector = n;
-        }
-        else {
-          // cross product
-          typedef Eigen::Ref< const Vector3d > vector3_cr;
-          Vector3d n    = vector3_cr( qp.dx_dXi.col( 0 ) ).cross( vector3_cr( qp.dx_dXi.col( 1 ) ) );
-          qp.areaVector = n;
-        }
-
-        qp.JxW = qp.areaVector.norm() * qp.weight;
-
-        quadraturePoints.push_back( std::move( qp ) );
-      }
-    }
-
-    VectorXd BoundaryElement::computeScalarLoadVector()
-    {
-      /* compute the load vector for a constant scalar distributed load
-       * Attention: result =  boundary-element-sized!
-       *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
-       * */
-
-      VectorXd Pk = VectorXd::Zero( nNodes );
-
-      for ( const auto& qp : quadraturePoints )
-        Pk += qp.JxW * qp.N;
-
-      return Pk;
-    }
-
-    MatrixXd BoundaryElement::computeDScalarLoadVector_dCoordinates()
-    {
-      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented" );
-      VectorXd Pk = VectorXd::Zero( nNodes );
-
-      return Pk;
-    }
-
-    VectorXd BoundaryElement::computeSurfaceNormalVectorialLoadVector()
-    {
-      /* compute the load vector for a constant distributed load (e.g. pressure)
-       * Attention: result =  boundary-element-sized!
-       *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
-       * */
-
-      VectorXd Pk = VectorXd::Zero( coordinates.size() );
-
-      for ( const auto& qp : quadraturePoints )
-        Pk += qp.weight * qp.areaVector.transpose() * NB( qp.N, nDim );
-
-      return Pk;
-    }
-
-    VectorXd BoundaryElement::computeSurfaceNormalVectorialLoadVectorForAxisymmetricElements()
-    {
-      /* compute the load vector for a constant distributed load (e.g. pressure) for axisymmetric elements
-       * (circumferential integration included)
-       * Attention: result =  boundary-element-sized!
-       *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
-       * */
-
-      VectorXd Pk = VectorXd::Zero( coordinates.size() );
-
-      for ( const auto& qp : quadraturePoints ) {
-        // Pk += qp.weight * qp.areaVector.transpose() * NB( qp.N, nDim );
-        Eigen::VectorXd coordAtGauss = NB( qp.N, nDim ) * coordinates;
-        Pk += qp.weight * 2. * coordAtGauss( 0 ) * Constants::Pi * qp.areaVector.transpose() * NB( qp.N, nDim );
-      }
-
-      return Pk;
-    }
-
-    MatrixXd BoundaryElement::computeDSurfaceNormalVectorialLoadVector_dCoordinates()
-    {
-      MatrixXd K = MatrixXd::Zero( coordinates.size(), coordinates.size() );
-
+      // areaVector and integration area
       if ( nDim == 2 ) {
-        // Neuner, November 2018
-        Matrix2d R;
-        // clang-format off
+        // 90deg rotation
+        Vector2d n;
+        n << qp.dx_dXi( 1 ), -qp.dx_dXi( 0 );
+        qp.areaVector = n;
+      }
+      else {
+        // cross product
+        typedef Eigen::Ref< const Vector3d > vector3_cr;
+        Vector3d n    = vector3_cr( qp.dx_dXi.col( 0 ) ).cross( vector3_cr( qp.dx_dXi.col( 1 ) ) );
+        qp.areaVector = n;
+      }
+
+      qp.JxW = qp.areaVector.norm() * qp.weight;
+
+      quadraturePoints.push_back( std::move( qp ) );
+    }
+  }
+
+  VectorXd BoundaryElement::computeScalarLoadVector()
+  {
+    /* compute the load vector for a constant scalar distributed load
+     * Attention: result =  boundary-element-sized!
+     *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
+     * */
+
+    VectorXd Pk = VectorXd::Zero( nNodes );
+
+    for ( const auto& qp : quadraturePoints )
+      Pk += qp.JxW * qp.N;
+
+    return Pk;
+  }
+
+  MatrixXd BoundaryElement::computeDScalarLoadVector_dCoordinates()
+  {
+    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented" );
+    VectorXd Pk = VectorXd::Zero( nNodes );
+
+    return Pk;
+  }
+
+  VectorXd BoundaryElement::computeSurfaceNormalVectorialLoadVector()
+  {
+    /* compute the load vector for a constant distributed load (e.g. pressure)
+     * Attention: result =  boundary-element-sized!
+     *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
+     * */
+
+    VectorXd Pk = VectorXd::Zero( coordinates.size() );
+
+    for ( const auto& qp : quadraturePoints )
+      Pk += qp.weight * qp.areaVector.transpose() * NB( qp.N, nDim );
+
+    return Pk;
+  }
+
+  VectorXd BoundaryElement::computeSurfaceNormalVectorialLoadVectorForAxisymmetricElements()
+  {
+    /* compute the load vector for a constant distributed load (e.g. pressure) for axisymmetric elements
+     * (circumferential integration included)
+     * Attention: result =  boundary-element-sized!
+     *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
+     * */
+
+    VectorXd Pk = VectorXd::Zero( coordinates.size() );
+
+    for ( const auto& qp : quadraturePoints ) {
+      // Pk += qp.weight * qp.areaVector.transpose() * NB( qp.N, nDim );
+      Eigen::VectorXd coordAtGauss = NB( qp.N, nDim ) * coordinates;
+      Pk += qp.weight * 2. * coordAtGauss( 0 ) * Constants::Pi * qp.areaVector.transpose() * NB( qp.N, nDim );
+    }
+
+    return Pk;
+  }
+
+  MatrixXd BoundaryElement::computeDSurfaceNormalVectorialLoadVector_dCoordinates()
+  {
+    MatrixXd K = MatrixXd::Zero( coordinates.size(), coordinates.size() );
+
+    if ( nDim == 2 ) {
+      // Neuner, November 2018
+      Matrix2d R;
+      // clang-format off
                 R << 0, 1,
                     -1, 0;
-        // clang-format on
+      // clang-format on
 
-        for ( const auto& qp : quadraturePoints )
-          for ( int I = 0; I < nNodes; I++ )
-            for ( int J = 0; J < nNodes; J++ )
-              K.block< 2, 2 >( I * 2, J * 2 ) += qp.N( I ) * qp.dNdXi( J ) * R * qp.weight;
-      }
+      for ( const auto& qp : quadraturePoints )
+        for ( int I = 0; I < nNodes; I++ )
+          for ( int J = 0; J < nNodes; J++ )
+            K.block< 2, 2 >( I * 2, J * 2 ) += qp.N( I ) * qp.dNdXi( J ) * R * qp.weight;
+    }
 
-      else if ( nDim == 3 ) {
-        // Belytschko et al. 2014, pp.364
-        Matrix3d HXi0, HXi1;
-        for ( const auto& qp : quadraturePoints ) {
-          const MatrixXd& J = qp.dx_dXi;
+    else if ( nDim == 3 ) {
+      // Belytschko et al. 2014, pp.364
+      Matrix3d HXi0, HXi1;
+      for ( const auto& qp : quadraturePoints ) {
+        const MatrixXd& J = qp.dx_dXi;
 
-          // clang-format off
+        // clang-format off
                     HXi0 << 0,       J(2,0), -J(1,0),
                            -J(2,0),  0,       J(0,0),
                             J(1,0), -J(0,0),  0;
@@ -211,104 +210,103 @@ namespace Marmot {
                     HXi1 << 0,       J(2,1), -J(1,1),
                            -J(2,1),  0,       J(0,1),
                             J(1,1), -J(0,1),  0;
-          // clang-format on
+        // clang-format on
 
-          for ( int I = 0; I < nNodes; I++ )
-            for ( int J = 0; J < nNodes; J++ )
-              K.block< 3, 3 >( I * 3, J * 3 ) += qp.N( I ) * ( qp.dNdXi( 0, J ) * HXi1 - qp.dNdXi( 1, J ) * HXi0 ) *
-                                                 qp.weight;
-        }
+        for ( int I = 0; I < nNodes; I++ )
+          for ( int J = 0; J < nNodes; J++ )
+            K.block< 3, 3 >( I * 3, J * 3 ) += qp.N( I ) * ( qp.dNdXi( 0, J ) * HXi1 - qp.dNdXi( 1, J ) * HXi0 ) *
+                                               qp.weight;
       }
-
-      return K;
     }
 
-    VectorXd BoundaryElement::computeVectorialLoadVector( const Eigen::VectorXd& direction )
-    {
-      /* compute the load vector for a constant distributed load (e.g. traction) in arbitrary direction
-       * Attention: result =  boundary-element-sized!
-       *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
-       * */
+    return K;
+  }
 
-      VectorXd Pk = VectorXd::Zero( coordinates.size() );
+  VectorXd BoundaryElement::computeVectorialLoadVector( const Eigen::VectorXd& direction )
+  {
+    /* compute the load vector for a constant distributed load (e.g. traction) in arbitrary direction
+     * Attention: result =  boundary-element-sized!
+     *  -> use expandBoundaryToParentVector to obtain the parent-element-sized load vector
+     * */
 
-      for ( const auto& qp : quadraturePoints )
-        Pk += qp.JxW * direction.transpose() * NB( qp.N, nDim );
+    VectorXd Pk = VectorXd::Zero( coordinates.size() );
 
-      return Pk;
-    }
+    for ( const auto& qp : quadraturePoints )
+      Pk += qp.JxW * direction.transpose() * NB( qp.N, nDim );
 
-    MatrixXd BoundaryElement::computeDVectorialLoadVector_dCoordinates( const Eigen::VectorXd& direction )
-    {
-      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented" );
-      VectorXd Pk = VectorXd::Zero( coordinates.size() );
+    return Pk;
+  }
 
-      return Pk;
-    }
+  MatrixXd BoundaryElement::computeDVectorialLoadVector_dCoordinates( const Eigen::VectorXd& direction )
+  {
+    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented" );
+    VectorXd Pk = VectorXd::Zero( coordinates.size() );
 
-    VectorXd BoundaryElement::condenseParentToBoundaryScalar( const VectorXd& parentVector )
-    {
-      /** Condense any scalar quantiaty parent vector to the corresponding boundary child vector (e.g.
-       * temperature fields ) dependent on the underlying indices mapping
-       * */
-      VectorXd boundaryVector( nNodes * nDim );
+    return Pk;
+  }
 
-      for ( int i = 0; i < mapBoundaryToParentScalar.size(); i++ )
-        boundaryVector( i ) = parentVector( mapBoundaryToParentScalar( i ) );
+  VectorXd BoundaryElement::condenseParentToBoundaryScalar( const VectorXd& parentVector )
+  {
+    /** Condense any scalar quantiaty parent vector to the corresponding boundary child vector (e.g.
+     * temperature fields ) dependent on the underlying indices mapping
+     * */
+    VectorXd boundaryVector( nNodes * nDim );
 
-      return boundaryVector;
-    }
+    for ( int i = 0; i < mapBoundaryToParentScalar.size(); i++ )
+      boundaryVector( i ) = parentVector( mapBoundaryToParentScalar( i ) );
 
-    void BoundaryElement::assembleIntoParentScalar( const Eigen::VectorXd&        boundaryVector,
-                                                    Eigen::Ref< Eigen::VectorXd > parentVector )
-    {
-      /* assemble any scalar boundary load vector (e.g. temperature load) into the corresponding parental vector
-       * */
+    return boundaryVector;
+  }
 
-      for ( int i = 0; i < boundaryVector.size(); i++ )
-        parentVector( mapBoundaryToParentScalar( i ) ) += boundaryVector( i );
-    }
+  void BoundaryElement::assembleIntoParentScalar( const Eigen::VectorXd&        boundaryVector,
+                                                  Eigen::Ref< Eigen::VectorXd > parentVector )
+  {
+    /* assemble any scalar boundary load vector (e.g. temperature load) into the corresponding parental vector
+     * */
 
-    void BoundaryElement::assembleIntoParentStiffnessScalar( const Eigen::MatrixXd&        KBoundary,
-                                                             Eigen::Ref< Eigen::MatrixXd > KParent )
-    {
-      // mind the negative sign for a proper assembly of the residual(!) stiffness !
-      for ( int i = 0; i < KBoundary.cols(); i++ )
-        for ( int j = 0; j < KBoundary.cols(); j++ )
-          KParent( mapBoundaryToParentScalar( i ), mapBoundaryToParentScalar( j ) ) -= KBoundary( i, j );
-    }
+    for ( int i = 0; i < boundaryVector.size(); i++ )
+      parentVector( mapBoundaryToParentScalar( i ) ) += boundaryVector( i );
+  }
 
-    VectorXd BoundaryElement::condenseParentToBoundaryVectorial( const VectorXd& parentVector )
-    {
-      /*  condense any parent vector to the corresponding boundary child vector (e.g.
-       * coordinates) dependent on the underlying indices mapping
-       * */
-      VectorXd boundaryVector( nNodes * nDim );
+  void BoundaryElement::assembleIntoParentStiffnessScalar( const Eigen::MatrixXd&        KBoundary,
+                                                           Eigen::Ref< Eigen::MatrixXd > KParent )
+  {
+    // mind the negative sign for a proper assembly of the residual(!) stiffness !
+    for ( int i = 0; i < KBoundary.cols(); i++ )
+      for ( int j = 0; j < KBoundary.cols(); j++ )
+        KParent( mapBoundaryToParentScalar( i ), mapBoundaryToParentScalar( j ) ) -= KBoundary( i, j );
+  }
 
-      for ( int i = 0; i < mapBoundaryToParentVectorial.size(); i++ )
-        boundaryVector( i ) = parentVector( mapBoundaryToParentVectorial( i ) );
+  VectorXd BoundaryElement::condenseParentToBoundaryVectorial( const VectorXd& parentVector )
+  {
+    /*  condense any parent vector to the corresponding boundary child vector (e.g.
+     * coordinates) dependent on the underlying indices mapping
+     * */
+    VectorXd boundaryVector( nNodes * nDim );
 
-      return boundaryVector;
-    }
+    for ( int i = 0; i < mapBoundaryToParentVectorial.size(); i++ )
+      boundaryVector( i ) = parentVector( mapBoundaryToParentVectorial( i ) );
 
-    void BoundaryElement::assembleIntoParentVectorial( const Eigen::VectorXd&        boundaryVector,
-                                                       Eigen::Ref< Eigen::VectorXd > parentVector )
-    {
-      /* assemble any boundary vector (e.g. pressure load) into the corresponding parental vector
-       * */
+    return boundaryVector;
+  }
 
-      for ( int i = 0; i < boundaryVector.size(); i++ )
-        parentVector( mapBoundaryToParentVectorial( i ) ) += boundaryVector( i );
-    }
+  void BoundaryElement::assembleIntoParentVectorial( const Eigen::VectorXd&        boundaryVector,
+                                                     Eigen::Ref< Eigen::VectorXd > parentVector )
+  {
+    /* assemble any boundary vector (e.g. pressure load) into the corresponding parental vector
+     * */
 
-    void BoundaryElement::assembleIntoParentStiffnessVectorial( const Eigen::MatrixXd&        KBoundary,
-                                                                Eigen::Ref< Eigen::MatrixXd > KParent )
-    {
-      // mind the negative sign for a proper assembly of the residual(!) stiffness !
-      for ( int i = 0; i < KBoundary.cols(); i++ )
-        for ( int j = 0; j < KBoundary.cols(); j++ )
-          KParent( mapBoundaryToParentVectorial( i ), mapBoundaryToParentVectorial( j ) ) -= KBoundary( i, j );
-    }
+    for ( int i = 0; i < boundaryVector.size(); i++ )
+      parentVector( mapBoundaryToParentVectorial( i ) ) += boundaryVector( i );
+  }
 
-  } // namespace FiniteElement
-} // namespace Marmot
+  void BoundaryElement::assembleIntoParentStiffnessVectorial( const Eigen::MatrixXd&        KBoundary,
+                                                              Eigen::Ref< Eigen::MatrixXd > KParent )
+  {
+    // mind the negative sign for a proper assembly of the residual(!) stiffness !
+    for ( int i = 0; i < KBoundary.cols(); i++ )
+      for ( int j = 0; j < KBoundary.cols(); j++ )
+        KParent( mapBoundaryToParentVectorial( i ), mapBoundaryToParentVectorial( j ) ) -= KBoundary( i, j );
+  }
+
+} // namespace Marmot::FiniteElement

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
@@ -3,274 +3,284 @@
 #include "Marmot/MarmotVoigt.h"
 #include <iostream>
 
-using namespace Eigen;
-MarmotElementSpatialWrapper::MarmotElementSpatialWrapper( int                              nDim,
-                                                          int                              nDimChild,
-                                                          int                              nNodes,
-                                                          int                              nRhsChild,
-                                                          const int                        rhsIndicesToBeWrapped[],
-                                                          int                              nRhsIndicesToBeWrapped,
-                                                          std::unique_ptr< MarmotElement > childElement )
+namespace Marmot {
 
-  : nDim( nDim ),
-    nDimChild( nDimChild ),
-    nNodes( nNodes ),
-    nRhsChild( nRhsChild ),
-    rhsIndicesToBeProjected( rhsIndicesToBeWrapped, nRhsIndicesToBeWrapped ),
-    projectedSize( nRhsChild ),
-    unprojectedSize( nRhsChild + rhsIndicesToBeProjected.size() * ( nDim - nDimChild ) ),
-    childElement( std::move( childElement ) )
-{
-}
+  using namespace Eigen;
+  MarmotElementSpatialWrapper::MarmotElementSpatialWrapper( int                              nDim,
+                                                            int                              nDimChild,
+                                                            int                              nNodes,
+                                                            int                              nRhsChild,
+                                                            const int                        rhsIndicesToBeWrapped[],
+                                                            int                              nRhsIndicesToBeWrapped,
+                                                            std::unique_ptr< MarmotElement > childElement )
 
-int MarmotElementSpatialWrapper::getNumberOfRequiredStateVars()
-{
-  return childElement->getNumberOfRequiredStateVars();
-}
-
-std::vector< std::vector< std::string > > MarmotElementSpatialWrapper::getNodeFields()
-{
-  return childElement->getNodeFields();
-}
-
-int MarmotElementSpatialWrapper::getNNodes()
-{
-  return nNodes;
-}
-
-int MarmotElementSpatialWrapper::getNSpatialDimensions()
-{
-  return nDim;
-}
-
-int MarmotElementSpatialWrapper::getNDofPerElement()
-{
-  return unprojectedSize;
-}
-
-std::string MarmotElementSpatialWrapper::getElementShape()
-{
-  return childElement->getElementShape();
-}
-
-void MarmotElementSpatialWrapper::assignProperty( const MarmotMaterialSection& property )
-{
-  childElement->assignProperty( property );
-}
-
-void MarmotElementSpatialWrapper::assignProperty( const ElementProperties& property )
-{
-  childElement->assignProperty( property );
-}
-
-void MarmotElementSpatialWrapper::assignProperty( const std::string& propertyName, const double* properties )
-{
-  childElement->assignProperty( propertyName, properties );
-}
-
-std::vector< std::string > MarmotElementSpatialWrapper::getPropertyNames() const
-{
-  return childElement->getPropertyNames();
-}
-
-std::vector< int > MarmotElementSpatialWrapper::getDofIndicesPermutationPattern()
-{
-  std::vector< int > permutationPattern;
-
-  auto childPermutationPattern = childElement->getDofIndicesPermutationPattern();
-
-  int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
-  int indexChild;
-  while ( i < projectedSize ) {
-
-    indexChild = childPermutationPattern[i];
-    if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
-      // copy the Transformation block wise ( if current DOF is projected )
-      for ( int l = 0; l < nDim; l++ )
-        permutationPattern.push_back( indexChild + j + l );
-
-      i += nDimChild;
-      j += ( nDim - nDimChild );
-      k += 1;
-    }
-    else {
-      permutationPattern.push_back( indexChild + j );
-      i++;
-      j++;
-    }
+    : nDim( nDim ),
+      nDimChild( nDimChild ),
+      nNodes( nNodes ),
+      nRhsChild( nRhsChild ),
+      rhsIndicesToBeProjected( rhsIndicesToBeWrapped, nRhsIndicesToBeWrapped ),
+      projectedSize( nRhsChild ),
+      unprojectedSize( nRhsChild + rhsIndicesToBeProjected.size() * ( nDim - nDimChild ) ),
+      childElement( std::move( childElement ) )
+  {
   }
 
-  return permutationPattern;
-}
-
-void MarmotElementSpatialWrapper::assignStateVars( double* stateVars, int nStateVars )
-{
-  childElement->assignStateVars( stateVars, nStateVars );
-}
-
-void MarmotElementSpatialWrapper::initializeYourself()
-{
-  childElement->initializeYourself();
-}
-
-void MarmotElementSpatialWrapper::assignNodeCoordinates( const double* coordinates )
-{
-  Map< const MatrixXd > unprojectedCoordinates( coordinates, nDim, nNodes );
-
-  if ( nDimChild == 1 ) {
-    // take the (normalized) directional vector based on the first 2 nodes (valid for truss2,
-    // truss3);
-    VectorXd n = unprojectedCoordinates.col( 1 ) - unprojectedCoordinates.col( 0 );
-    n /= n.norm();
-    T = n.transpose();
+  int MarmotElementSpatialWrapper::getNumberOfRequiredStateVars()
+  {
+    return childElement->getNumberOfRequiredStateVars();
   }
 
-  P = MatrixXd::Zero( projectedSize, unprojectedSize );
-  // Alternatively: P as a Sparse matrix; currently not necessary...
-
-  int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
-  while ( i < projectedSize ) {
-
-    if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
-      // copy the Transformation block wise ( if current DOF is projected )
-      P.block( i, j, nDimChild, nDim ) = T;
-
-      i += nDimChild;
-      j += nDim;
-      k += 1;
-    }
-    else {
-      P( i, j ) = 1.0;
-      i++;
-      j++;
-    }
+  std::vector< std::vector< std::string > > MarmotElementSpatialWrapper::getNodeFields()
+  {
+    return childElement->getNodeFields();
   }
 
-  // Projection of node coordinates
-  projectedCoordinates = MatrixXd::Zero( nDimChild, nNodes );
-  for ( int i = 0; i < nNodes; i++ )
-    projectedCoordinates.col( i ) = T * unprojectedCoordinates.col( i );
+  int MarmotElementSpatialWrapper::getNNodes()
+  {
+    return nNodes;
+  }
 
-  childElement->assignNodeCoordinates( projectedCoordinates.data() );
-}
+  int MarmotElementSpatialWrapper::getNSpatialDimensions()
+  {
+    return nDim;
+  }
 
-void MarmotElementSpatialWrapper::computeKernels( const double* Q,
-                                                  const double* dQ,
-                                                  double*       Pe_,
-                                                  double*       Ke_,
-                                                  double        time,
-                                                  double        dT )
-{
-  Map< const VectorXd > Q_Unprojected( Q, unprojectedSize );
-  Map< const VectorXd > dQ_Unprojected( dQ, unprojectedSize );
+  int MarmotElementSpatialWrapper::getNDofPerElement()
+  {
+    return unprojectedSize;
+  }
 
-  VectorXd Q_Projected  = P * Q_Unprojected;
-  VectorXd dQ_Projected = P * dQ_Unprojected;
+  std::string MarmotElementSpatialWrapper::getElementShape()
+  {
+    return childElement->getElementShape();
+  }
 
-  VectorXd Pe_Projected = VectorXd::Zero( projectedSize );
-  MatrixXd Ke_Projected = MatrixXd::Zero( projectedSize, projectedSize );
+  void MarmotElementSpatialWrapper::assignProperty( const MarmotMaterialSection& property )
+  {
+    childElement->assignProperty( property );
+  }
 
-  childElement
-    ->computeKernels( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
+  void MarmotElementSpatialWrapper::assignProperty( const ElementProperties& property )
+  {
+    childElement->assignProperty( property );
+  }
 
-  Map< VectorXd > Pe_Unprojected( Pe_, unprojectedSize );
-  Map< MatrixXd > Ke_Unprojected( Ke_, unprojectedSize, unprojectedSize );
+  void MarmotElementSpatialWrapper::assignProperty( const std::string& propertyName, const double* properties )
+  {
+    childElement->assignProperty( propertyName, properties );
+  }
 
-  Ke_Unprojected += P.transpose() * Ke_Projected * P;
-  Pe_Unprojected += P.transpose() * Pe_Projected;
-}
+  std::vector< std::string > MarmotElementSpatialWrapper::getPropertyNames() const
+  {
+    return childElement->getPropertyNames();
+  }
 
-void MarmotElementSpatialWrapper::setInitialConditions( StateTypes state, const double* values )
-{
-  childElement->setInitialConditions( state, values );
-}
+  std::vector< int > MarmotElementSpatialWrapper::getDofIndicesPermutationPattern()
+  {
+    std::vector< int > permutationPattern;
 
-void MarmotElementSpatialWrapper::computeDistributedLoad( DistributedLoadTypes loadType,
-                                                          double*              P_,
-                                                          double*              K,
-                                                          int                  elementFace,
-                                                          const double*        load,
-                                                          const double*        QTotal,
-                                                          double               time,
-                                                          double               dT )
-{
-  VectorXd P_Projected = VectorXd::Zero( projectedSize );
-  MatrixXd Ke_Projected( projectedSize, projectedSize );
+    auto childPermutationPattern = childElement->getDofIndicesPermutationPattern();
 
-  childElement
-    ->computeDistributedLoad( loadType, P_Projected.data(), Ke_Projected.data(), elementFace, QTotal, load, time, dT );
+    int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
+    int indexChild;
+    while ( i < projectedSize ) {
 
-  Map< VectorXd > P_Unprojected( P_, unprojectedSize );
-  P_Unprojected = P.transpose() * P_Projected;
+      indexChild = childPermutationPattern[i];
+      if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
+        // copy the Transformation block wise ( if current DOF is projected )
+        for ( int l = 0; l < nDim; l++ )
+          permutationPattern.push_back( indexChild + j + l );
 
-  Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
-  Ke_Unprojected = P.transpose() * Ke_Projected * P;
-}
+        i += nDimChild;
+        j += ( nDim - nDimChild );
+        k += 1;
+      }
+      else {
+        permutationPattern.push_back( indexChild + j );
+        i++;
+        j++;
+      }
+    }
 
-void MarmotElementSpatialWrapper::computeBodyForce( double*       P_,
-                                                    double*       K,
-                                                    const double* load,
-                                                    const double* QTotal,
+    return permutationPattern;
+  }
+
+  void MarmotElementSpatialWrapper::assignStateVars( double* stateVars, int nStateVars )
+  {
+    childElement->assignStateVars( stateVars, nStateVars );
+  }
+
+  void MarmotElementSpatialWrapper::initializeYourself()
+  {
+    childElement->initializeYourself();
+  }
+
+  void MarmotElementSpatialWrapper::assignNodeCoordinates( const double* coordinates )
+  {
+    Map< const MatrixXd > unprojectedCoordinates( coordinates, nDim, nNodes );
+
+    if ( nDimChild == 1 ) {
+      // take the (normalized) directional vector based on the first 2 nodes (valid for truss2,
+      // truss3);
+      VectorXd n = unprojectedCoordinates.col( 1 ) - unprojectedCoordinates.col( 0 );
+      n /= n.norm();
+      T = n.transpose();
+    }
+
+    P = MatrixXd::Zero( projectedSize, unprojectedSize );
+    // Alternatively: P as a Sparse matrix; currently not necessary...
+
+    int i = 0, j = 0, k = 0; // i: projected, j: unprojected, k: indicesToProject
+    while ( i < projectedSize ) {
+
+      if ( k < rhsIndicesToBeProjected.size() && i == rhsIndicesToBeProjected( k ) ) {
+        // copy the Transformation block wise ( if current DOF is projected )
+        P.block( i, j, nDimChild, nDim ) = T;
+
+        i += nDimChild;
+        j += nDim;
+        k += 1;
+      }
+      else {
+        P( i, j ) = 1.0;
+        i++;
+        j++;
+      }
+    }
+
+    // Projection of node coordinates
+    projectedCoordinates = MatrixXd::Zero( nDimChild, nNodes );
+    for ( int i = 0; i < nNodes; i++ )
+      projectedCoordinates.col( i ) = T * unprojectedCoordinates.col( i );
+
+    childElement->assignNodeCoordinates( projectedCoordinates.data() );
+  }
+
+  void MarmotElementSpatialWrapper::computeKernels( const double* Q,
+                                                    const double* dQ,
+                                                    double*       Pe_,
+                                                    double*       Ke_,
                                                     double        time,
                                                     double        dT )
-{
-  VectorXd P_Projected = VectorXd::Zero( projectedSize );
-  MatrixXd Ke_Projected( projectedSize, projectedSize );
+  {
+    Map< const VectorXd > Q_Unprojected( Q, unprojectedSize );
+    Map< const VectorXd > dQ_Unprojected( dQ, unprojectedSize );
 
-  childElement->computeBodyForce( P_Projected.data(), Ke_Projected.data(), load, QTotal, time, dT );
+    VectorXd Q_Projected  = P * Q_Unprojected;
+    VectorXd dQ_Projected = P * dQ_Unprojected;
 
-  Map< VectorXd > P_Unprojected( P_, unprojectedSize );
-  P_Unprojected = P.transpose() * P_Projected;
+    VectorXd Pe_Projected = VectorXd::Zero( projectedSize );
+    MatrixXd Ke_Projected = MatrixXd::Zero( projectedSize, projectedSize );
 
-  Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
-  Ke_Unprojected = P.transpose() * Ke_Projected * P;
-}
+    childElement
+      ->computeKernels( Q_Projected.data(), dQ_Projected.data(), Pe_Projected.data(), Ke_Projected.data(), time, dT );
 
-StateView MarmotElementSpatialWrapper::getStateView( const std::string& stateName, int quadraturePoint )
-{
-  if ( stateName == "MarmotElementSpatialWrapper.T" ) {
-    return { T.data(), static_cast< int >( T.size() ) };
+    Map< VectorXd > Pe_Unprojected( Pe_, unprojectedSize );
+    Map< MatrixXd > Ke_Unprojected( Ke_, unprojectedSize, unprojectedSize );
+
+    Ke_Unprojected += P.transpose() * Ke_Projected * P;
+    Pe_Unprojected += P.transpose() * Pe_Projected;
   }
 
-  return childElement->getStateView( stateName, quadraturePoint );
-}
-
-std::vector< double > MarmotElementSpatialWrapper::getCoordinatesAtCenter()
-{
-  std::vector< double > coords( nDim );
-
-  Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
-
-  const auto                          coordsChild_ = childElement->getCoordinatesAtCenter();
-  Eigen::Map< const Eigen::VectorXd > coordsChild( &coordsChild_[0], coordsChild_.size() );
-
-  coordsMap = P.transpose() * coordsChild;
-
-  return coords;
-}
-
-std::vector< std::vector< double > > MarmotElementSpatialWrapper::getCoordinatesAtQuadraturePoints()
-{
-  auto listedChildCoords = childElement->getCoordinatesAtQuadraturePoints();
-
-  std::vector< std::vector< double > > listedCoords;
-
-  std::vector< double >         coords( nDim );
-  Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
-
-  for ( const auto& coordsChild : listedChildCoords ) {
-    Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], nDim );
-    coordsMap = P.transpose() * coordsChildMap;
-
-    listedCoords.push_back( coords );
+  void MarmotElementSpatialWrapper::setInitialConditions( StateTypes state, const double* values )
+  {
+    childElement->setInitialConditions( state, values );
   }
 
-  return listedCoords;
-}
+  void MarmotElementSpatialWrapper::computeDistributedLoad( DistributedLoadTypes loadType,
+                                                            double*              P_,
+                                                            double*              K,
+                                                            int                  elementFace,
+                                                            const double*        load,
+                                                            const double*        QTotal,
+                                                            double               time,
+                                                            double               dT )
+  {
+    VectorXd P_Projected = VectorXd::Zero( projectedSize );
+    MatrixXd Ke_Projected( projectedSize, projectedSize );
 
-int MarmotElementSpatialWrapper::getNumberOfQuadraturePoints()
-{
-  auto numberOfQuadraturePoints = childElement->getNumberOfQuadraturePoints();
+    childElement->computeDistributedLoad( loadType,
+                                          P_Projected.data(),
+                                          Ke_Projected.data(),
+                                          elementFace,
+                                          QTotal,
+                                          load,
+                                          time,
+                                          dT );
 
-  return numberOfQuadraturePoints;
-}
+    Map< VectorXd > P_Unprojected( P_, unprojectedSize );
+    P_Unprojected = P.transpose() * P_Projected;
+
+    Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
+    Ke_Unprojected = P.transpose() * Ke_Projected * P;
+  }
+
+  void MarmotElementSpatialWrapper::computeBodyForce( double*       P_,
+                                                      double*       K,
+                                                      const double* load,
+                                                      const double* QTotal,
+                                                      double        time,
+                                                      double        dT )
+  {
+    VectorXd P_Projected = VectorXd::Zero( projectedSize );
+    MatrixXd Ke_Projected( projectedSize, projectedSize );
+
+    childElement->computeBodyForce( P_Projected.data(), Ke_Projected.data(), load, QTotal, time, dT );
+
+    Map< VectorXd > P_Unprojected( P_, unprojectedSize );
+    P_Unprojected = P.transpose() * P_Projected;
+
+    Map< MatrixXd > Ke_Unprojected( K, unprojectedSize, unprojectedSize );
+    Ke_Unprojected = P.transpose() * Ke_Projected * P;
+  }
+
+  StateView MarmotElementSpatialWrapper::getStateView( const std::string& stateName, int quadraturePoint )
+  {
+    if ( stateName == "MarmotElementSpatialWrapper.T" ) {
+      return { T.data(), static_cast< int >( T.size() ) };
+    }
+
+    return childElement->getStateView( stateName, quadraturePoint );
+  }
+
+  std::vector< double > MarmotElementSpatialWrapper::getCoordinatesAtCenter()
+  {
+    std::vector< double > coords( nDim );
+
+    Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
+
+    const auto                          coordsChild_ = childElement->getCoordinatesAtCenter();
+    Eigen::Map< const Eigen::VectorXd > coordsChild( &coordsChild_[0], coordsChild_.size() );
+
+    coordsMap = P.transpose() * coordsChild;
+
+    return coords;
+  }
+
+  std::vector< std::vector< double > > MarmotElementSpatialWrapper::getCoordinatesAtQuadraturePoints()
+  {
+    auto listedChildCoords = childElement->getCoordinatesAtQuadraturePoints();
+
+    std::vector< std::vector< double > > listedCoords;
+
+    std::vector< double >         coords( nDim );
+    Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
+
+    for ( const auto& coordsChild : listedChildCoords ) {
+      Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], nDim );
+      coordsMap = P.transpose() * coordsChildMap;
+
+      listedCoords.push_back( coords );
+    }
+
+    return listedCoords;
+  }
+
+  int MarmotElementSpatialWrapper::getNumberOfQuadraturePoints()
+  {
+    auto numberOfQuadraturePoints = childElement->getNumberOfQuadraturePoints();
+
+    return numberOfQuadraturePoints;
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/src/MarmotGeometryElement.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotGeometryElement.cpp
@@ -1,228 +1,232 @@
 #include "Marmot/MarmotGeometryElement.h"
 
-using namespace Eigen;
+namespace Marmot {
 
-/* Template Specialization for Shape functions.
- * These (full) specializations are precompiled into the current static marmotMechanics.
- * Thus, they act as static links to the corresponding FiniteElement functions.
- *
- * For a new element, please specialize ALL functions.
- *
- * */
+  using namespace Eigen;
 
-// Bar2
-template <>
-MarmotGeometryElement< 1, 2 >::NSized MarmotGeometryElement< 1, 2 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial1D::Bar2::N( xi( 0 ) );
-}
-// Quad4
-template <>
-MarmotGeometryElement< 2, 4 >::NSized MarmotGeometryElement< 2, 4 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad4::N( xi );
-}
-// Quad8
-template <>
-MarmotGeometryElement< 2, 8 >::NSized MarmotGeometryElement< 2, 8 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad8::N( xi );
-}
-// Tetra4
-template <>
-MarmotGeometryElement< 3, 4 >::NSized MarmotGeometryElement< 3, 4 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra4::N( xi );
-}
-// Tetra10
-template <>
-MarmotGeometryElement< 3, 10 >::NSized MarmotGeometryElement< 3, 10 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra10::N( xi );
-}
-// Hexa8
-template <>
-MarmotGeometryElement< 3, 8 >::NSized MarmotGeometryElement< 3, 8 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa8::N( xi );
-}
-// Hexa20
-template <>
-MarmotGeometryElement< 3, 20 >::NSized MarmotGeometryElement< 3, 20 >::N( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa20::N( xi );
-}
+  /* Template Specialization for Shape functions.
+   * These (full) specializations are precompiled into the current static marmotMechanics.
+   * Thus, they act as static links to the corresponding FiniteElement functions.
+   *
+   * For a new element, please specialize ALL functions.
+   *
+   * */
 
-/* Template Specialization for Shape functions derivatives.
- * */
-// Bar2
-template <>
-MarmotGeometryElement< 1, 2 >::dNdXiSized MarmotGeometryElement< 1, 2 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial1D::Bar2::dNdXi( xi( 0 ) );
-}
-// Quad4
-template <>
-MarmotGeometryElement< 2, 4 >::dNdXiSized MarmotGeometryElement< 2, 4 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad4::dNdXi( xi );
-}
-// Quad8
-template <>
-MarmotGeometryElement< 2, 8 >::dNdXiSized MarmotGeometryElement< 2, 8 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial2D::Quad8::dNdXi( xi );
-}
-// Tetra4
-template <>
-MarmotGeometryElement< 3, 4 >::dNdXiSized MarmotGeometryElement< 3, 4 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra4::dNdXi( xi );
-}
-// Tetra10
-template <>
-MarmotGeometryElement< 3, 10 >::dNdXiSized MarmotGeometryElement< 3, 10 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Tetra10::dNdXi( xi );
-}
-// Hexa8
-template <>
-MarmotGeometryElement< 3, 8 >::dNdXiSized MarmotGeometryElement< 3, 8 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa8::dNdXi( xi );
-}
-// Hexa20
-template <>
-MarmotGeometryElement< 3, 20 >::dNdXiSized MarmotGeometryElement< 3, 20 >::dNdXi( const XiSized& xi ) const
-{
-  return Marmot::FiniteElement::Spatial3D::Hexa20::dNdXi( xi );
-}
+  // Bar2
+  template <>
+  MarmotGeometryElement< 1, 2 >::NSized MarmotGeometryElement< 1, 2 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial1D::Bar2::N( xi( 0 ) );
+  }
+  // Quad4
+  template <>
+  MarmotGeometryElement< 2, 4 >::NSized MarmotGeometryElement< 2, 4 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad4::N( xi );
+  }
+  // Quad8
+  template <>
+  MarmotGeometryElement< 2, 8 >::NSized MarmotGeometryElement< 2, 8 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad8::N( xi );
+  }
+  // Tetra4
+  template <>
+  MarmotGeometryElement< 3, 4 >::NSized MarmotGeometryElement< 3, 4 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra4::N( xi );
+  }
+  // Tetra10
+  template <>
+  MarmotGeometryElement< 3, 10 >::NSized MarmotGeometryElement< 3, 10 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra10::N( xi );
+  }
+  // Hexa8
+  template <>
+  MarmotGeometryElement< 3, 8 >::NSized MarmotGeometryElement< 3, 8 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa8::N( xi );
+  }
+  // Hexa20
+  template <>
+  MarmotGeometryElement< 3, 20 >::NSized MarmotGeometryElement< 3, 20 >::N( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa20::N( xi );
+  }
 
-/* Template Specialization for B Operator
- * Note that partial template specialization (i.e., for all nDim=2 and all nDim=3) is not valid for
- * methods (only for classes) in C++, and, hence, the B Operator must be specialized for each
- * nDim/nNodes combination individually.
- * */
+  /* Template Specialization for Shape functions derivatives.
+   * */
+  // Bar2
+  template <>
+  MarmotGeometryElement< 1, 2 >::dNdXiSized MarmotGeometryElement< 1, 2 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial1D::Bar2::dNdXi( xi( 0 ) );
+  }
+  // Quad4
+  template <>
+  MarmotGeometryElement< 2, 4 >::dNdXiSized MarmotGeometryElement< 2, 4 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad4::dNdXi( xi );
+  }
+  // Quad8
+  template <>
+  MarmotGeometryElement< 2, 8 >::dNdXiSized MarmotGeometryElement< 2, 8 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::Quad8::dNdXi( xi );
+  }
+  // Tetra4
+  template <>
+  MarmotGeometryElement< 3, 4 >::dNdXiSized MarmotGeometryElement< 3, 4 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra4::dNdXi( xi );
+  }
+  // Tetra10
+  template <>
+  MarmotGeometryElement< 3, 10 >::dNdXiSized MarmotGeometryElement< 3, 10 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Tetra10::dNdXi( xi );
+  }
+  // Hexa8
+  template <>
+  MarmotGeometryElement< 3, 8 >::dNdXiSized MarmotGeometryElement< 3, 8 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa8::dNdXi( xi );
+  }
+  // Hexa20
+  template <>
+  MarmotGeometryElement< 3, 20 >::dNdXiSized MarmotGeometryElement< 3, 20 >::dNdXi( const XiSized& xi ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::Hexa20::dNdXi( xi );
+  }
 
-/* TODO: Replace by constexpr if expression for each dimension -> get rid of partial specializations; full
- * specialization should be possible
- *
- * */
+  /* Template Specialization for B Operator
+   * Note that partial template specialization (i.e., for all nDim=2 and all nDim=3) is not valid for
+   * methods (only for classes) in C++, and, hence, the B Operator must be specialized for each
+   * nDim/nNodes combination individually.
+   * */
 
-// Bar2
-template <>
-typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::B( const dNdXiSized& dNdX ) const
-{
-  return dNdX;
-}
-// Quad4
-template <>
-typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial2D::B< 4 >( dNdX );
-}
-// axisymmetric quad8
-template <>
-typename MarmotGeometryElement< 2, 4 >::BSizedAxisymmetric MarmotGeometryElement< 2, 4 >::B_axisymmetric(
-  const dNdXiSized& dNdX,
-  const NSized&     N,
-  const XiSized&    x_gauss ) const
-{
-  return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 4 >( dNdX, N, x_gauss );
-}
-// Quad8
-template <>
-typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial2D::B< 8 >( dNdX );
-}
-// axisymmetric quad8
-template <>
-typename MarmotGeometryElement< 2, 8 >::BSizedAxisymmetric MarmotGeometryElement< 2, 8 >::B_axisymmetric(
-  const dNdXiSized& dNdX,
-  const NSized&     N,
-  const XiSized&    x_gauss ) const
-{
-  return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 8 >( dNdX, N, x_gauss );
-}
-// Tetra4
-template <>
-typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 4 >( dNdX );
-}
-// Tetra10
-template <>
-typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 10 >( dNdX );
-}
-// Hexa8
-template <>
-typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 8 >( dNdX );
-}
-// Hexa8 B-bar
-template <>
-typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B_bar( const dNdXiSized& dNdX,
-                                                                                     const dNdXiSized& dNdX0 ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B_bar< 8 >( dNdX, dNdX0 );
-}
-// Hexa20
-template <>
-typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::B( const dNdXiSized& dNdX ) const
-{
-  return Marmot::FiniteElement::Spatial3D::B< 20 >( dNdX );
-}
+  /* TODO: Replace by constexpr if expression for each dimension -> get rid of partial specializations; full
+   * specialization should be possible
+   *
+   * */
 
-// Bar2
-template <>
-typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return dNdX * F( 0, 0 );
-}
-// Quad4
-template <>
-typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial2D::BGreen< 4 >( dNdX, F );
-}
-// Quad8
-template <>
-typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial2D::BGreen< 8 >( dNdX, F );
-}
-// Tetra4
-template <>
-typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 4 >( dNdX, F );
-}
-// Tetra10
-template <>
-typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::BGreen( const dNdXiSized&    dNdX,
+  // Bar2
+  template <>
+  typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::B( const dNdXiSized& dNdX ) const
+  {
+    return dNdX;
+  }
+  // Quad4
+  template <>
+  typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::B< 4 >( dNdX );
+  }
+  // axisymmetric quad8
+  template <>
+  typename MarmotGeometryElement< 2, 4 >::BSizedAxisymmetric MarmotGeometryElement< 2, 4 >::B_axisymmetric(
+    const dNdXiSized& dNdX,
+    const NSized&     N,
+    const XiSized&    x_gauss ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 4 >( dNdX, N, x_gauss );
+  }
+  // Quad8
+  template <>
+  typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::B< 8 >( dNdX );
+  }
+  // axisymmetric quad8
+  template <>
+  typename MarmotGeometryElement< 2, 8 >::BSizedAxisymmetric MarmotGeometryElement< 2, 8 >::B_axisymmetric(
+    const dNdXiSized& dNdX,
+    const NSized&     N,
+    const XiSized&    x_gauss ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::axisymmetric::B< 8 >( dNdX, N, x_gauss );
+  }
+  // Tetra4
+  template <>
+  typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 4 >( dNdX );
+  }
+  // Tetra10
+  template <>
+  typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 10 >( dNdX );
+  }
+  // Hexa8
+  template <>
+  typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 8 >( dNdX );
+  }
+  // Hexa8 B-bar
+  template <>
+  typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::B_bar( const dNdXiSized& dNdX,
+                                                                                       const dNdXiSized& dNdX0 ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B_bar< 8 >( dNdX, dNdX0 );
+  }
+  // Hexa20
+  template <>
+  typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::B( const dNdXiSized& dNdX ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::B< 20 >( dNdX );
+  }
+
+  // Bar2
+  template <>
+  typename MarmotGeometryElement< 1, 2 >::BSized MarmotGeometryElement< 1, 2 >::BGreen( const dNdXiSized&    dNdX,
                                                                                         const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 10 >( dNdX, F );
-}
-// Hexa8
-template <>
-typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::BGreen( const dNdXiSized&    dNdX,
-                                                                                      const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 8 >( dNdX, F );
-}
-// Hexa20
-template <>
-typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::BGreen( const dNdXiSized&    dNdX,
+  {
+    return dNdX * F( 0, 0 );
+  }
+  // Quad4
+  template <>
+  typename MarmotGeometryElement< 2, 4 >::BSized MarmotGeometryElement< 2, 4 >::BGreen( const dNdXiSized&    dNdX,
                                                                                         const JacobianSized& F ) const
-{
-  return Marmot::FiniteElement::Spatial3D::BGreen< 20 >( dNdX, F );
-}
+  {
+    return Marmot::FiniteElement::Spatial2D::BGreen< 4 >( dNdX, F );
+  }
+  // Quad8
+  template <>
+  typename MarmotGeometryElement< 2, 8 >::BSized MarmotGeometryElement< 2, 8 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                        const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial2D::BGreen< 8 >( dNdX, F );
+  }
+  // Tetra4
+  template <>
+  typename MarmotGeometryElement< 3, 4 >::BSized MarmotGeometryElement< 3, 4 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                        const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 4 >( dNdX, F );
+  }
+  // Tetra10
+  template <>
+  typename MarmotGeometryElement< 3, 10 >::BSized MarmotGeometryElement< 3, 10 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                          const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 10 >( dNdX, F );
+  }
+  // Hexa8
+  template <>
+  typename MarmotGeometryElement< 3, 8 >::BSized MarmotGeometryElement< 3, 8 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                        const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 8 >( dNdX, F );
+  }
+  // Hexa20
+  template <>
+  typename MarmotGeometryElement< 3, 20 >::BSized MarmotGeometryElement< 3, 20 >::BGreen( const dNdXiSized&    dNdX,
+                                                                                          const JacobianSized& F ) const
+  {
+    return Marmot::FiniteElement::Spatial3D::BGreen< 20 >( dNdX, F );
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotDeformationMeasures.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotDeformationMeasures.h
@@ -27,17 +27,60 @@
 #include "Marmot/MarmotFastorTensorBasics.h"
 #include <Fastor/tensor_algebra/permute.h>
 
-namespace Marmot::ContinuumMechanics {
+namespace Marmot::ContinuumMechanics::DeformationMeasures {
 
-  namespace DeformationMeasures {
+  using namespace FastorIndices;
+  using namespace FastorStandardTensors;
 
-    using namespace FastorIndices;
-    using namespace FastorStandardTensors;
+  /** @brief Computes the right Cauchy-Green tensor \f$\boldsymbol{C}\f$.
+   * @tparam T Scalar type (e.g., float, double, autodiff::dual)
+   * @param F Deformation gradient tensor
+   * @return The right Cauchy-Green tensor
+   *
+   * The right Cauchy-Green deformation tensor is defined as:
+   * \f[
+   *   \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F}
+   * \f]
+   * or in index notation:
+   * \f[
+   *   C_{IJ} = F_{iI} F_{iJ}
+   * \f]
+   */
+  template < typename T >
+  Tensor33t< T > rightCauchyGreen( const Tensor33t< T >& F )
+  {
+    const Tensor33t< T > C = einsum< iI, iJ >( F, F );
+    return C;
+  }
 
-    /** @brief Computes the right Cauchy-Green tensor \f$\boldsymbol{C}\f$.
+  /** @brief Computes the left Cauchy-Green tensor \f$\boldsymbol{b}\f$.
+   * @tparam T Scalar type (e.g., float, double, autodiff::dual)
+   * @param F Deformation gradient tensor
+   * @return The left Cauchy-Green tensor b
+   *
+   * The left Cauchy-Green deformation tensor is defined as:
+   * \f[
+   *   \boldsymbol{b} = \boldsymbol{F} \boldsymbol{F}^T
+   * \f]
+   * or in index notation:
+   * \f[
+   *   b_{ij} = F_{iI} F_{jI}
+   * \f]
+   */
+  template < typename T >
+  Tensor33t< T > leftCauchyGreen( const Tensor33t< T >& F )
+  {
+    const Tensor33t< T > b = einsum< iJ, jJ >( F, F );
+    return b;
+  }
+
+  namespace FirstOrderDerived {
+
+    /** @brief Computes the right Cauchy-Green tensor \f$\boldsymbol{C}\f$ and its derivative with respect to
+     * \f$\boldsymbol{F}\f$.
      * @tparam T Scalar type (e.g., float, double, autodiff::dual)
      * @param F Deformation gradient tensor
-     * @return The right Cauchy-Green tensor
+     * @returns A pair containing the right Cauchy-Green tensor C and its derivative with respect to F
      *
      * The right Cauchy-Green deformation tensor is defined as:
      * \f[
@@ -47,18 +90,27 @@ namespace Marmot::ContinuumMechanics {
      * \f[
      *   C_{IJ} = F_{iI} F_{iJ}
      * \f]
+     * The derivative of \f$\boldsymbol{C}\f$ with respect to \f$\boldsymbol{F}\f$ is given by:
+     * \f[
+     *  \frac{\partial C_{IJ}}{\partial F_{kK}} = \delta_{IK} F_{kJ} + F_{kI} \delta_{JK}
+     * \f]
      */
     template < typename T >
-    Tensor33t< T > rightCauchyGreen( const Tensor33t< T >& F )
+    std::pair< Tensor33t< T >, Tensor3333t< T > > rightCauchyGreen( const Tensor33t< T >& F )
     {
-      const Tensor33t< T > C = einsum< iI, iJ >( F, F );
-      return C;
+      const Tensor33t< T > C = Marmot::ContinuumMechanics::DeformationMeasures::rightCauchyGreen( F );
+
+      const Tensor3333t< T > dC_dF = einsum< IK, kJ, to_IJkK >( Spatial3D::I, F ) +
+                                     einsum< kI, JK, to_IJkK >( F, Spatial3D::I );
+
+      return { C, dC_dF };
     }
 
-    /** @brief Computes the left Cauchy-Green tensor \f$\boldsymbol{b}\f$.
+    /** @brief Computes the left Cauchy-Green tensor \f$\boldsymbol{b}\f$ and its derivative with respect to
+     * \f$\boldsymbol{F}\f$.
      * @tparam T Scalar type (e.g., float, double, autodiff::dual)
      * @param F Deformation gradient tensor
-     * @return The left Cauchy-Green tensor b
+     * @return A pair containing the left Cauchy-Green tensor b and its derivative with respect to F
      *
      * The left Cauchy-Green deformation tensor is defined as:
      * \f[
@@ -68,192 +120,137 @@ namespace Marmot::ContinuumMechanics {
      * \f[
      *   b_{ij} = F_{iI} F_{jI}
      * \f]
+     * The derivative of \f$\boldsymbol{b}\f$ with respect to \f$\boldsymbol{F}\f$ is given by:
+     * \f[
+     *  \frac{\partial b_{ij}}{\partial F_{kK}} = \delta_{ik} F_{jK} + F_{iK} \delta_{jk}
+     * \f]
      */
     template < typename T >
-    Tensor33t< T > leftCauchyGreen( const Tensor33t< T >& F )
+    std::pair< Tensor33t< T >, Tensor3333t< T > > leftCauchyGreen( const Tensor33t< T >& F )
     {
-      const Tensor33t< T > b = einsum< iJ, jJ >( F, F );
-      return b;
+      Tensor33t< T > b = Marmot::ContinuumMechanics::DeformationMeasures::leftCauchyGreen( F );
+
+      const Tensor3333t< T > db_dF = einsum< ik, jK, to_ijkK >( Spatial3D::I, F ) +
+                                     einsum< iK, jk, to_ijkK >( F, Spatial3D::I );
+
+      return { b, db_dF };
     }
 
-    namespace FirstOrderDerived {
+    /** @brief Computes the deformed normal vector and its derivative with respect to the inverse
+     * deformation gradient.
+     * @param FInv Inverse of the deformation gradient tensor
+     * @param N_x_dA0 Undeformed normal vector scaled by undeformed area
+     * @return A pair containing the deformed normal vector and its derivative with respect to FInv
+     *
+     * The deformed normal vector is defined as:
+     * \f[
+     *   n_i = \frac{ F^{-1}_{Ii} N_{I} J dA_0 } { \| F^{-1}_{Ki} N_{K} J dA_0 \| }
+     * \f]
+     */
 
-      /** @brief Computes the right Cauchy-Green tensor \f$\boldsymbol{C}\f$ and its derivative with respect to
-       * \f$\boldsymbol{F}\f$.
-       * @tparam T Scalar type (e.g., float, double, autodiff::dual)
-       * @param F Deformation gradient tensor
-       * @returns A pair containing the right Cauchy-Green tensor C and its derivative with respect to F
-       *
-       * The right Cauchy-Green deformation tensor is defined as:
-       * \f[
-       *   \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F}
-       * \f]
-       * or in index notation:
-       * \f[
-       *   C_{IJ} = F_{iI} F_{iJ}
-       * \f]
-       * The derivative of \f$\boldsymbol{C}\f$ with respect to \f$\boldsymbol{F}\f$ is given by:
-       * \f[
-       *  \frac{\partial C_{IJ}}{\partial F_{kK}} = \delta_{IK} F_{kJ} + F_{kI} \delta_{JK}
-       * \f]
-       */
-      template < typename T >
-      std::pair< Tensor33t< T >, Tensor3333t< T > > rightCauchyGreen( const Tensor33t< T >& F )
-      {
-        const Tensor33t< T > C = Marmot::ContinuumMechanics::DeformationMeasures::rightCauchyGreen( F );
+    template < int nDim >
+    std::pair< Fastor::Tensor< double, nDim >, Fastor::Tensor< double, nDim, nDim, nDim > > deformedNormalVectorFromUndeformedSurfaceVector(
+      const Fastor::Tensor< double, nDim, nDim >& FInv,
+      const Fastor::Tensor< double, nDim >&       N_x_dA0 )
+    {
 
-        const Tensor3333t< T > dC_dF = einsum< IK, kJ, to_IJkK >( Spatial3D::I, F ) +
-                                       einsum< kI, JK, to_IJkK >( F, Spatial3D::I );
+      using namespace Fastor;
+      using namespace FastorIndices;
 
-        return { C, dC_dF };
-      }
+      using TensorDd   = Tensor< double, nDim >;
+      using TensorDDd  = Tensor< double, nDim, nDim >;
+      using TensorDDDd = Tensor< double, nDim, nDim, nDim >;
 
-      /** @brief Computes the left Cauchy-Green tensor \f$\boldsymbol{b}\f$ and its derivative with respect to
-       * \f$\boldsymbol{F}\f$.
-       * @tparam T Scalar type (e.g., float, double, autodiff::dual)
-       * @param F Deformation gradient tensor
-       * @return A pair containing the left Cauchy-Green tensor b and its derivative with respect to F
-       *
-       * The left Cauchy-Green deformation tensor is defined as:
-       * \f[
-       *   \boldsymbol{b} = \boldsymbol{F} \boldsymbol{F}^T
-       * \f]
-       * or in index notation:
-       * \f[
-       *   b_{ij} = F_{iI} F_{jI}
-       * \f]
-       * The derivative of \f$\boldsymbol{b}\f$ with respect to \f$\boldsymbol{F}\f$ is given by:
-       * \f[
-       *  \frac{\partial b_{ij}}{\partial F_{kK}} = \delta_{ik} F_{jK} + F_{iK} \delta_{jk}
-       * \f]
-       */
-      template < typename T >
-      std::pair< Tensor33t< T >, Tensor3333t< T > > leftCauchyGreen( const Tensor33t< T >& F )
-      {
-        Tensor33t< T > b = Marmot::ContinuumMechanics::DeformationMeasures::leftCauchyGreen( F );
+      const static TensorDDd Eye = []() {
+        TensorDDd I;
+        I.eye();
+        return I;
+      }();
 
-        const Tensor3333t< T > db_dF = einsum< ik, jK, to_ijkK >( Spatial3D::I, F ) +
-                                       einsum< iK, jk, to_ijkK >( F, Spatial3D::I );
+      const double    detJ        = 1. / determinant( FInv );
+      const TensorDDd dDetJ_dFInv = -1 * std::pow( detJ, 2 ) *
+                                    transpose( inverse( ( FInv ) ) ); // derivative of detJ w.r.t. FInv
 
-        return { b, db_dF };
-      }
+      const TensorDd
+                       NTilde        = einsum< Index< 0 >, Index< 0, 1 > >( N_x_dA0,
+                                                      FInv ); // deformed normal vector scaled by deformed area
+      const TensorDDDd dNTilde_dFInv = einsum< Index< 0 >, Index< 1, 2 >, OIndex< 1, 0, 2 > >( N_x_dA0, Eye );
 
-      /** @brief Computes the deformed normal vector and its derivative with respect to the inverse
-       * deformation gradient.
-       * @param FInv Inverse of the deformation gradient tensor
-       * @param N_x_dA0 Undeformed normal vector scaled by undeformed area
-       * @return A pair containing the deformed normal vector and its derivative with respect to FInv
-       *
-       * The deformed normal vector is defined as:
-       * \f[
-       *   n_i = \frac{ F^{-1}_{Ii} N_{I} J dA_0 } { \| F^{-1}_{Ki} N_{K} J dA_0 \| }
-       * \f]
-       */
+      const TensorDd   n_x_dA               = detJ * NTilde;
+      const TensorDDDd NTilde_x_dDetJ_dFInv = outer( NTilde, dDetJ_dFInv );
+      const TensorDDDd dn_x_dA_dFInv        = NTilde_x_dDetJ_dFInv + detJ * dNTilde_dFInv;
 
-      template < int nDim >
-      std::pair< Fastor::Tensor< double, nDim >, Fastor::Tensor< double, nDim, nDim, nDim > > deformedNormalVectorFromUndeformedSurfaceVector(
-        const Fastor::Tensor< double, nDim, nDim >& FInv,
-        const Fastor::Tensor< double, nDim >&       N_x_dA0 )
-      {
+      const TensorDd  n          = n_x_dA / norm( n_x_dA ); // deformed normal vector
+      const TensorDDd dn_dn_x_dA = ( Eye - outer( n, n ) ) * ( 1. / norm( n_x_dA ) );
 
-        using namespace Fastor;
-        using namespace FastorIndices;
+      const TensorDDDd dn_dFInv = einsum< ij, jkl >( dn_dn_x_dA, dn_x_dA_dFInv );
 
-        using TensorDd   = Tensor< double, nDim >;
-        using TensorDDd  = Tensor< double, nDim, nDim >;
-        using TensorDDDd = Tensor< double, nDim, nDim, nDim >;
+      return { n, dn_dFInv };
+    }
 
-        const static TensorDDd Eye = []() {
-          TensorDDd I;
-          I.eye();
-          return I;
-        }();
+    /** @brief Computes the deformed normal projection tensor and its derivative with respect to the inverse
+     * deformation gradient.
+     * @param FInv Inverse of the deformation gradient tensor
+     * @param N_x_dA0 Undeformed normal vector scaled by undeformed area
+     * @return A pair containing the deformed normal projection tensor and its derivative with respect to FInv
+     *
+     * The deformed normal projection tensor is defined as:
+     * \f[
+     *   N_{ij} = n_i n_j = \frac{ F^{-1}_{Ii} N_{I} J dA_0 \times F^{-1}_{Jj} N_{J} J dA_0} { \| F^{-1}_{Ki} N_{K} J
+     * dA_0 \|^2 }
+     * \f]
+     */
+    template < int nDim >
+    inline std::pair< Fastor::Tensor< double, nDim, nDim >, Fastor::Tensor< double, nDim, nDim, nDim, nDim > > deformedNormalProjectionTensor(
+      const Fastor::Tensor< double, nDim, nDim >& FInv,
+      const Fastor::Tensor< double, nDim >&       N_x_dA0 )
+    {
 
-        const double    detJ        = 1. / determinant( FInv );
-        const TensorDDd dDetJ_dFInv = -1 * std::pow( detJ, 2 ) *
-                                      transpose( inverse( ( FInv ) ) ); // derivative of detJ w.r.t. FInv
+      using namespace Fastor;
+      using namespace FastorIndices;
+      using TensorDDd   = Tensor< double, nDim, nDim >;
+      using TensorDDDDd = Tensor< double, nDim, nDim, nDim, nDim >;
 
-        const TensorDd
-                         NTilde        = einsum< Index< 0 >, Index< 0, 1 > >( N_x_dA0,
-                                                        FInv ); // deformed normal vector scaled by deformed area
-        const TensorDDDd dNTilde_dFInv = einsum< Index< 0 >, Index< 1, 2 >, OIndex< 1, 0, 2 > >( N_x_dA0, Eye );
+      const auto [n, dn_dFInv] = deformedNormalVectorFromUndeformedSurfaceVector< nDim >( FInv, N_x_dA0 );
+      const TensorDDd n_ij     = outer( n, n );
 
-        const TensorDd   n_x_dA               = detJ * NTilde;
-        const TensorDDDd NTilde_x_dDetJ_dFInv = outer( NTilde, dDetJ_dFInv );
-        const TensorDDDd dn_x_dA_dFInv        = NTilde_x_dDetJ_dFInv + detJ * dNTilde_dFInv;
+      const TensorDDDDd aux         = outer( n, dn_dFInv );
+      const TensorDDDDd dn_ij_dFInv = aux + Fastor::permute< Fastor::Index< 1, 0, 2, 3 > >( aux );
 
-        const TensorDd  n          = n_x_dA / norm( n_x_dA ); // deformed normal vector
-        const TensorDDd dn_dn_x_dA = ( Eye - outer( n, n ) ) * ( 1. / norm( n_x_dA ) );
+      return { n_ij, dn_ij_dFInv };
+    }
 
-        const TensorDDDd dn_dFInv = einsum< ij, jkl >( dn_dn_x_dA, dn_x_dA_dFInv );
+    /**
+     * @brief Computes the inverse of the deformation gradient and its derivative with respect to the deformation
+     * gradient.
+     * @param F Deformation gradient tensor
+     * @return A pair containing the inverse of the deformation gradient and its derivative with respect to F
+     *
+     * The inverse of the deformation gradient is defined as:
+     * \f[
+     *  \boldsymbol{F}^{-1}
+     *  \f]
+     *  The derivative of \f$\boldsymbol{F}^{-1}\f$ with respect to \f$\boldsymbol{F}\f$ is given by:
+     *  \f[
+     *  \frac{\partial F^{-1}_{iK}}{\partial F_{jL}} = - F^{-1}_{iL} F^{-1}_{jK}
+     *  \f]
+     */
+    template < int nDim >
+    inline std::pair< Fastor::Tensor< double, nDim, nDim >, Fastor::Tensor< double, nDim, nDim, nDim, nDim > > inverseDeformationGradient(
+      const Fastor::Tensor< double, nDim, nDim >& F )
+    {
 
-        return { n, dn_dFInv };
-      }
+      using namespace Fastor;
+      using namespace FastorIndices;
+      using TensorDDd   = Tensor< double, nDim, nDim >;
+      using TensorDDDDd = Tensor< double, nDim, nDim, nDim, nDim >;
 
-      /** @brief Computes the deformed normal projection tensor and its derivative with respect to the inverse
-       * deformation gradient.
-       * @param FInv Inverse of the deformation gradient tensor
-       * @param N_x_dA0 Undeformed normal vector scaled by undeformed area
-       * @return A pair containing the deformed normal projection tensor and its derivative with respect to FInv
-       *
-       * The deformed normal projection tensor is defined as:
-       * \f[
-       *   N_{ij} = n_i n_j = \frac{ F^{-1}_{Ii} N_{I} J dA_0 \times F^{-1}_{Jj} N_{J} J dA_0} { \| F^{-1}_{Ki} N_{K} J
-       * dA_0 \|^2 }
-       * \f]
-       */
-      template < int nDim >
-      inline std::pair< Fastor::Tensor< double, nDim, nDim >, Fastor::Tensor< double, nDim, nDim, nDim, nDim > > deformedNormalProjectionTensor(
-        const Fastor::Tensor< double, nDim, nDim >& FInv,
-        const Fastor::Tensor< double, nDim >&       N_x_dA0 )
-      {
+      const TensorDDd   FInv     = inverse( F );
+      const TensorDDDDd dFInv_dF = -einsum< Ik, Ki, to_IikK >( FInv, FInv );
 
-        using namespace Fastor;
-        using namespace FastorIndices;
-        using TensorDDd   = Tensor< double, nDim, nDim >;
-        using TensorDDDDd = Tensor< double, nDim, nDim, nDim, nDim >;
+      return { FInv, dFInv_dF };
+    }
 
-        const auto [n, dn_dFInv] = deformedNormalVectorFromUndeformedSurfaceVector< nDim >( FInv, N_x_dA0 );
-        const TensorDDd n_ij     = outer( n, n );
+  } // namespace FirstOrderDerived
 
-        const TensorDDDDd aux         = outer( n, dn_dFInv );
-        const TensorDDDDd dn_ij_dFInv = aux + Fastor::permute< Fastor::Index< 1, 0, 2, 3 > >( aux );
-
-        return { n_ij, dn_ij_dFInv };
-      }
-
-      /**
-       * @brief Computes the inverse of the deformation gradient and its derivative with respect to the deformation
-       * gradient.
-       * @param F Deformation gradient tensor
-       * @return A pair containing the inverse of the deformation gradient and its derivative with respect to F
-       *
-       * The inverse of the deformation gradient is defined as:
-       * \f[
-       *  \boldsymbol{F}^{-1}
-       *  \f]
-       *  The derivative of \f$\boldsymbol{F}^{-1}\f$ with respect to \f$\boldsymbol{F}\f$ is given by:
-       *  \f[
-       *  \frac{\partial F^{-1}_{iK}}{\partial F_{jL}} = - F^{-1}_{iL} F^{-1}_{jK}
-       *  \f]
-       */
-      template < int nDim >
-      inline std::pair< Fastor::Tensor< double, nDim, nDim >, Fastor::Tensor< double, nDim, nDim, nDim, nDim > > inverseDeformationGradient(
-        const Fastor::Tensor< double, nDim, nDim >& F )
-      {
-
-        using namespace Fastor;
-        using namespace FastorIndices;
-        using TensorDDd   = Tensor< double, nDim, nDim >;
-        using TensorDDDDd = Tensor< double, nDim, nDim, nDim, nDim >;
-
-        const TensorDDd   FInv     = inverse( F );
-        const TensorDDDDd dFInv_dF = -einsum< Ik, Ki, to_IikK >( FInv, FInv );
-
-        return { FInv, dFInv_dF };
-      }
-
-    } // namespace FirstOrderDerived
-
-  }   // namespace DeformationMeasures
-} // namespace Marmot::ContinuumMechanics
+} // namespace Marmot::ContinuumMechanics::DeformationMeasures

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotEnergyDensityFunctions.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotEnergyDensityFunctions.h
@@ -26,43 +26,197 @@
 #pragma once
 #include "Marmot/MarmotFastorTensorBasics.h"
 
-namespace Marmot::ContinuumMechanics {
+namespace Marmot::ContinuumMechanics::EnergyDensityFunctions {
 
-  namespace EnergyDensityFunctions {
+  using namespace Fastor;
+  using namespace FastorStandardTensors;
 
-    using namespace Fastor;
-    using namespace FastorStandardTensors;
+  /** @brief Hyperelastic Energy Density Function Wa acc. Pence & Gou (2015), Eq. (2.11)
+   *
+   *  The energy density function \f$W_a\f$ is given as
+   *  \f[
+   *    W_a = \frac{G}{2} (I_1 - 3) + \left(\frac{K}{2} - \frac{G}{3}\right) (J - 1)^2 - G \ln(J)
+   *  \f]
+   *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
+   *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
+   * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and shear
+   * modulus, respectively.
+   *
+   * @tparam T Scalar type, e.g. double, float, etc.
+   * @param C Right Cauchy-Green tensor
+   * @param K Bulk modulus
+   * @param G Shear modulus
+   * @return Energy density
+   */
+  template < typename T >
+  T PenceGouPotentialA( const Tensor33t< T >& C, const double K, const double G )
+  {
 
-    /** @brief Hyperelastic Energy Density Function Wa acc. Pence & Gou (2015), Eq. (2.11)
+    const T J  = sqrt( determinant( C ) );
+    const T I1 = trace( C );
+
+    T res = G / 2. * ( I1 - 3. ) + ( K / 2. - G / 3. ) * pow( J - 1, 2 ) - G * log( J );
+
+    return res;
+  }
+
+  /** @brief Hyperelastic Energy Density Function Wb acc. Pence & Gou (2015), Eq. (2.12)
+   *
+   *  The energy density function \f$W_b\f$ is given as
+   *  \f[
+   *    W_b = \frac{K}{8} \left(J - \frac{1}{J}\right)^2 + \frac{G}{2} \left(I_1 J^{-\frac{2}{3}} - 3\right)
+   *  \f]
+   *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
+   *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
+   * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and shear
+   * modulus, respectively.
+   *
+   * @tparam T Scalar type, e.g. double, float, etc.
+   * @param C Right Cauchy-Green tensor
+   * @param K Bulk modulus
+   * @param G Shear modulus
+   * @return Energy density
+   */
+  template < typename T >
+  T PenceGouPotentialB( const Tensor33t< T >& C, const double K, const double G )
+  {
+
+    const T detC = determinant( C );
+    const T I1   = trace( C );
+
+    T res = K / 8. * ( detC + 1. / detC - 2. ) + G / 2. * ( I1 * pow( detC, -1. / 3 ) - 3. );
+
+    return res;
+  }
+
+  /** @brief Hyperelastic Energy Density Function Wc acc. Pence & Gou (2015), Eq. (2.13)
+   *
+   *  The energy density function \f$W_c\f$ is given as
+   *  \f[
+   *    W_c = \frac{G}{2} (I_1 - 3) + \frac{3 G^2}{3 K - 2 G} \left(J^{\frac{2}{3} - \frac{K}{G}} - 1\right)
+   *  \f]
+   *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
+   *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
+   * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and shear
+   * modulus, respectively.
+   *
+   * @tparam T Scalar type, e.g. double, float, etc.
+   * @param C Right Cauchy-Green tensor
+   * @param K Bulk modulus
+   * @param G Shear modulus
+   * @return Energy density
+   */
+  template < typename T >
+  T PenceGouPotentialC( const Tensor33t< T >& C, const double K, const double G )
+  {
+
+    const T J  = sqrt( determinant( C ) );
+    const T I1 = trace( C );
+
+    T res = G / 2. * ( I1 - 3. ) + 3. * G * G / ( 3. * K - 2. * G ) * ( pow( J, 2. / 3 - K / G ) - 1 );
+
+    return res;
+  }
+
+  /**
+   * @brief Mooney-Rivlin Hyperelastic Energy Density Function
+   * The energy density function \f$W_{MR}\f$ is given as
+   * \f[
+   *   W_{MR} = C_1 (\bar{I}_1 - 3) + C_2 (\bar{I}_2 - 3) + \frac{1}{D_1} (J - 1)^2
+   * \f]
+   * where \f$ \bar{I}_1 = I_1 J^{-\frac{2}{3}} \f$ and \f$ \bar{I}_2 = I_2 J^{-\frac{4}{3}} \f$ are the first
+   * and second invariant of the isochoric right Cauchy-Green tensor, respectively, \f$ I_1 =
+   * \text{tr}(\boldsymbol{C}) \f$ and \f$ I_2 = 0.5 (I_1^2 - \text{tr}(\boldsymbol{C}^2)) \f$ are the first and
+   * second invariant of the right Cauchy-Green tensor \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J
+   * = \sqrt{\det(\boldsymbol{C})} = \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$
+   * C_1, C_2, D_1 \f$ are material parameters.
+   *
+   * @tparam T Scalar type, e.g. double, float, etc.
+   * @param C Right Cauchy-Green tensor
+   * @param C1 Mooney-Rivlin material parameter C1
+   * @param C2 Mooney-Rivlin material parameter C2
+   * @param D1 Mooney-Rivlin material parameter D1
+   * @return Energy density
+   */
+  template < typename T >
+  T MooneyRivlinPotential( const Tensor33t< T >& C, const double C1, const double C2, const double D1 )
+  {
+
+    const T J   = sqrt( determinant( C ) );
+    const T I1  = trace( C );
+    const T I1_ = I1 * pow( J, -2. / 3. );
+    const T I2_ = 0.5 * ( I1 * I1 - trace( C % C ) ) * pow( J, -4. / 3. );
+    T       res = C1 * ( I1_ - 3. ) + C2 * ( I2_ - 3. ) + 1. / D1 * ( 0.5 * ( J * J - 1 ) - log( J ) );
+
+    return res;
+  }
+
+  /** @brief Yeoh hyperelastic energy density function.
+   *
+   *  The energy density function is given as
+   *  \f[
+   *    W = C_1 (\bar{I}_1 - 3) + C_2 (\bar{I}_1 - 3)^2 + C_3 (\bar{I}_1 - 3)^3 + \frac{1}{D_1}\left(
+   *    \frac{J^2 - 1}{2} - \ln J \right)
+   *  \f]
+   *  where \f$\bar{I}_1 = I_1 J^{-2/3}\f$, \f$I_1 = \mathrm{tr}(\boldsymbol{C})\f$, and
+   *  \f$J = \sqrt{\det(\boldsymbol{C})}\f$.
+   *
+   * @tparam T Scalar type, e.g. double, float, autodiff scalar.
+   * @param C Right Cauchy-Green tensor.
+   * @param C1 Yeoh material parameter.
+   * @param C2 Yeoh material parameter.
+   * @param C3 Yeoh material parameter.
+   * @param D1 Volumetric penalty parameter.
+   * @return Energy density.
+   */
+  template < typename T >
+  T YeohPotential( const Tensor33t< T >& C, const double C1, const double C2, const double C3, const double D1 )
+  {
+
+    const T J         = sqrt( determinant( C ) );
+    const T I1        = trace( C );
+    const T I1_minus3 = I1 * pow( J, -2. / 3. ) - 3.;
+    T       res       = C1 * I1_minus3 + C2 * I1_minus3 * I1_minus3 + C3 * I1_minus3 * I1_minus3 * I1_minus3 +
+            1. / D1 * ( 0.5 * ( J * J - 1 ) - log( J ) );
+    return res;
+  }
+
+  /** @brief Standard compressible Neo-Hooke energy density function in terms of \f$\boldsymbol{C}\f$.
+   *
+   * @tparam T Scalar type, e.g. double, float, autodiff scalar.
+   * @param C Right Cauchy-Green tensor.
+   * @param K Bulk modulus.
+   * @param G Shear modulus.
+   * @return Energy density.
+   */
+  template < typename T >
+  T standardNeoHooke( const Tensor33t< T >& C, const double K, const double G )
+  {
+    const double lambda = K - 2.0 / 3.0 * G;
+
+    /*
+     * we use the potential in terms of C
+     * Psi = G/2 ( tr(C) - 3 - 2 ln(J) ) + lambda/2 ( 0.5 ( J^2 - 1 ) - ln(J) )
+     * where J = sqrt( det(C) ) and ln(J) = 0.5 ln( det(C) )
      *
-     *  The energy density function \f$W_a\f$ is given as
-     *  \f[
-     *    W_a = \frac{G}{2} (I_1 - 3) + \left(\frac{K}{2} - \frac{G}{3}\right) (J - 1)^2 - G \ln(J)
-     *  \f]
-     *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
-     *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
-     * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and shear
-     * modulus, respectively.
+     * we can the rewrite as
+     * Psi = G/2 ( tr(C) - 3 - ln(det(C)) ) + lambda/2 ( 0.5 ( det(C) - 1 ) - 0.5 ln(det(C)) )
      *
-     * @tparam T Scalar type, e.g. double, float, etc.
-     * @param C Right Cauchy-Green tensor
-     * @param K Bulk modulus
-     * @param G Shear modulus
-     * @return Energy density
      */
-    template < typename T >
-    T PenceGouPotentialA( const Tensor33t< T >& C, const double K, const double G )
-    {
 
-      const T J  = sqrt( determinant( C ) );
-      const T I1 = trace( C );
+    const T trC    = trace( C );
+    const T detC   = determinant( C );
+    const T lnDetC = log( detC );
+    // energy density
+    const T psi = G / 2 * ( trC - 3.0 - lnDetC ) + lambda / 4 * ( detC - 1.0 - lnDetC );
 
-      T res = G / 2. * ( I1 - 3. ) + ( K / 2. - G / 3. ) * pow( J - 1, 2 ) - G * log( J );
+    return psi;
+  }
 
-      return res;
-    }
+  namespace FirstOrderDerived {
 
-    /** @brief Hyperelastic Energy Density Function Wb acc. Pence & Gou (2015), Eq. (2.12)
+    /** @brief Hyperelastic Energy Density Function Wb acc. Pence & Gou (2015), Eq. (2.12) and its first derivative
+     * w.r.t. C
      *
      *  The energy density function \f$W_b\f$ is given as
      *  \f[
@@ -70,129 +224,129 @@ namespace Marmot::ContinuumMechanics {
      *  \f]
      *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
      *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
-     * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and shear
-     * modulus, respectively.
+     * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and
+     * shear modulus, respectively.
      *
-     * @tparam T Scalar type, e.g. double, float, etc.
-     * @param C Right Cauchy-Green tensor
-     * @param K Bulk modulus
-     * @param G Shear modulus
-     * @return Energy density
-     */
-    template < typename T >
-    T PenceGouPotentialB( const Tensor33t< T >& C, const double K, const double G )
-    {
-
-      const T detC = determinant( C );
-      const T I1   = trace( C );
-
-      T res = K / 8. * ( detC + 1. / detC - 2. ) + G / 2. * ( I1 * pow( detC, -1. / 3 ) - 3. );
-
-      return res;
-    }
-
-    /** @brief Hyperelastic Energy Density Function Wc acc. Pence & Gou (2015), Eq. (2.13)
-     *
-     *  The energy density function \f$W_c\f$ is given as
+     *  Additionally, the first derivative w.r.t. C is computed as
      *  \f[
-     *    W_c = \frac{G}{2} (I_1 - 3) + \frac{3 G^2}{3 K - 2 G} \left(J^{\frac{2}{3} - \frac{K}{G}} - 1\right)
+     *    \frac{\partial W_b}{\partial \boldsymbol{C}} = \frac{\partial W_b}{\partial J} \frac{\partial J}{\partial
+     * \boldsymbol{C}} + \frac{\partial W_b}{\partial I_1} \frac{\partial I_1}{\partial \boldsymbol{C}} \f] where \f[
+     *    \frac{\partial J}{\partial \boldsymbol{C}} = \frac{1}{2} J \boldsymbol{C}^{-1}
      *  \f]
-     *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
-     *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
-     * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and shear
-     * modulus, respectively.
+     *  and
+     *  \f[
+     *    \frac{\partial I_1}{\partial \boldsymbol{C}} = \boldsymbol{I}
+     *  \f]
      *
      * @tparam T Scalar type, e.g. double, float, etc.
      * @param C Right Cauchy-Green tensor
      * @param K Bulk modulus
      * @param G Shear modulus
-     * @return Energy density
+     * @return A tuple containing energy density and its first derivative w.r.t. C
      */
     template < typename T >
-    T PenceGouPotentialC( const Tensor33t< T >& C, const double K, const double G )
+    std::tuple< T, Tensor33t< T > > PenceGouPotentialB( const Tensor33t< T >& C, const double K, const double G )
     {
+      using namespace FastorIndices;
 
       const T J  = sqrt( determinant( C ) );
       const T I1 = trace( C );
+      // energy density
+      T psi = K / 8. * pow( J - 1. / J, 2. ) + G / 2. * ( I1 * pow( J, -2. / 3 ) - 3. );
 
-      T res = G / 2. * ( I1 - 3. ) + 3. * G * G / ( 3. * K - 2. * G ) * ( pow( J, 2. / 3 - K / G ) - 1 );
+      // first derivative w.r.t. C
+      const T dPsi_dJ  = K / 4. * ( J - 1. / J ) * ( 1. + 1. / ( J * J ) ) - G / 3. * I1 * pow( J, -5. / 3. );
+      const T dPsi_dI1 = G / 2. * pow( J, -2. / 3. );
 
-      return res;
+      const Tensor33t< T > CInv   = inverse( C );
+      const Tensor33t< T > dJ_dC  = multiplyFastorTensorWithScalar( transpose( CInv ), T( J / 2. ) );
+      const Tensor33t< T > dI1_dC = fastorTensorFromDoubleTensor< T >( Spatial3D::I );
+
+      Tensor33t< T > dPsi_dC = multiplyFastorTensorWithScalar( dJ_dC, dPsi_dJ ) +
+                               multiplyFastorTensorWithScalar( dI1_dC, dPsi_dI1 );
+
+      return { psi, dPsi_dC };
     }
+  } // namespace FirstOrderDerived
 
-    /**
-     * @brief Mooney-Rivlin Hyperelastic Energy Density Function
-     * The energy density function \f$W_{MR}\f$ is given as
+  namespace SecondOrderDerived {
+
+    /** @brief Hyperelastic Energy Density Function Wb acc. Pence & Gou (2015), Eq. (2.12) and its first and second
+     * derivative w.r.t. C
+     *
+     * The energy density function \f$W_b\f$ is given as
      * \f[
-     *   W_{MR} = C_1 (\bar{I}_1 - 3) + C_2 (\bar{I}_2 - 3) + \frac{1}{D_1} (J - 1)^2
+     *   W_b = \frac{K}{8} \left(J - \frac{1}{J}\right)^2 + \frac{G}{2} \left(I_1 J^{-\frac{2}{3}} - 3\right)
      * \f]
-     * where \f$ \bar{I}_1 = I_1 J^{-\frac{2}{3}} \f$ and \f$ \bar{I}_2 = I_2 J^{-\frac{4}{3}} \f$ are the first
-     * and second invariant of the isochoric right Cauchy-Green tensor, respectively, \f$ I_1 =
-     * \text{tr}(\boldsymbol{C}) \f$ and \f$ I_2 = 0.5 (I_1^2 - \text{tr}(\boldsymbol{C}^2)) \f$ are the first and
-     * second invariant of the right Cauchy-Green tensor \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J
-     * = \sqrt{\det(\boldsymbol{C})} = \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$
-     * C_1, C_2, D_1 \f$ are material parameters.
+     * where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
+     * \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
+     * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and
+     * shear modulus, respectively.
+     *
+     * Additionally, the first and second derivative w.r.t. \f$\boldsymbol{C}\f$,
+     * i.e.,
+     * \f[
+     * \frac{\partial W_b}{\partial \boldsymbol{C}} \quad \text{and} \quad
+     * \frac{\partial^2 W_b}{\partial \boldsymbol{C} \partial \boldsymbol{C}}
+     * \f]
+     * are computed.
      *
      * @tparam T Scalar type, e.g. double, float, etc.
      * @param C Right Cauchy-Green tensor
-     * @param C1 Mooney-Rivlin material parameter C1
-     * @param C2 Mooney-Rivlin material parameter C2
-     * @param D1 Mooney-Rivlin material parameter D1
-     * @return Energy density
+     * @param K Bulk modulus
+     * @param G Shear modulus
+     * @return A tuple containing energy density, its first and second derivative w.r.t. C
+     *
      */
     template < typename T >
-    T MooneyRivlinPotential( const Tensor33t< T >& C, const double C1, const double C2, const double D1 )
+    std::tuple< T, Tensor33t< T >, Tensor3333t< T > > PenceGouPotentialB( const Tensor33t< T >& C,
+                                                                          const double          K,
+                                                                          const double          G )
     {
+      using namespace FastorIndices;
 
-      const T J   = sqrt( determinant( C ) );
-      const T I1  = trace( C );
-      const T I1_ = I1 * pow( J, -2. / 3. );
-      const T I2_ = 0.5 * ( I1 * I1 - trace( C % C ) ) * pow( J, -4. / 3. );
-      T       res = C1 * ( I1_ - 3. ) + C2 * ( I2_ - 3. ) + 1. / D1 * ( 0.5 * ( J * J - 1 ) - log( J ) );
+      const T J  = sqrt( determinant( C ) );
+      const T I1 = trace( C );
+      // energy density
+      T psi = K / 8. * pow( J - 1. / J, 2. ) + G / 2. * ( I1 * pow( J, -2. / 3 ) - 3. );
 
-      return res;
+      // first derivative w.r.t. C
+      const T dPsi_dJ  = K / 4. * ( J - 1. / J ) * ( 1 + 1. / ( J * J ) ) - G / 3. * I1 * pow( J, -5. / 3. );
+      const T dPsi_dI1 = G / 2. * pow( J, -2. / 3. );
+
+      const Tensor33t< T > CInv   = inverse( C );
+      const Tensor33t< T > dJ_dC  = 0.5 * J * transpose( CInv );
+      const Tensor33t< T > dI1_dC = Spatial3D::I;
+
+      Tensor33t< T > dPsi_dC = dPsi_dJ * dJ_dC + dPsi_dI1 * dI1_dC;
+
+      // second derivative w.r.t. C
+      const T          d2Psi_dJdJ  = K / 4. * ( 1. + 3. / ( J * J * J * J ) ) + 5. / 9. * G * I1 * pow( J, -8. / 3. );
+      const T          d2Psi_dJdI1 = -G / 3. * pow( J, -5. / 3. );
+      Tensor3333t< T > d2J_dCdC    = J / 4. * einsum< JI, LK, to_IJKL >( CInv, CInv ) -
+                                  J / 2. * einsum< JK, LI, to_IJKL >( CInv, CInv );
+
+      Tensor3333t< T > d2Psi_dCdC = d2Psi_dJdJ * einsum< IJ, KL >( dJ_dC, dJ_dC ) + dPsi_dJ * d2J_dCdC +
+                                    d2Psi_dJdI1 *
+                                      ( einsum< IJ, KL >( dJ_dC, dI1_dC ) + einsum< IJ, KL >( dI1_dC, dJ_dC ) );
+
+      return { psi, dPsi_dC, d2Psi_dCdC };
     }
 
-    /** @brief Yeoh hyperelastic energy density function.
-     *
-     *  The energy density function is given as
-     *  \f[
-     *    W = C_1 (\bar{I}_1 - 3) + C_2 (\bar{I}_1 - 3)^2 + C_3 (\bar{I}_1 - 3)^3 + \frac{1}{D_1}\left(
-     *    \frac{J^2 - 1}{2} - \ln J \right)
-     *  \f]
-     *  where \f$\bar{I}_1 = I_1 J^{-2/3}\f$, \f$I_1 = \mathrm{tr}(\boldsymbol{C})\f$, and
-     *  \f$J = \sqrt{\det(\boldsymbol{C})}\f$.
-     *
-     * @tparam T Scalar type, e.g. double, float, autodiff scalar.
-     * @param C Right Cauchy-Green tensor.
-     * @param C1 Yeoh material parameter.
-     * @param C2 Yeoh material parameter.
-     * @param C3 Yeoh material parameter.
-     * @param D1 Volumetric penalty parameter.
-     * @return Energy density.
-     */
-    template < typename T >
-    T YeohPotential( const Tensor33t< T >& C, const double C1, const double C2, const double C3, const double D1 )
-    {
-
-      const T J         = sqrt( determinant( C ) );
-      const T I1        = trace( C );
-      const T I1_minus3 = I1 * pow( J, -2. / 3. ) - 3.;
-      T       res       = C1 * I1_minus3 + C2 * I1_minus3 * I1_minus3 + C3 * I1_minus3 * I1_minus3 * I1_minus3 +
-              1. / D1 * ( 0.5 * ( J * J - 1 ) - log( J ) );
-      return res;
-    }
-
-    /** @brief Standard compressible Neo-Hooke energy density function in terms of \f$\boldsymbol{C}\f$.
+    /** @brief Standard compressible Neo-Hooke energy density and first/second derivatives w.r.t.
+     * \f$\boldsymbol{C}\f$.
      *
      * @tparam T Scalar type, e.g. double, float, autodiff scalar.
      * @param C Right Cauchy-Green tensor.
      * @param K Bulk modulus.
      * @param G Shear modulus.
-     * @return Energy density.
+     * @return Tuple of energy density, first derivative and second derivative w.r.t. \f$\boldsymbol{C}\f$.
      */
     template < typename T >
-    T standardNeoHooke( const Tensor33t< T >& C, const double K, const double G )
+    std::tuple< T, FastorStandardTensors::Tensor33t< T >, FastorStandardTensors::Tensor3333t< T > > standardNeoHooke(
+      const FastorStandardTensors::Tensor33t< T >& C,
+      const double&                                K,
+      const double&                                G )
     {
       const double lambda = K - 2.0 / 3.0 * G;
 
@@ -212,234 +366,76 @@ namespace Marmot::ContinuumMechanics {
       // energy density
       const T psi = G / 2 * ( trC - 3.0 - lnDetC ) + lambda / 4 * ( detC - 1.0 - lnDetC );
 
-      return psi;
+      // first derivative quantities
+      const Tensor33t< T >& dTrC_dC    = makeOtherScalarType< T >( Spatial3D::I );
+      const Tensor33t< T >  invCt      = transpose( inverse( C ) );
+      const Tensor33t< T >  dDetC_dC   = multiplyFastorTensorWithScalar( invCt, detC );
+      const Tensor33t< T >& dLnDetC_dC = invCt;
+
+      // first derivative with respect to C
+      const Tensor33t< T > dPsi_dC = G / 2 * ( dTrC_dC - dLnDetC_dC ) + lambda / 4 * ( dDetC_dC - dLnDetC_dC );
+
+      // second derivative quantities
+      using namespace FastorIndices;
+      using lj                          = Index< l_, j_ >;
+      using li                          = Index< l_, i_ >;
+      const Tensor3333t< T > dInvCt_dC  = -0.5 * ( einsum< ik, lj, to_ijkl >( invCt, invCt ) +
+                                                  einsum< jk, li, to_ijkl >( invCt, invCt ) );
+      const Tensor3333t< T > d2DetC_dC2 = multiplyFastorTensorWithScalar( dInvCt_dC, detC ) +
+                                          einsum< ij, kl, to_ijkl >( invCt, dDetC_dC );
+      const Tensor3333t< T >& d2LnDetC_dC2 = dInvCt_dC;
+
+      // second derivative with respect to C
+      const Tensor3333t< T > d2Psi_dC2 = lambda / 4.0 * d2DetC_dC2 - ( G / 2.0 + lambda / 4.0 ) * d2LnDetC_dC2;
+      return { psi, dPsi_dC, d2Psi_dC2 };
     }
 
-    namespace FirstOrderDerived {
+    /** @brief Isotropic Biot-Neo-Hooke energy density and derivatives w.r.t. right stretch \f$\boldsymbol{U}\f$.
+     *
+     * @details Internally evaluates the standard Neo-Hooke potential in terms of
+     * \f$\boldsymbol{C}=\boldsymbol{U}\boldsymbol{U}\f$ and applies chain-rule transformations.
+     *
+     * @tparam T Scalar type, e.g. double, float, autodiff scalar.
+     * @param U Right stretch tensor.
+     * @param K Bulk modulus.
+     * @param G Shear modulus.
+     * @return Tuple of energy density, first derivative and second derivative w.r.t. \f$\boldsymbol{U}\f$.
+     */
+    template < typename T >
+    std::tuple< T, FastorStandardTensors::Tensor33t< T >, FastorStandardTensors::Tensor3333t< T > > BiotNeoHooke(
+      const FastorStandardTensors::Tensor33t< T >& U,
+      const double&                                K,
+      const double&                                G )
+    {
+      using namespace FastorIndices;
+      Tensor3333t< T > I4       = makeOtherScalarType< T >( Spatial3D::I4 );
+      Tensor33t< T >   C        = U % U;
+      Tensor3333t< T > dC_dU    = 2 * einsum< iL, ijkl >( U, I4 );
+      Tensor3333t< T > d2C_dUdU = 2 * I4;
 
-      /** @brief Hyperelastic Energy Density Function Wb acc. Pence & Gou (2015), Eq. (2.12) and its first derivative
-       * w.r.t. C
-       *
-       *  The energy density function \f$W_b\f$ is given as
-       *  \f[
-       *    W_b = \frac{K}{8} \left(J - \frac{1}{J}\right)^2 + \frac{G}{2} \left(I_1 J^{-\frac{2}{3}} - 3\right)
-       *  \f]
-       *  where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
-       *  \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
-       * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and
-       * shear modulus, respectively.
-       *
-       *  Additionally, the first derivative w.r.t. C is computed as
-       *  \f[
-       *    \frac{\partial W_b}{\partial \boldsymbol{C}} = \frac{\partial W_b}{\partial J} \frac{\partial J}{\partial
-       * \boldsymbol{C}} + \frac{\partial W_b}{\partial I_1} \frac{\partial I_1}{\partial \boldsymbol{C}} \f] where \f[
-       *    \frac{\partial J}{\partial \boldsymbol{C}} = \frac{1}{2} J \boldsymbol{C}^{-1}
-       *  \f]
-       *  and
-       *  \f[
-       *    \frac{\partial I_1}{\partial \boldsymbol{C}} = \boldsymbol{I}
-       *  \f]
-       *
-       * @tparam T Scalar type, e.g. double, float, etc.
-       * @param C Right Cauchy-Green tensor
-       * @param K Bulk modulus
-       * @param G Shear modulus
-       * @return A tuple containing energy density and its first derivative w.r.t. C
-       */
-      template < typename T >
-      std::tuple< T, Tensor33t< T > > PenceGouPotentialB( const Tensor33t< T >& C, const double K, const double G )
-      {
-        using namespace FastorIndices;
+      auto [psi, dPsi_dC, d2Psi_dCdC] = standardNeoHooke< T >( C, K, G );
 
-        const T J  = sqrt( determinant( C ) );
-        const T I1 = trace( C );
-        // energy density
-        T psi = K / 8. * pow( J - 1. / J, 2. ) + G / 2. * ( I1 * pow( J, -2. / 3 ) - 3. );
+      Tensor33t< T >   dPsi_dU    = einsum< kl, klmn >( dPsi_dC, dC_dU );
+      Tensor3333t< T > d2Psi_dUdU = einsum< ijkl, klmn >( einsum< ijkl, ijmn >( dC_dU, d2Psi_dCdC ), dC_dU ) +
+                                    einsum< jL, ijkl >( dPsi_dC, d2C_dUdU );
 
-        // first derivative w.r.t. C
-        const T dPsi_dJ  = K / 4. * ( J - 1. / J ) * ( 1. + 1. / ( J * J ) ) - G / 3. * I1 * pow( J, -5. / 3. );
-        const T dPsi_dI1 = G / 2. * pow( J, -2. / 3. );
+      return { psi, dPsi_dU, d2Psi_dUdU };
+    }
 
-        const Tensor33t< T > CInv   = inverse( C );
-        const Tensor33t< T > dJ_dC  = multiplyFastorTensorWithScalar( transpose( CInv ), T( J / 2. ) );
-        const Tensor33t< T > dI1_dC = fastorTensorFromDoubleTensor< T >( Spatial3D::I );
+  } // namespace SecondOrderDerived
 
-        Tensor33t< T > dPsi_dC = multiplyFastorTensorWithScalar( dJ_dC, dPsi_dJ ) +
-                                 multiplyFastorTensorWithScalar( dI1_dC, dPsi_dI1 );
-
-        return { psi, dPsi_dC };
-      }
-    } // namespace FirstOrderDerived
-
-    namespace SecondOrderDerived {
-
-      /** @brief Hyperelastic Energy Density Function Wb acc. Pence & Gou (2015), Eq. (2.12) and its first and second
-       * derivative w.r.t. C
-       *
-       * The energy density function \f$W_b\f$ is given as
-       * \f[
-       *   W_b = \frac{K}{8} \left(J - \frac{1}{J}\right)^2 + \frac{G}{2} \left(I_1 J^{-\frac{2}{3}} - 3\right)
-       * \f]
-       * where \f$ I_1 = \text{tr}(\boldsymbol{C}) \f$ is the first invariant of the right Cauchy-Green tensor
-       * \f$ \boldsymbol{C} = \boldsymbol{F}^T \boldsymbol{F} \f$, \f$ J = \sqrt{\det(\boldsymbol{C})} =
-       * \det(\boldsymbol{F}) \f$ is the determinant of the deformation gradient, and \f$ K, G \f$ are the bulk and
-       * shear modulus, respectively.
-       *
-       * Additionally, the first and second derivative w.r.t. \f$\boldsymbol{C}\f$,
-       * i.e.,
-       * \f[
-       * \frac{\partial W_b}{\partial \boldsymbol{C}} \quad \text{and} \quad
-       * \frac{\partial^2 W_b}{\partial \boldsymbol{C} \partial \boldsymbol{C}}
-       * \f]
-       * are computed.
-       *
-       * @tparam T Scalar type, e.g. double, float, etc.
-       * @param C Right Cauchy-Green tensor
-       * @param K Bulk modulus
-       * @param G Shear modulus
-       * @return A tuple containing energy density, its first and second derivative w.r.t. C
-       *
-       */
-      template < typename T >
-      std::tuple< T, Tensor33t< T >, Tensor3333t< T > > PenceGouPotentialB( const Tensor33t< T >& C,
-                                                                            const double          K,
-                                                                            const double          G )
-      {
-        using namespace FastorIndices;
-
-        const T J  = sqrt( determinant( C ) );
-        const T I1 = trace( C );
-        // energy density
-        T psi = K / 8. * pow( J - 1. / J, 2. ) + G / 2. * ( I1 * pow( J, -2. / 3 ) - 3. );
-
-        // first derivative w.r.t. C
-        const T dPsi_dJ  = K / 4. * ( J - 1. / J ) * ( 1 + 1. / ( J * J ) ) - G / 3. * I1 * pow( J, -5. / 3. );
-        const T dPsi_dI1 = G / 2. * pow( J, -2. / 3. );
-
-        const Tensor33t< T > CInv   = inverse( C );
-        const Tensor33t< T > dJ_dC  = 0.5 * J * transpose( CInv );
-        const Tensor33t< T > dI1_dC = Spatial3D::I;
-
-        Tensor33t< T > dPsi_dC = dPsi_dJ * dJ_dC + dPsi_dI1 * dI1_dC;
-
-        // second derivative w.r.t. C
-        const T          d2Psi_dJdJ  = K / 4. * ( 1. + 3. / ( J * J * J * J ) ) + 5. / 9. * G * I1 * pow( J, -8. / 3. );
-        const T          d2Psi_dJdI1 = -G / 3. * pow( J, -5. / 3. );
-        Tensor3333t< T > d2J_dCdC    = J / 4. * einsum< JI, LK, to_IJKL >( CInv, CInv ) -
-                                    J / 2. * einsum< JK, LI, to_IJKL >( CInv, CInv );
-
-        Tensor3333t< T > d2Psi_dCdC = d2Psi_dJdJ * einsum< IJ, KL >( dJ_dC, dJ_dC ) + dPsi_dJ * d2J_dCdC +
-                                      d2Psi_dJdI1 *
-                                        ( einsum< IJ, KL >( dJ_dC, dI1_dC ) + einsum< IJ, KL >( dI1_dC, dJ_dC ) );
-
-        return { psi, dPsi_dC, d2Psi_dCdC };
-      }
-
-      /** @brief Standard compressible Neo-Hooke energy density and first/second derivatives w.r.t.
-       * \f$\boldsymbol{C}\f$.
-       *
-       * @tparam T Scalar type, e.g. double, float, autodiff scalar.
-       * @param C Right Cauchy-Green tensor.
-       * @param K Bulk modulus.
-       * @param G Shear modulus.
-       * @return Tuple of energy density, first derivative and second derivative w.r.t. \f$\boldsymbol{C}\f$.
-       */
-      template < typename T >
-      std::tuple< T, FastorStandardTensors::Tensor33t< T >, FastorStandardTensors::Tensor3333t< T > > standardNeoHooke(
-        const FastorStandardTensors::Tensor33t< T >& C,
-        const double&                                K,
-        const double&                                G )
-      {
-        const double lambda = K - 2.0 / 3.0 * G;
-
-        /*
-         * we use the potential in terms of C
-         * Psi = G/2 ( tr(C) - 3 - 2 ln(J) ) + lambda/2 ( 0.5 ( J^2 - 1 ) - ln(J) )
-         * where J = sqrt( det(C) ) and ln(J) = 0.5 ln( det(C) )
-         *
-         * we can the rewrite as
-         * Psi = G/2 ( tr(C) - 3 - ln(det(C)) ) + lambda/2 ( 0.5 ( det(C) - 1 ) - 0.5 ln(det(C)) )
-         *
-         */
-
-        const T trC    = trace( C );
-        const T detC   = determinant( C );
-        const T lnDetC = log( detC );
-        // energy density
-        const T psi = G / 2 * ( trC - 3.0 - lnDetC ) + lambda / 4 * ( detC - 1.0 - lnDetC );
-
-        // first derivative quantities
-        const Tensor33t< T >& dTrC_dC    = makeOtherScalarType< T >( Spatial3D::I );
-        const Tensor33t< T >  invCt      = transpose( inverse( C ) );
-        const Tensor33t< T >  dDetC_dC   = multiplyFastorTensorWithScalar( invCt, detC );
-        const Tensor33t< T >& dLnDetC_dC = invCt;
-
-        // first derivative with respect to C
-        const Tensor33t< T > dPsi_dC = G / 2 * ( dTrC_dC - dLnDetC_dC ) + lambda / 4 * ( dDetC_dC - dLnDetC_dC );
-
-        // second derivative quantities
-        using namespace FastorIndices;
-        using lj                          = Index< l_, j_ >;
-        using li                          = Index< l_, i_ >;
-        const Tensor3333t< T > dInvCt_dC  = -0.5 * ( einsum< ik, lj, to_ijkl >( invCt, invCt ) +
-                                                    einsum< jk, li, to_ijkl >( invCt, invCt ) );
-        const Tensor3333t< T > d2DetC_dC2 = multiplyFastorTensorWithScalar( dInvCt_dC, detC ) +
-                                            einsum< ij, kl, to_ijkl >( invCt, dDetC_dC );
-        const Tensor3333t< T >& d2LnDetC_dC2 = dInvCt_dC;
-
-        // second derivative with respect to C
-        const Tensor3333t< T > d2Psi_dC2 = lambda / 4.0 * d2DetC_dC2 - ( G / 2.0 + lambda / 4.0 ) * d2LnDetC_dC2;
-        return { psi, dPsi_dC, d2Psi_dC2 };
-      }
-
-      /** @brief Isotropic Biot-Neo-Hooke energy density and derivatives w.r.t. right stretch \f$\boldsymbol{U}\f$.
-       *
-       * @details Internally evaluates the standard Neo-Hooke potential in terms of
-       * \f$\boldsymbol{C}=\boldsymbol{U}\boldsymbol{U}\f$ and applies chain-rule transformations.
-       *
-       * @tparam T Scalar type, e.g. double, float, autodiff scalar.
-       * @param U Right stretch tensor.
-       * @param K Bulk modulus.
-       * @param G Shear modulus.
-       * @return Tuple of energy density, first derivative and second derivative w.r.t. \f$\boldsymbol{U}\f$.
-       */
-      template < typename T >
-      std::tuple< T, FastorStandardTensors::Tensor33t< T >, FastorStandardTensors::Tensor3333t< T > > BiotNeoHooke(
-        const FastorStandardTensors::Tensor33t< T >& U,
-        const double&                                K,
-        const double&                                G )
-      {
-        using namespace FastorIndices;
-        Tensor3333t< T > I4       = makeOtherScalarType< T >( Spatial3D::I4 );
-        Tensor33t< T >   C        = U % U;
-        Tensor3333t< T > dC_dU    = 2 * einsum< iL, ijkl >( U, I4 );
-        Tensor3333t< T > d2C_dUdU = 2 * I4;
-
-        auto [psi, dPsi_dC, d2Psi_dCdC] = standardNeoHooke< T >( C, K, G );
-
-        Tensor33t< T >   dPsi_dU    = einsum< kl, klmn >( dPsi_dC, dC_dU );
-        Tensor3333t< T > d2Psi_dUdU = einsum< ijkl, klmn >( einsum< ijkl, ijmn >( dC_dU, d2Psi_dCdC ), dC_dU ) +
-                                      einsum< jL, ijkl >( dPsi_dC, d2C_dUdU );
-
-        return { psi, dPsi_dU, d2Psi_dUdU };
-      }
-
-    } // namespace SecondOrderDerived
-
-    namespace ThirdOrderDerived {
-      /** @brief Standard compressible Neo-Hooke energy density and first/second/third derivatives w.r.t.
-       * \f$\boldsymbol{C}\f$.
-       *
-       * @param C Right Cauchy-Green tensor.
-       * @param K Bulk modulus.
-       * @param G Shear modulus.
-       * @return Tuple of energy density, first derivative, second derivative and third derivative.
-       */
-      std::tuple< double, FastorStandardTensors::Tensor33d, FastorStandardTensors::Tensor3333d, FastorStandardTensors::Tensor333333d > standardNeoHooke(
-        const FastorStandardTensors::Tensor33d& C,
-        const double&                           K,
-        const double&                           G );
-    } // namespace ThirdOrderDerived
-  }   // namespace EnergyDensityFunctions
-
-} // namespace Marmot::ContinuumMechanics
+  namespace ThirdOrderDerived {
+    /** @brief Standard compressible Neo-Hooke energy density and first/second/third derivatives w.r.t.
+     * \f$\boldsymbol{C}\f$.
+     *
+     * @param C Right Cauchy-Green tensor.
+     * @param K Bulk modulus.
+     * @param G Shear modulus.
+     * @return Tuple of energy density, first derivative, second derivative and third derivative.
+     */
+    std::tuple< double, FastorStandardTensors::Tensor33d, FastorStandardTensors::Tensor3333d, FastorStandardTensors::Tensor333333d > standardNeoHooke(
+      const FastorStandardTensors::Tensor33d& C,
+      const double&                           K,
+      const double&                           G );
+  } // namespace ThirdOrderDerived
+} // namespace Marmot::ContinuumMechanics::EnergyDensityFunctions

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotFiniteStrainPlasticity.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotFiniteStrainPlasticity.h
@@ -36,67 +36,62 @@
  * the plastic velocity gradient.
  */
 
-namespace Marmot {
-  namespace ContinuumMechanics::FiniteStrain::Plasticity {
+namespace Marmot::ContinuumMechanics::FiniteStrain::Plasticity::FlowIntegration {
 
-    namespace FlowIntegration {
+  using namespace FastorStandardTensors;
+  using namespace Fastor;
 
-      using namespace FastorStandardTensors;
-      using namespace Fastor;
+  /** Computes the incremental plastic deformation gradient from the plastic velocity gradient
+   *  using the exponential map.
+   *
+   *  The exponential map is given by
+   *  \f[
+   *    \Delta F_{\bar I J} = \exp\left(\Delta \lambda \frac{\partial g}{\partial M_{\bar K L}}\right)_{J \bar{I}}
+   *  \f]
+   *  where \f$ \Delta \lambda \frac{\partial g}{\partial M_{\bar K L}} \f$ is the incremental plastic velocity
+   * gradient.
+   *
+   *  @tparam T Scalar type.
+   *  @param dGp Incremental plastic velocity gradient.
+   *  @return Incremental plastic deformation gradient.
+   */
+  template < typename T >
+  Tensor33t< T > exponentialMap( const Tensor33t< T >& dGp )
+  {
+    const Tensor33t< T > dFpT = TensorUtility::TensorExponential::computeTensorExponential( dGp, 15, 1e-14, 1e-14 );
+    const Tensor33t< T > out  = permute< Index< 1, 0 > >( dFpT );
+    return out;
+  }
+  namespace FirstOrderDerived {
 
-      /** Computes the incremental plastic deformation gradient from the plastic velocity gradient
-       *  using the exponential map.
-       *
-       *  The exponential map is given by
-       *  \f[
-       *    \Delta F_{\bar I J} = \exp\left(\Delta \lambda \frac{\partial g}{\partial M_{\bar K L}}\right)_{J \bar{I}}
-       *  \f]
-       *  where \f$ \Delta \lambda \frac{\partial g}{\partial M_{\bar K L}} \f$ is the incremental plastic velocity
-       * gradient.
-       *
-       *  @tparam T Scalar type.
-       *  @param dGp Incremental plastic velocity gradient.
-       *  @return Incremental plastic deformation gradient.
-       */
-      template < typename T >
-      Tensor33t< T > exponentialMap( const Tensor33t< T >& dGp )
-      {
-        const Tensor33t< T > dFpT = TensorUtility::TensorExponential::computeTensorExponential( dGp, 15, 1e-14, 1e-14 );
-        const Tensor33t< T > out  = permute< Index< 1, 0 > >( dFpT );
-        return out;
-      }
-      namespace FirstOrderDerived {
+    /** Computes the incremental plastic deformation gradient from the plastic velocity gradient
+     *  using a first order approximation.
+     *  The first order approximation is given by
+     *  \f[
+     *    \Delta F_{\bar I J} = \left( \delta_{\bar K L} + \Delta \lambda \frac{\partial f}{\partial M_{\bar K
+     * L}}\right)_{J \bar{I}} \f] where \f$ \Delta \lambda \frac{\partial f}{\partial M_{\bar K L}} \f$ is the
+     * incremental plastic velocity gradient.
+     *
+     *  @param deltaGp Incremental plastic velocity gradient.
+     *  @return A pair of the incremental plastic deformation gradient and its derivative w.r.t. the plastic
+     * velocity gradient.
+     */
+    std::pair< Tensor33d, Tensor3333d > explicitIntegration( const Tensor33d& deltaGp );
 
-        /** Computes the incremental plastic deformation gradient from the plastic velocity gradient
-         *  using a first order approximation.
-         *  The first order approximation is given by
-         *  \f[
-         *    \Delta F_{\bar I J} = \left( \delta_{\bar K L} + \Delta \lambda \frac{\partial f}{\partial M_{\bar K
-         * L}}\right)_{J \bar{I}} \f] where \f$ \Delta \lambda \frac{\partial f}{\partial M_{\bar K L}} \f$ is the
-         * incremental plastic velocity gradient.
-         *
-         *  @param deltaGp Incremental plastic velocity gradient.
-         *  @return A pair of the incremental plastic deformation gradient and its derivative w.r.t. the plastic
-         * velocity gradient.
-         */
-        std::pair< Tensor33d, Tensor3333d > explicitIntegration( const Tensor33d& deltaGp );
+    /** Computes the incremental plastic deformation gradient from the plastic velocity gradient
+     *  using the exponential map.
+     *  The exponential map is given by
+     *  \f[
+     *    \Delta F_{\bar I J} = \exp\left(\Delta \lambda \frac{\partial f}{\partial M_{\bar I J}}\right)_{J \bar{I}}
+     *  \f]
+     *  where \f$ \Delta \lambda \frac{\partial f}{\partial M_{\bar I J}} \f$ is the incremental plastic velocity
+     * gradient.
+     *
+     *  @param deltaGp Incremental plastic velocity gradient.
+     *  @return A pair of the incremental plastic deformation gradient and its derivative w.r.t. the plastic
+     * velocity gradient.
+     */
+    std::pair< Tensor33d, Tensor3333d > exponentialMap( const Tensor33d& deltaGp );
+  } // namespace FirstOrderDerived
 
-        /** Computes the incremental plastic deformation gradient from the plastic velocity gradient
-         *  using the exponential map.
-         *  The exponential map is given by
-         *  \f[
-         *    \Delta F_{\bar I J} = \exp\left(\Delta \lambda \frac{\partial f}{\partial M_{\bar I J}}\right)_{J \bar{I}}
-         *  \f]
-         *  where \f$ \Delta \lambda \frac{\partial f}{\partial M_{\bar I J}} \f$ is the incremental plastic velocity
-         * gradient.
-         *
-         *  @param deltaGp Incremental plastic velocity gradient.
-         *  @return A pair of the incremental plastic deformation gradient and its derivative w.r.t. the plastic
-         * velocity gradient.
-         */
-        std::pair< Tensor33d, Tensor3333d > exponentialMap( const Tensor33d& deltaGp );
-      } // namespace FirstOrderDerived
-
-    }   // namespace FlowIntegration
-  }     // namespace ContinuumMechanics::FiniteStrain::Plasticity
-} // namespace Marmot
+} // namespace Marmot::ContinuumMechanics::FiniteStrain::Plasticity::FlowIntegration

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotFiniteStrainViscoelasticity.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotFiniteStrainViscoelasticity.h
@@ -26,199 +26,197 @@
 #include "Marmot/MarmotFastorTensorBasics.h"
 #include "Marmot/MarmotMath.h"
 
-namespace Marmot {
-  namespace ContinuumMechanics::FiniteStrain::Viscoelasticity {
+namespace Marmot::ContinuumMechanics::FiniteStrain::Viscoelasticity {
 
-    /**
-     * @brief Struct to hold properties of a generalized maxwell model
-     */
-    struct MaxwellProperties {
-      int                   nMaxwell; ///< Number of maxwell elements
-      std::vector< double > gamma;    ///< Weighting factors of maxwell elements
-      double                sumGamma; ///< Sum of weighting factors
-      std::vector< double > tau;      ///< Relaxation times of maxwell elements
-    };
+  /**
+   * @brief Struct to hold properties of a generalized maxwell model
+   */
+  struct MaxwellProperties {
+    int                   nMaxwell; ///< Number of maxwell elements
+    std::vector< double > gamma;    ///< Weighting factors of maxwell elements
+    double                sumGamma; ///< Sum of weighting factors
+    std::vector< double > tau;      ///< Relaxation times of maxwell elements
+  };
 
-    MaxwellProperties createMaxwellProperties( int nMaxwell, const double* gammaTauPairVector );
+  MaxwellProperties createMaxwellProperties( int nMaxwell, const double* gammaTauPairVector );
 
-    /**
-     * @brief Evaluate generalized maxwell model contribution to stress and tangent
-     * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
-     * @param[in,out] tangent            Tangent tensor to be updated (input is the instantaneous hyperelasticelastic
-     * tangent)
-     * @param[in]  dTangent_dDeformation Derivative of tangent w.r.t. deformation
-     * @param[in]  initialCompliance     Initial compliance tensor
-     * @param[in]  dStress               Increment of the initial stress tensor
-     * @param[in]  dT                    Time increment
-     * @param[in]  maxwellProperties     Properties of the generalized maxwell model
-     * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
-     *
-     * @details This update function uses the approach in:
-     * Liu et al. 2021, A continuum and computational framework for viscoelastodynamics: I. Finite deformation linear
-     * models, Comput. Meth. Appl. Mech. Engrg. 385, 114059
-     */
-    void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&           stress,
-                                          FastorStandardTensors::Tensor3333d&         tangent,
-                                          const FastorStandardTensors::Tensor333333d& dTangent_dDeformation,
-                                          const FastorStandardTensors::Tensor3333d&   initialCompliance,
-                                          const FastorStandardTensors::Tensor33d&     dStress,
-                                          const double                                dT,
-                                          const MaxwellProperties&                    maxwellProperties,
-                                          double*                                     stateVars );
+  /**
+   * @brief Evaluate generalized maxwell model contribution to stress and tangent
+   * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
+   * @param[in,out] tangent            Tangent tensor to be updated (input is the instantaneous hyperelasticelastic
+   * tangent)
+   * @param[in]  dTangent_dDeformation Derivative of tangent w.r.t. deformation
+   * @param[in]  initialCompliance     Initial compliance tensor
+   * @param[in]  dStress               Increment of the initial stress tensor
+   * @param[in]  dT                    Time increment
+   * @param[in]  maxwellProperties     Properties of the generalized maxwell model
+   * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
+   *
+   * @details This update function uses the approach in:
+   * Liu et al. 2021, A continuum and computational framework for viscoelastodynamics: I. Finite deformation linear
+   * models, Comput. Meth. Appl. Mech. Engrg. 385, 114059
+   */
+  void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&           stress,
+                                        FastorStandardTensors::Tensor3333d&         tangent,
+                                        const FastorStandardTensors::Tensor333333d& dTangent_dDeformation,
+                                        const FastorStandardTensors::Tensor3333d&   initialCompliance,
+                                        const FastorStandardTensors::Tensor33d&     dStress,
+                                        const double                                dT,
+                                        const MaxwellProperties&                    maxwellProperties,
+                                        double*                                     stateVars );
 
-    /**
-     * @brief Evaluate generalized maxwell model contribution to stress and tangent
-     * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
-     * tangent)
-     * @param[in,out] tangent            Tangent tensor to be updated (input is the instantaneous hyperelasticelastic
-     * tangent)
-     * @param[in]  dStress               Increment of the initial stress tensor
-     * @param[in]  dT                    Time increment
-     * @param[in]  maxwellProperties     Properties of the generalized maxwell model
-     * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
-     *
-     * @details This update correspond to the approach by Simo (1987)
-     * and is used in the implementation of the generalized maxwell model in the finite element code
-     */
-    void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&       stress,
-                                          FastorStandardTensors::Tensor3333d&     tangent,
-                                          const FastorStandardTensors::Tensor33d& dStress,
-                                          const double                            dT,
-                                          const MaxwellProperties&                maxwellProperties,
-                                          double*                                 stateVars );
+  /**
+   * @brief Evaluate generalized maxwell model contribution to stress and tangent
+   * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
+   * tangent)
+   * @param[in,out] tangent            Tangent tensor to be updated (input is the instantaneous hyperelasticelastic
+   * tangent)
+   * @param[in]  dStress               Increment of the initial stress tensor
+   * @param[in]  dT                    Time increment
+   * @param[in]  maxwellProperties     Properties of the generalized maxwell model
+   * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
+   *
+   * @details This update correspond to the approach by Simo (1987)
+   * and is used in the implementation of the generalized maxwell model in the finite element code
+   */
+  void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&       stress,
+                                        FastorStandardTensors::Tensor3333d&     tangent,
+                                        const FastorStandardTensors::Tensor33d& dStress,
+                                        const double                            dT,
+                                        const MaxwellProperties&                maxwellProperties,
+                                        double*                                 stateVars );
 
-    /**
-     * @brief Evaluate generalized maxwell model contribution to stress without tangent update
-     * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
-     * tangent)
-     * @param[in]  dStress               Increment of the initial stress tensor
-     * @param[in]  dT                    Time increment
-     * @param[in]  maxwellProperties     Properties of the generalized maxwell model
-     * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
-     *
-     * @details This update correspond to the approach by Simo (1987)
-     * and is used in the implementation of the generalized maxwell model in the finite element code
-     */
-    template < typename T = double >
-    void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33t< T >&       stress,
-                                          const FastorStandardTensors::Tensor33t< T >& dStress,
-                                          const double                                 dT,
-                                          const MaxwellProperties&                     maxwellProperties,
-                                          double*                                      stateVars )
-    {
+  /**
+   * @brief Evaluate generalized maxwell model contribution to stress without tangent update
+   * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
+   * tangent)
+   * @param[in]  dStress               Increment of the initial stress tensor
+   * @param[in]  dT                    Time increment
+   * @param[in]  maxwellProperties     Properties of the generalized maxwell model
+   * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
+   *
+   * @details This update correspond to the approach by Simo (1987)
+   * and is used in the implementation of the generalized maxwell model in the finite element code
+   */
+  template < typename T = double >
+  void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33t< T >&       stress,
+                                        const FastorStandardTensors::Tensor33t< T >& dStress,
+                                        const double                                 dT,
+                                        const MaxwellProperties&                     maxwellProperties,
+                                        double*                                      stateVars )
+  {
 
-      if ( maxwellProperties.nMaxwell == 0 )
-        return;
+    if ( maxwellProperties.nMaxwell == 0 )
+      return;
 
-      using namespace Fastor;
-      using namespace Marmot::FastorStandardTensors;
-      using namespace Marmot::FastorIndices;
+    using namespace Fastor;
+    using namespace Marmot::FastorStandardTensors;
+    using namespace Marmot::FastorIndices;
 
-      // scale equilibrium stress contribution
-      stress = multiplyFastorTensorWithScalar( stress, T( 1.0 - maxwellProperties.sumGamma ) );
+    // scale equilibrium stress contribution
+    stress = multiplyFastorTensorWithScalar( stress, T( 1.0 - maxwellProperties.sumGamma ) );
 
-      for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
-        // get old  maxewell element stress from state variables
-        const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
+    for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
+      // get old  maxewell element stress from state variables
+      const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
 
-        // get parameters of maxwell element
-        const double& tau   = maxwellProperties.tau[i];
-        const double& gamma = maxwellProperties.gamma[i];
+      // get parameters of maxwell element
+      const double& tau   = maxwellProperties.tau[i];
+      const double& gamma = maxwellProperties.gamma[i];
 
-        const double dT_tau    = std::max( dT / tau, 1e-15 );
-        const double expFactor = Math::exp( -dT_tau );
+      const double dT_tau    = std::max( dT / tau, 1e-15 );
+      const double expFactor = Math::exp( -dT_tau );
 
-        double alpha = expFactor;
-        double beta  = gamma / dT_tau * ( 1.0 - expFactor );
+      double alpha = expFactor;
+      double beta  = gamma / dT_tau * ( 1.0 - expFactor );
 
-        if ( dT_tau < 1e-6 ) {
-          // use taylor expansion for small dt/tau
-          alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
-          beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
-        }
-
-        // compute new stress in maxwell element
-        const Tensor33t< T > Q_np = makeOtherScalarType< T >( evaluate( alpha * Q_n ) ) +
-                                    multiplyFastorTensorWithScalar( dStress, T( beta ) );
-
-        // add contribution to stress
-        stress += Q_np;
-
-        const Tensor33d Q_np_real = makeReal( Q_np );
-
-        // update state variables
-        memcpy( stateVars + i * 9, Q_np_real.data(), 9 * sizeof( double ) );
+      if ( dT_tau < 1e-6 ) {
+        // use taylor expansion for small dt/tau
+        alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
+        beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
       }
+
+      // compute new stress in maxwell element
+      const Tensor33t< T > Q_np = makeOtherScalarType< T >( evaluate( alpha * Q_n ) ) +
+                                  multiplyFastorTensorWithScalar( dStress, T( beta ) );
+
+      // add contribution to stress
+      stress += Q_np;
+
+      const Tensor33d Q_np_real = makeReal( Q_np );
+
+      // update state variables
+      memcpy( stateVars + i * 9, Q_np_real.data(), 9 * sizeof( double ) );
     }
+  }
 
-    /**
-     * @brief Evaluate generalized maxwell model contribution to stress without tangent update
-     * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
-     * tangent)
-     * @param[in]  tangent               Tangent tensor to be used for stress update
-     * @param[in]  initialCompliance     Initial compliance tensor
-     * @param[in]  dStress               Increment of the initial stress tensor
-     * @param[in]  dT                    Time increment
-     * @param[in]  maxwellProperties     Properties of the generalized maxwell model
-     * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
-     *
-     * @details This update function uses the approach in:
-     * Liu et al. 2021, A continuum and computational framework for viscoelastodynamics: I. Finite deformation linear
-     * models, Comput. Meth. Appl. Mech. Engrg. 385, 114059
-     */
+  /**
+   * @brief Evaluate generalized maxwell model contribution to stress without tangent update
+   * @param[in,out] stress             Stress tensor to be updated (input is the instantaneous hyperelastic stress)
+   * tangent)
+   * @param[in]  tangent               Tangent tensor to be used for stress update
+   * @param[in]  initialCompliance     Initial compliance tensor
+   * @param[in]  dStress               Increment of the initial stress tensor
+   * @param[in]  dT                    Time increment
+   * @param[in]  maxwellProperties     Properties of the generalized maxwell model
+   * @param[in,out] stateVars          State variables array (size: nMaxwell * 9)
+   *
+   * @details This update function uses the approach in:
+   * Liu et al. 2021, A continuum and computational framework for viscoelastodynamics: I. Finite deformation linear
+   * models, Comput. Meth. Appl. Mech. Engrg. 385, 114059
+   */
 
-    template < typename T = double >
-    void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33t< T >&         stress,
-                                          const FastorStandardTensors::Tensor3333t< T >& tangent,
-                                          const FastorStandardTensors::Tensor3333t< T >& initialCompliance,
-                                          const FastorStandardTensors::Tensor33t< T >&   dStress,
-                                          const double                                   dT,
-                                          const MaxwellProperties&                       maxwellProperties,
-                                          double*                                        stateVars )
-    {
+  template < typename T = double >
+  void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33t< T >&         stress,
+                                        const FastorStandardTensors::Tensor3333t< T >& tangent,
+                                        const FastorStandardTensors::Tensor3333t< T >& initialCompliance,
+                                        const FastorStandardTensors::Tensor33t< T >&   dStress,
+                                        const double                                   dT,
+                                        const MaxwellProperties&                       maxwellProperties,
+                                        double*                                        stateVars )
+  {
 
-      if ( maxwellProperties.nMaxwell == 0 )
-        return;
+    if ( maxwellProperties.nMaxwell == 0 )
+      return;
 
-      using namespace Fastor;
-      using namespace Marmot::FastorStandardTensors;
-      using namespace Marmot::FastorIndices;
+    using namespace Fastor;
+    using namespace Marmot::FastorStandardTensors;
+    using namespace Marmot::FastorIndices;
 
-      // scale equilibrium stress contribution
-      stress = stress * ( 1.0 - maxwellProperties.sumGamma );
+    // scale equilibrium stress contribution
+    stress = stress * ( 1.0 - maxwellProperties.sumGamma );
 
-      for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
-        // get old  maxewell element stress from state variables
-        const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
+    for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
+      // get old  maxewell element stress from state variables
+      const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
 
-        // get parameters of maxwell element
-        const double& tau   = maxwellProperties.tau[i];
-        const double& gamma = maxwellProperties.gamma[i];
+      // get parameters of maxwell element
+      const double& tau   = maxwellProperties.tau[i];
+      const double& gamma = maxwellProperties.gamma[i];
 
-        const double dT_tau    = std::max( dT / tau, 1e-15 );
-        const double expFactor = Math::exp( -dT_tau );
+      const double dT_tau    = std::max( dT / tau, 1e-15 );
+      const double expFactor = Math::exp( -dT_tau );
 
-        double alpha = expFactor;
-        double beta  = gamma / dT_tau * ( 1.0 - expFactor );
+      double alpha = expFactor;
+      double beta  = gamma / dT_tau * ( 1.0 - expFactor );
 
-        if ( dT_tau < 1e-6 ) {
-          // use taylor expansion for small dt/tau
-          alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
-          beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
-        }
-
-        // compute new stress in maxwell element
-        const Tensor33t< T > Q_np = alpha * makeOtherScalarType< T >( Q_n ) + beta * dStress;
-
-        // add contribution to stress
-        const Tensor33t< T > H_np = einsum< ijkl, kl >( initialCompliance, Q_np );
-        stress += einsum< ij, ijkl >( H_np, tangent );
-
-        // update state variables
-        Tensor33d Q_np_real = makeReal( Q_np );
-        memcpy( stateVars + i * 9, Q_np_real.data(), 9 * sizeof( double ) );
+      if ( dT_tau < 1e-6 ) {
+        // use taylor expansion for small dt/tau
+        alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
+        beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
       }
-    }
 
-  } // namespace ContinuumMechanics::FiniteStrain::Viscoelasticity
-} // namespace Marmot
+      // compute new stress in maxwell element
+      const Tensor33t< T > Q_np = alpha * makeOtherScalarType< T >( Q_n ) + beta * dStress;
+
+      // add contribution to stress
+      const Tensor33t< T > H_np = einsum< ijkl, kl >( initialCompliance, Q_np );
+      stress += einsum< ij, ijkl >( H_np, tangent );
+
+      // update state variables
+      Tensor33d Q_np_real = makeReal( Q_np );
+      memcpy( stateVars + i * 9, Q_np_real.data(), 9 * sizeof( double ) );
+    }
+  }
+
+} // namespace Marmot::ContinuumMechanics::FiniteStrain::Viscoelasticity

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrain.h
@@ -29,353 +29,364 @@
 #include <cmath>
 #include <vector>
 
-/**
- * @class MarmotMaterialFiniteStrain
- * @brief Abstract base class for mechanical materials in the finite strain regime.
- *
- * Derived classes implement computeStress() to provide the constitutive response
- * (Kirchhoff stress, density, elastic energy density) and the algorithmic tangent.
- */
-class MarmotMaterialFiniteStrain {
-
-protected:
-  const double* materialProperties;  ///< Pointer to the array of material property values.
-  const int     nMaterialProperties; ///< Number of material property values.
-
-public:
-  const int materialNumber; ///< Unique identifier for this material instance.
+namespace Marmot {
 
   /**
-   * @brief Construct a MarmotMaterialFiniteStrain.
-   * @param[in] matProperties_       Pointer to the array of material property values.
-   * @param[in] nMaterialProperties_ Number of material property values.
-   * @param[in] materialNumber_      Unique identifier for this material instance.
-   */
-  MarmotMaterialFiniteStrain( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
-    : materialProperties( matProperties_ ),
-      nMaterialProperties( nMaterialProperties_ ),
-      materialNumber( materialNumber_ )
-  {
-  }
-
-  /// Default destructor
-  virtual ~MarmotMaterialFiniteStrain() = default;
-
-  /// Layout of the state variables
-  MarmotStateLayoutDynamic stateLayout;
-
-  /**
-   * @struct ConstitutiveResponse
-   * @brief Constitutive response of a material at given state.
-   * @tparam nDim Number of spatial dimensions (2 or 3).
+   * @class MarmotMaterialFiniteStrain
+   * @brief Abstract base class for mechanical materials in the finite strain regime.
    *
-   *  Contains stress, density and elastic energy density.
+   * Derived classes implement computeStress() to provide the constitutive response
+   * (Kirchhoff stress, density, elastic energy density) and the algorithmic tangent.
    */
-  template < int nDim >
-  struct ConstitutiveResponse {
-    Fastor::Tensor< double, nDim, nDim > tau;                  ///< Kirchhoff stress
-    double                               elasticEnergyDensity; ///< elastic energy per unit volume
-    double                               dissipation;          ///< dissipation per unit volume
-    double*                              stateVars;            ///< pointer to state variables
+  class MarmotMaterialFiniteStrain {
+
+  protected:
+    const double* materialProperties;  ///< Pointer to the array of material property values.
+    const int     nMaterialProperties; ///< Number of material property values.
+
+  public:
+    const int materialNumber; ///< Unique identifier for this material instance.
 
     /**
-     * @brief Default constructor.
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+     * @brief Construct a MarmotMaterialFiniteStrain.
+     * @param[in] matProperties_       Pointer to the array of material property values.
+     * @param[in] nMaterialProperties_ Number of material property values.
+     * @param[in] materialNumber_      Unique identifier for this material instance.
      */
-    ConstitutiveResponse()
-      : tau( Fastor::Tensor< double, nDim, nDim >( 0.0 ) ),
-        elasticEnergyDensity( 0.0 ),
-        dissipation( 0.0 ),
-        stateVars( nullptr )
+    MarmotMaterialFiniteStrain( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : materialProperties( matProperties_ ),
+        nMaterialProperties( nMaterialProperties_ ),
+        materialNumber( materialNumber_ )
     {
     }
+
+    /// Default destructor
+    virtual ~MarmotMaterialFiniteStrain() = default;
+
+    /// Layout of the state variables
+    MarmotStateLayoutDynamic stateLayout;
+
     /**
-     * @brief Constructor for initializing the constitutive response.
-     * @param tau_ Kirchhoff stress tensor.
-     * @param elasticEnergyDensity_ Elastic energy density.
-     * @param dissipation_ Dissipation per unit volume.
-     * @param stateVars_ Pointer to state variables.
+     * @struct ConstitutiveResponse
+     * @brief Constitutive response of a material at given state.
+     * @tparam nDim Number of spatial dimensions (2 or 3).
+     *
+     *  Contains stress, density and elastic energy density.
      */
-    ConstitutiveResponse( const Fastor::Tensor< double, nDim, nDim >& tau_,
-                          double                                      elasticEnergyDensity_,
-                          double                                      dissipation_,
-                          double*                                     stateVars_ )
-      : tau( tau_ ), elasticEnergyDensity( elasticEnergyDensity_ ), dissipation( dissipation_ ), stateVars( stateVars_ )
+    template < int nDim >
+    struct ConstitutiveResponse {
+      Fastor::Tensor< double, nDim, nDim > tau;                  ///< Kirchhoff stress
+      double                               elasticEnergyDensity; ///< elastic energy per unit volume
+      double                               dissipation;          ///< dissipation per unit volume
+      double*                              stateVars;            ///< pointer to state variables
+
+      /**
+       * @brief Default constructor.
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      ConstitutiveResponse()
+        : tau( Fastor::Tensor< double, nDim, nDim >( 0.0 ) ),
+          elasticEnergyDensity( 0.0 ),
+          dissipation( 0.0 ),
+          stateVars( nullptr )
+      {
+      }
+      /**
+       * @brief Constructor for initializing the constitutive response.
+       * @param tau_ Kirchhoff stress tensor.
+       * @param elasticEnergyDensity_ Elastic energy density.
+       * @param dissipation_ Dissipation per unit volume.
+       * @param stateVars_ Pointer to state variables.
+       */
+      ConstitutiveResponse( const Fastor::Tensor< double, nDim, nDim >& tau_,
+                            double                                      elasticEnergyDensity_,
+                            double                                      dissipation_,
+                            double*                                     stateVars_ )
+        : tau( tau_ ),
+          elasticEnergyDensity( elasticEnergyDensity_ ),
+          dissipation( dissipation_ ),
+          stateVars( stateVars_ )
+      {
+      }
+    };
+
+    /**
+     * @struct AlgorithmicModuli
+     * @brief Algorithmic tangent moduli of a material.
+     * @tparam nDim Number of spatial dimensions (2 or 3).
+     *
+     * Contains the algorithmic tangent moduli \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$
+     * with respect to the deformation gradient \f$\boldsymbol{F}\f$.
+     * */
+    template < int nDim >
+    struct AlgorithmicModuli {
+      Fastor::Tensor< double, nDim, nDim, nDim, nDim > dTau_dF; ///< tangent operator w.r.t. deformation gradient
+    };
+
+    /**
+     * @struct Deformation
+     * @brief Represents the deformation state of a material.
+     *
+     * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
+     * material.
+     */
+    template < int nDim >
+    struct Deformation {
+      Fastor::Tensor< double, nDim, nDim > F; ///< deformation gradient
+    };
+
+    /**
+     * @struct TimeIncrement
+     * @brief Represents a time increment in a simulation.
+     *
+     * This struct holds information about the current time
+     * and the time step size (dT).
+     */
+    struct TimeIncrement {
+      const double time; ///< time at the beginning of the increment
+      const double dT;   ///< size of the time increment
+    };
+
+    /**
+     * @brief Updates the material state.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] tangents AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * Computes the Kirchhoff \f$\boldsymbol{\tau}\f$ stress
+     * from the deformation gradient \f$\boldsymbol{F}\f$ and the
+     * time increment \f$\Delta t\f$.
+     * It further updates the mass density \f$\rho\f$ and the elastic energy density.
+     * Additionally, computes the algorithmic tangent moduli
+     * \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$.
+     *
+     * */
+    virtual void computeStress( ConstitutiveResponse< 3 >& response,
+                                AlgorithmicModuli< 3 >&    tangents,
+                                const Deformation< 3 >&    deformation,
+                                const TimeIncrement&       timeIncrement ) const = 0;
+
+    /**
+     * @brief Explicit version of computeStress for use in explicit time integration schemes.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * @note The default implementation calls computeStress and ignores the algorithmic tangent.
+     * @note Derived classes may override this method for efficiency reasons.
+     */
+    virtual void computeStressExplicit( ConstitutiveResponse< 3 >& response,
+                                        const Deformation< 3 >&    deformation,
+                                        const TimeIncrement&       timeIncrement ) const
     {
+      AlgorithmicModuli< 3 > tangents;
+      computeStress( response, tangents, deformation, timeIncrement );
     }
-  };
 
-  /**
-   * @struct AlgorithmicModuli
-   * @brief Algorithmic tangent moduli of a material.
-   * @tparam nDim Number of spatial dimensions (2 or 3).
-   *
-   * Contains the algorithmic tangent moduli \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$
-   * with respect to the deformation gradient \f$\boldsymbol{F}\f$.
-   * */
-  template < int nDim >
-  struct AlgorithmicModuli {
-    Fastor::Tensor< double, nDim, nDim, nDim, nDim > dTau_dF; ///< tangent operator w.r.t. deformation gradient
-  };
+    /**
+     * @brief Computes the Kirchhoff stress given the deformation, time increment, and eigen deformation.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] tangents AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
+     *
+     */
+    virtual void computeStress( ConstitutiveResponse< 3 >&                  response,
+                                AlgorithmicModuli< 3 >&                     tangents,
+                                const Deformation< 3 >&                     deformation,
+                                const TimeIncrement&                        timeIncrement,
+                                const std::tuple< double, double, double >& eigenDeformation ) const;
 
-  /**
-   * @struct Deformation
-   * @brief Represents the deformation state of a material.
-   *
-   * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
-   * material.
-   */
-  template < int nDim >
-  struct Deformation {
-    Fastor::Tensor< double, nDim, nDim > F; ///< deformation gradient
-  };
+    /**
+     * @brief Compute stress under plane strain conditions.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] algorithmicModuli AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * It uses the general 3D computeStress function for a plane strain Deformation.
+     * The algorithmic tangent is modified according to plane strain conditions.
+     */
+    virtual void computePlaneStrain( ConstitutiveResponse< 3 >& response,
+                                     AlgorithmicModuli< 3 >&    algorithmicModuli,
+                                     const Deformation< 3 >&    deformation,
+                                     const TimeIncrement&       timeIncrement ) const;
 
-  /**
-   * @struct TimeIncrement
-   * @brief Represents a time increment in a simulation.
-   *
-   * This struct holds information about the current time
-   * and the time step size (dT).
-   */
-  struct TimeIncrement {
-    const double time; ///< time at the beginning of the increment
-    const double dT;   ///< size of the time increment
-  };
-
-  /**
-   * @brief Updates the material state.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] tangents AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * Computes the Kirchhoff \f$\boldsymbol{\tau}\f$ stress
-   * from the deformation gradient \f$\boldsymbol{F}\f$ and the
-   * time increment \f$\Delta t\f$.
-   * It further updates the mass density \f$\rho\f$ and the elastic energy density.
-   * Additionally, computes the algorithmic tangent moduli
-   * \f$\frac{\partial \boldsymbol{\tau}}{\partial \boldsymbol{F}}\f$.
-   *
-   * */
-  virtual void computeStress( ConstitutiveResponse< 3 >& response,
-                              AlgorithmicModuli< 3 >&    tangents,
-                              const Deformation< 3 >&    deformation,
-                              const TimeIncrement&       timeIncrement ) const = 0;
-
-  /**
-   * @brief Explicit version of computeStress for use in explicit time integration schemes.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * @note The default implementation calls computeStress and ignores the algorithmic tangent.
-   * @note Derived classes may override this method for efficiency reasons.
-   */
-  virtual void computeStressExplicit( ConstitutiveResponse< 3 >& response,
-                                      const Deformation< 3 >&    deformation,
-                                      const TimeIncrement&       timeIncrement ) const
-  {
-    AlgorithmicModuli< 3 > tangents;
-    computeStress( response, tangents, deformation, timeIncrement );
-  }
-
-  /**
-   * @brief Computes the Kirchhoff stress given the deformation, time increment, and eigen deformation.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] tangents AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
-   *
-   */
-  virtual void computeStress( ConstitutiveResponse< 3 >&                  response,
-                              AlgorithmicModuli< 3 >&                     tangents,
-                              const Deformation< 3 >&                     deformation,
-                              const TimeIncrement&                        timeIncrement,
-                              const std::tuple< double, double, double >& eigenDeformation ) const;
-
-  /**
-   * @brief Compute stress under plane strain conditions.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] algorithmicModuli AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * It uses the general 3D computeStress function for a plane strain Deformation.
-   * The algorithmic tangent is modified according to plane strain conditions.
-   */
-  virtual void computePlaneStrain( ConstitutiveResponse< 3 >& response,
-                                   AlgorithmicModuli< 3 >&    algorithmicModuli,
-                                   const Deformation< 3 >&    deformation,
-                                   const TimeIncrement&       timeIncrement ) const;
-
-  /**
-   * @brief Explicit version of computePlaneStrain for use in explicit time integration schemes.
-   * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
-   */
-  virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >& response,
-                                           const Deformation< 3 >&    deformation,
-                                           const TimeIncrement&       timeIncrement ) const
-  {
-    AlgorithmicModuli< 3 > algorithmicModuli;
-    computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement );
-  }
-
-  /**
-   * @brief Compute stress under plane strain conditions with eigen deformation.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] algorithmicModuli AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
-   *
-   * It uses the general 3D computeStress function for a plane strain Deformation.
-   * The algorithmic tangent is modified according to plane strain conditions.
-   */
-  virtual void computePlaneStrain( ConstitutiveResponse< 3 >&                  response,
-                                   AlgorithmicModuli< 3 >&                     algorithmicModuli,
-                                   const Deformation< 3 >&                     deformation,
-                                   const TimeIncrement&                        timeIncrement,
-                                   const std::tuple< double, double, double >& eigenDeformation ) const;
-
-  /**
-   * @brief Explicit version of computePlaneStrain with eigen deformation for use in explicit time integration schemes.
-   * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
-   */
-  virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >&                  response,
-                                           const Deformation< 3 >&                     deformation,
-                                           const TimeIncrement&                        timeIncrement,
-                                           const std::tuple< double, double, double >& eigenDeformation ) const
-  {
-    AlgorithmicModuli< 3 > algorithmicModuli;
-    computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
-  }
-
-  /**
-   * @brief Compute stress under plane stress conditions.
-   * @param[inout] response ConstitutiveResponse instance
-   * @param[out] algorithmicModuli AlgorithmicModuli instance
-   * @param[in] deformation Deformation instance
-   * @param[in] timeIncrement TimeIncrement instance
-   *
-   * It uses the general 3D computeStress function and iteratively finds the out-of-plane deformation.
-   * The algorithmic tangent is modified according to plane stress conditions.
-   */
-  virtual void computePlaneStress( ConstitutiveResponse< 2 >& response,
-                                   AlgorithmicModuli< 2 >&    algorithmicModuli,
-                                   const Deformation< 2 >&    deformation,
-                                   const TimeIncrement&       timeIncrement ) const;
-
-  /**
-   * @brief Explicit version of computePlaneStress for use in explicit time integration schemes.
-   * @note The default implementation calls computePlaneStress and ignores the algorithmic tangent.
-   */
-  virtual void computePlaneStressExplicit( ConstitutiveResponse< 2 >& response,
-                                           const Deformation< 2 >&    deformation,
-                                           const TimeIncrement&       timeIncrement ) const
-  {
-    AlgorithmicModuli< 2 > algorithmicModuli;
-    computePlaneStress( response, algorithmicModuli, deformation, timeIncrement );
-  }
-
-  /**
-   * @brief Find the eigen deformation that corresponds to a given eigen stress.
-   * @param initialGuess Initial guess for the eigen deformation.
-   * @param eigenStress Target eigen stress.
-   * @param stateVars Pointer to the state variable array used during iteration.
-   * @return Eigen deformation that corresponds to the given eigen stress.
-   *
-   * This function iteratively finds the eigen deformation that corresponds to a given eigen stress.
-   * This is used e.g. for geostatic stress initialization.
-   */
-  std::tuple< double, double, double > findEigenDeformationForEigenStress(
-    const std::tuple< double, double, double >& initialGuess,
-    const std::tuple< double, double, double >& eigenStress,
-    double*                                     stateVars ) const;
-
-  /**
-   * @brief Get a view to the state variables.
-   * @param stateName Name of the state variable
-   * @param stateVars Pointer to the state variable array
-   * @return StatView to access the state variable
-   */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
-  {
-    return stateLayout.getStateView( stateVars, stateName );
-  }
-
-  /**
-   * @brief Get the total number of required state variables.
-   * @return Total number of required state variables
-   */
-  int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
-  /**
-   * @brief Initialize the state variables at a material point.
-   * @param stateVars Pointer to the state variable array
-   * @param nStateVars Number of state variables
-   *
-   * @note The default implementation initializes all state variables to zero.
-   */
-  virtual void initializeYourself( double* stateVars, int nStateVars )
-  {
-    for ( int i = 0; i < nStateVars; ++i ) {
-      stateVars[i] = 0.0;
+    /**
+     * @brief Explicit version of computePlaneStrain for use in explicit time integration schemes.
+     * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
+     */
+    virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >& response,
+                                             const Deformation< 3 >&    deformation,
+                                             const TimeIncrement&       timeIncrement ) const
+    {
+      AlgorithmicModuli< 3 > algorithmicModuli;
+      computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement );
     }
-  }
 
-  /**
-   * @brief Get the maximum wave speed of the material for a given deformation gradient.
-   * @param[in] stateVars Pointer to the state variable array
-   * @param[in] deformationGradient Current deformation gradient used as perturbation reference
-   * @return Maximum wave speed
-   * @details The default implementation computes diagonal Voigt tangent entries by centered
-   * finite differences and returns `sqrt(max(C_ii) / rho)`.
-   */
-  virtual double getMaximumWaveSpeed( const double*                         stateVars,
-                                      const Fastor::Tensor< double, 3, 3 >& deformationGradient ) const
-  {
-    constexpr double dEps = 1e-6;
+    /**
+     * @brief Compute stress under plane strain conditions with eigen deformation.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] algorithmicModuli AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     * @param[in] eigenDeformation Tuple representing eigen deformation in each spatial direction.
+     *
+     * It uses the general 3D computeStress function for a plane strain Deformation.
+     * The algorithmic tangent is modified according to plane strain conditions.
+     */
+    virtual void computePlaneStrain( ConstitutiveResponse< 3 >&                  response,
+                                     AlgorithmicModuli< 3 >&                     algorithmicModuli,
+                                     const Deformation< 3 >&                     deformation,
+                                     const TimeIncrement&                        timeIncrement,
+                                     const std::tuple< double, double, double >& eigenDeformation ) const;
 
-    const int nStateVars = getNumberOfRequiredStateVars();
+    /**
+     * @brief Explicit version of computePlaneStrain with eigen deformation for use in explicit time integration
+     * schemes.
+     * @note The default implementation calls computePlaneStrain and ignores the algorithmic tangent.
+     */
+    virtual void computePlaneStrainExplicit( ConstitutiveResponse< 3 >&                  response,
+                                             const Deformation< 3 >&                     deformation,
+                                             const TimeIncrement&                        timeIncrement,
+                                             const std::tuple< double, double, double >& eigenDeformation ) const
+    {
+      AlgorithmicModuli< 3 > algorithmicModuli;
+      computePlaneStrain( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
+    }
 
-    double     maxStiffnessDiagonal = 0.0;
-    const auto timeIncrement        = TimeIncrement{ 0.0, 1.0 };
+    /**
+     * @brief Compute stress under plane stress conditions.
+     * @param[inout] response ConstitutiveResponse instance
+     * @param[out] algorithmicModuli AlgorithmicModuli instance
+     * @param[in] deformation Deformation instance
+     * @param[in] timeIncrement TimeIncrement instance
+     *
+     * It uses the general 3D computeStress function and iteratively finds the out-of-plane deformation.
+     * The algorithmic tangent is modified according to plane stress conditions.
+     */
+    virtual void computePlaneStress( ConstitutiveResponse< 2 >& response,
+                                     AlgorithmicModuli< 2 >&    algorithmicModuli,
+                                     const Deformation< 2 >&    deformation,
+                                     const TimeIncrement&       timeIncrement ) const;
 
-    for ( int i = 0; i < 3; ++i ) {
-      std::vector< double > stateVarsPlus( nStateVars, 0.0 );
-      std::vector< double > stateVarsMinus( nStateVars, 0.0 );
-      if ( stateVars != nullptr && nStateVars > 0 ) {
-        std::copy_n( stateVars, nStateVars, stateVarsPlus.begin() );
-        std::copy_n( stateVars, nStateVars, stateVarsMinus.begin() );
+    /**
+     * @brief Explicit version of computePlaneStress for use in explicit time integration schemes.
+     * @note The default implementation calls computePlaneStress and ignores the algorithmic tangent.
+     */
+    virtual void computePlaneStressExplicit( ConstitutiveResponse< 2 >& response,
+                                             const Deformation< 2 >&    deformation,
+                                             const TimeIncrement&       timeIncrement ) const
+    {
+      AlgorithmicModuli< 2 > algorithmicModuli;
+      computePlaneStress( response, algorithmicModuli, deformation, timeIncrement );
+    }
+
+    /**
+     * @brief Find the eigen deformation that corresponds to a given eigen stress.
+     * @param initialGuess Initial guess for the eigen deformation.
+     * @param eigenStress Target eigen stress.
+     * @param stateVars Pointer to the state variable array used during iteration.
+     * @return Eigen deformation that corresponds to the given eigen stress.
+     *
+     * This function iteratively finds the eigen deformation that corresponds to a given eigen stress.
+     * This is used e.g. for geostatic stress initialization.
+     */
+    std::tuple< double, double, double > findEigenDeformationForEigenStress(
+      const std::tuple< double, double, double >& initialGuess,
+      const std::tuple< double, double, double >& eigenStress,
+      double*                                     stateVars ) const;
+
+    /**
+     * @brief Get a view to the state variables.
+     * @param stateName Name of the state variable
+     * @param stateVars Pointer to the state variable array
+     * @return StatView to access the state variable
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const
+    {
+      return stateLayout.getStateView( stateVars, stateName );
+    }
+
+    /**
+     * @brief Get the total number of required state variables.
+     * @return Total number of required state variables
+     */
+    int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
+    /**
+     * @brief Initialize the state variables at a material point.
+     * @param stateVars Pointer to the state variable array
+     * @param nStateVars Number of state variables
+     *
+     * @note The default implementation initializes all state variables to zero.
+     */
+    virtual void initializeYourself( double* stateVars, int nStateVars )
+    {
+      for ( int i = 0; i < nStateVars; ++i ) {
+        stateVars[i] = 0.0;
+      }
+    }
+
+    /**
+     * @brief Get the maximum wave speed of the material for a given deformation gradient.
+     * @param[in] stateVars Pointer to the state variable array
+     * @param[in] deformationGradient Current deformation gradient used as perturbation reference
+     * @return Maximum wave speed
+     * @details The default implementation computes diagonal Voigt tangent entries by centered
+     * finite differences and returns `sqrt(max(C_ii) / rho)`.
+     */
+    virtual double getMaximumWaveSpeed( const double*                         stateVars,
+                                        const Fastor::Tensor< double, 3, 3 >& deformationGradient ) const
+    {
+      constexpr double dEps = 1e-6;
+
+      const int nStateVars = getNumberOfRequiredStateVars();
+
+      double     maxStiffnessDiagonal = 0.0;
+      const auto timeIncrement        = TimeIncrement{ 0.0, 1.0 };
+
+      for ( int i = 0; i < 3; ++i ) {
+        std::vector< double > stateVarsPlus( nStateVars, 0.0 );
+        std::vector< double > stateVarsMinus( nStateVars, 0.0 );
+        if ( stateVars != nullptr && nStateVars > 0 ) {
+          std::copy_n( stateVars, nStateVars, stateVarsPlus.begin() );
+          std::copy_n( stateVars, nStateVars, stateVarsMinus.begin() );
+        }
+
+        auto FPlus  = deformationGradient;
+        auto FMinus = deformationGradient;
+        FPlus( i, i ) *= ( 1.0 + dEps );
+        FMinus( i, i ) *= ( 1.0 - dEps );
+
+        Deformation< 3 > deformationPlus{ FPlus };
+        Deformation< 3 > deformationMinus{ FMinus };
+
+        ConstitutiveResponse< 3 > responsePlus{ Fastor::Tensor< double, 3, 3 >( 0.0 ), 0.0, 0.0, stateVarsPlus.data() };
+        ConstitutiveResponse< 3 > responseMinus{ Fastor::Tensor< double, 3, 3 >( 0.0 ),
+                                                 0.0,
+                                                 0.0,
+                                                 stateVarsMinus.data() };
+
+        computeStressExplicit( responsePlus, deformationPlus, timeIncrement );
+        computeStressExplicit( responseMinus, deformationMinus, timeIncrement );
+
+        const double dLogStrain = std::log( 1.0 + dEps ) - std::log( 1.0 - dEps );
+        const double Cii        = ( responsePlus.tau( i, i ) - responseMinus.tau( i, i ) ) / dLogStrain;
+        maxStiffnessDiagonal    = std::max( maxStiffnessDiagonal, Cii );
       }
 
-      auto FPlus  = deformationGradient;
-      auto FMinus = deformationGradient;
-      FPlus( i, i ) *= ( 1.0 + dEps );
-      FMinus( i, i ) *= ( 1.0 - dEps );
-
-      Deformation< 3 > deformationPlus{ FPlus };
-      Deformation< 3 > deformationMinus{ FMinus };
-
-      ConstitutiveResponse< 3 > responsePlus{ Fastor::Tensor< double, 3, 3 >( 0.0 ), 0.0, 0.0, stateVarsPlus.data() };
-      ConstitutiveResponse< 3 > responseMinus{ Fastor::Tensor< double, 3, 3 >( 0.0 ), 0.0, 0.0, stateVarsMinus.data() };
-
-      computeStressExplicit( responsePlus, deformationPlus, timeIncrement );
-      computeStressExplicit( responseMinus, deformationMinus, timeIncrement );
-
-      const double dLogStrain = std::log( 1.0 + dEps ) - std::log( 1.0 - dEps );
-      const double Cii        = ( responsePlus.tau( i, i ) - responseMinus.tau( i, i ) ) / dLogStrain;
-      maxStiffnessDiagonal    = std::max( maxStiffnessDiagonal, Cii );
+      const double density = getDensity( stateVars );
+      return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
     }
 
-    const double density = getDensity( stateVars );
-    return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
-  }
+    /**
+     * @brief Get the mass density of the material.
+     * @param[in] stateVars Pointer to the state variable array
+     * @return Mass density
+     */
+    virtual double getDensity( const double* stateVars ) const = 0;
+  };
 
-  /**
-   * @brief Get the mass density of the material.
-   * @param[in] stateVars Pointer to the state variable array
-   * @return Mass density
-   */
-  virtual double getDensity( const double* stateVars ) const = 0;
-};
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainAD.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainAD.h
@@ -29,164 +29,169 @@
 #include <Eigen/Core>
 #include <functional>
 
-/**
- * @brief Base class for finite strain materials using automatic differentiation.
- *
- * This class extends MarmotMaterialFiniteStrain by providing an interface for
- * computing stresses and algorithmic tangent moduli using automatic
- * differentiation. Derived material models implement computeStressAD() to
- * supply the AD-based constitutive response.
- */
-class MarmotMaterialFiniteStrainAD : public MarmotMaterialFiniteStrain {
+namespace Marmot {
 
-public:
   /**
-   * @brief Construct a MarmotMaterialFiniteStrainAD.
-   * @param[in] matProperties_       Pointer to the array of material property values.
-   * @param[in] nMaterialProperties_ Number of material property values.
-   * @param[in] materialNumber_      Unique identifier for this material instance.
-   */
-  MarmotMaterialFiniteStrainAD( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
-    : MarmotMaterialFiniteStrain( matProperties_, nMaterialProperties_, materialNumber_ )
-  {
-  }
-  /**
-   * @struct ConstitutiveResponseAD
-   * @brief Constitutive response of a material at given state.
-   * @tparam nDim Number of spatial dimensions (2 or 3).
+   * @brief Base class for finite strain materials using automatic differentiation.
    *
-   *  Contains stress, density and elastic energy density.
+   * This class extends MarmotMaterialFiniteStrain by providing an interface for
+   * computing stresses and algorithmic tangent moduli using automatic
+   * differentiation. Derived material models implement computeStressAD() to
+   * supply the AD-based constitutive response.
    */
-  template < int nDim >
-  struct ConstitutiveResponseAD {
-    Fastor::Tensor< autodiff::dual, nDim, nDim > tau;                  ///< Kirchhoff stress
-    double                                       elasticEnergyDensity; ///< elastic energy per unit volume
-    double                                       dissipation; ///< dissipation per unit volume (for inelastic materials)
-    double*                                      stateVars;   ///< pointer to state variables
+  class MarmotMaterialFiniteStrainAD : public MarmotMaterialFiniteStrain {
+
+  public:
+    /**
+     * @brief Construct a MarmotMaterialFiniteStrainAD.
+     * @param[in] matProperties_       Pointer to the array of material property values.
+     * @param[in] nMaterialProperties_ Number of material property values.
+     * @param[in] materialNumber_      Unique identifier for this material instance.
+     */
+    MarmotMaterialFiniteStrainAD( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : MarmotMaterialFiniteStrain( matProperties_, nMaterialProperties_, materialNumber_ )
+    {
+    }
+    /**
+     * @struct ConstitutiveResponseAD
+     * @brief Constitutive response of a material at given state.
+     * @tparam nDim Number of spatial dimensions (2 or 3).
+     *
+     *  Contains stress, density and elastic energy density.
+     */
+    template < int nDim >
+    struct ConstitutiveResponseAD {
+      Fastor::Tensor< autodiff::dual, nDim, nDim > tau;                  ///< Kirchhoff stress
+      double                                       elasticEnergyDensity; ///< elastic energy per unit volume
+      double  dissipation; ///< dissipation per unit volume (for inelastic materials)
+      double* stateVars;   ///< pointer to state variables
+
+      /**
+       * @brief Default constructor.
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      ConstitutiveResponseAD()
+        : tau( Fastor::Tensor< autodiff::dual, nDim, nDim >( 0.0 ) ),
+          elasticEnergyDensity( 0.0 ),
+          dissipation( 0.0 ),
+          stateVars( nullptr )
+      {
+      }
+
+      /**
+       * @brief Constructor for initializing the AD constitutive response.
+       * @param response ConstitutiveResponse instance to initialize from.
+       */
+      ConstitutiveResponseAD( const ConstitutiveResponse< nDim >& response )
+        : tau( Marmot::makeDual( response.tau ) ),
+          elasticEnergyDensity( response.elasticEnergyDensity ),
+          dissipation( response.dissipation ),
+          stateVars( response.stateVars )
+      {
+      }
+    };
 
     /**
-     * @brief Default constructor.
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+     * @struct DeformationAD
+     * @brief Represents the deformation state of a material.
+     *
+     * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
+     * material.
      */
-    ConstitutiveResponseAD()
-      : tau( Fastor::Tensor< autodiff::dual, nDim, nDim >( 0.0 ) ),
-        elasticEnergyDensity( 0.0 ),
-        dissipation( 0.0 ),
-        stateVars( nullptr )
+    template < int nDim >
+    struct DeformationAD {
+      Fastor::Tensor< autodiff::dual, nDim, nDim > F; ///< deformation gradient
+    };
+
+    /**
+     * @brief Compute Kirchhoff stress and algorithmic tangent using automatic differentiation.
+     *
+     * This method overrides MarmotMaterialFiniteStrain::computeStress() and provides a generic
+     * AD-based implementation for finite strain material models.
+     *
+     * The child class must implement computeStressAD(), which evaluates the constitutive response
+     * (Kirchhoff stress and any state updates) for a dual-valued deformation gradient. This base
+     * implementation then uses Marmot::AutomaticDifferentiation::dF_dT() to:
+     *  - compute the Kirchhoff stress \f$\boldsymbol{\tau}\f$ for the given deformation, and
+     *  - compute the consistent algorithmic tangent \f$\partial \boldsymbol{\tau} / \partial \boldsymbol{F}\f$.
+     *
+     * @note Automatic differentiation requires multiple seeded evaluations of computeStressAD().
+     *       Therefore, the state variables are reset to their "old" values before each seeded call.
+     *       Implementations of computeStressAD() must update state based only on primal values of
+     *       the dual inputs and must not branch or accumulate history based on derivative components.
+     *
+     * @param[out] response     Constitutive response container (stress, density, energy, state variables).
+     * @param[out] tangents     Algorithmic moduli container; filled with \f$\partial \tau / \partial F\f$.
+     * @param[in]  deformation  Deformation state (deformation gradient \f$\boldsymbol{F}\f$).
+     * @param[in]  timeIncrement Time increment information for rate-/history-dependent models.
+     */
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&    deformation,
+                        const TimeIncrement&       timeIncrement ) const override
     {
+      using namespace Marmot;
+      using namespace FastorStandardTensors;
+      using scalar = autodiff::dual;
+
+      Eigen::Map< Eigen::VectorXd > stateVars( response.stateVars, this->getNumberOfRequiredStateVars() );
+
+      // Remember old state to reset during potential multiple AD evaluations
+      const Eigen::VectorXd stateVarsOld = stateVars;
+      const Tensor33d       tauOld       = response.tau;
+
+      ConstitutiveResponseAD< 3 > responseAD( response );
+
+      std::function< Tensor33t< scalar >( const Tensor33t< scalar >& ) > computeTauAD =
+        [&]( const Tensor33t< scalar >& F_ ) {
+          // Reset stateVars to old state
+          stateVars = stateVarsOld;
+
+          // Construct AD state
+          DeformationAD< 3 > deformationAD;
+          deformationAD.F = F_;
+
+          responseAD.tau                  = Marmot::makeDual( tauOld ); // Initialize tau with old value for consistency
+          responseAD.elasticEnergyDensity = response.elasticEnergyDensity; // Initialize energy density
+          responseAD.dissipation          = response.dissipation;          // Initialize dissipation
+
+          // Compute stress utilizing the child class's AD implementation
+          this->computeStressAD( responseAD, deformationAD, timeIncrement );
+
+          // Extract and return the dual stress tensor for differentiation
+          Tensor33t< scalar > res = responseAD.tau;
+
+          return res;
+        };
+
+      // Compute Kirchhoff stress (tau) and algorithmic tangent (dTau_dF) with autodiff
+      std::tie( response.tau, tangents.dTau_dF ) = Marmot::AutomaticDifferentiation::dF_dT( computeTauAD,
+                                                                                            deformation.F );
+      response.elasticEnergyDensity              = responseAD.elasticEnergyDensity;
+      response.dissipation                       = responseAD.dissipation;
     }
 
     /**
-     * @brief Constructor for initializing the AD constitutive response.
-     * @param response ConstitutiveResponse instance to initialize from.
+     * @brief Compute the constitutive response in automatic differentiation (AD) form.
+     *
+     * This pure virtual function must be implemented by derived material models to compute
+     * the Kirchhoff stress tensor in \p response.tau for a given deformation in dual number
+     * form. The base class uses this AD formulation together with
+     * Marmot::AutomaticDifferentiation utilities to obtain algorithmic tangents by
+     * differentiating the stress with respect to the deformation gradient.
+     *
+     * Implementations may update the provided state variables via \p response.stateVars
+     * according to the given time increment.
+     *
+     * @param[out] response    Constitutive response in AD form (3D), with \p response.tau
+     *                         to be filled with the computed Kirchhoff stress.
+     * @param[in]  deformation Deformation state in AD form (3D), providing the deformation
+     *                         gradient \f$\boldsymbol{F}\f$ as dual numbers.
+     * @param[in]  timeIncrement Current time increment information for the constitutive update.
      */
-    ConstitutiveResponseAD( const ConstitutiveResponse< nDim >& response )
-      : tau( Marmot::makeDual( response.tau ) ),
-        elasticEnergyDensity( response.elasticEnergyDensity ),
-        dissipation( response.dissipation ),
-        stateVars( response.stateVars )
-    {
-    }
+    virtual void computeStressAD( ConstitutiveResponseAD< 3 >& response,
+                                  const DeformationAD< 3 >&    deformation,
+                                  const TimeIncrement&         timeIncrement ) const = 0;
   };
 
-  /**
-   * @struct DeformationAD
-   * @brief Represents the deformation state of a material.
-   *
-   * This struct holds the deformation gradient \f$\boldsymbol{F}\f$ which describes the local deformation of a
-   * material.
-   */
-  template < int nDim >
-  struct DeformationAD {
-    Fastor::Tensor< autodiff::dual, nDim, nDim > F; ///< deformation gradient
-  };
-
-  /**
-   * @brief Compute Kirchhoff stress and algorithmic tangent using automatic differentiation.
-   *
-   * This method overrides MarmotMaterialFiniteStrain::computeStress() and provides a generic
-   * AD-based implementation for finite strain material models.
-   *
-   * The child class must implement computeStressAD(), which evaluates the constitutive response
-   * (Kirchhoff stress and any state updates) for a dual-valued deformation gradient. This base
-   * implementation then uses Marmot::AutomaticDifferentiation::dF_dT() to:
-   *  - compute the Kirchhoff stress \f$\boldsymbol{\tau}\f$ for the given deformation, and
-   *  - compute the consistent algorithmic tangent \f$\partial \boldsymbol{\tau} / \partial \boldsymbol{F}\f$.
-   *
-   * @note Automatic differentiation requires multiple seeded evaluations of computeStressAD().
-   *       Therefore, the state variables are reset to their "old" values before each seeded call.
-   *       Implementations of computeStressAD() must update state based only on primal values of
-   *       the dual inputs and must not branch or accumulate history based on derivative components.
-   *
-   * @param[out] response     Constitutive response container (stress, density, energy, state variables).
-   * @param[out] tangents     Algorithmic moduli container; filled with \f$\partial \tau / \partial F\f$.
-   * @param[in]  deformation  Deformation state (deformation gradient \f$\boldsymbol{F}\f$).
-   * @param[in]  timeIncrement Time increment information for rate-/history-dependent models.
-   */
-  void computeStress( ConstitutiveResponse< 3 >& response,
-                      AlgorithmicModuli< 3 >&    tangents,
-                      const Deformation< 3 >&    deformation,
-                      const TimeIncrement&       timeIncrement ) const override
-  {
-    using namespace Marmot;
-    using namespace FastorStandardTensors;
-    using scalar = autodiff::dual;
-
-    Eigen::Map< Eigen::VectorXd > stateVars( response.stateVars, this->getNumberOfRequiredStateVars() );
-
-    // Remember old state to reset during potential multiple AD evaluations
-    const Eigen::VectorXd stateVarsOld = stateVars;
-    const Tensor33d       tauOld       = response.tau;
-
-    ConstitutiveResponseAD< 3 > responseAD( response );
-
-    std::function< Tensor33t< scalar >( const Tensor33t< scalar >& ) > computeTauAD =
-      [&]( const Tensor33t< scalar >& F_ ) {
-        // Reset stateVars to old state
-        stateVars = stateVarsOld;
-
-        // Construct AD state
-        DeformationAD< 3 > deformationAD;
-        deformationAD.F = F_;
-
-        responseAD.tau                  = Marmot::makeDual( tauOld ); // Initialize tau with old value for consistency
-        responseAD.elasticEnergyDensity = response.elasticEnergyDensity; // Initialize energy density
-        responseAD.dissipation          = response.dissipation;          // Initialize dissipation
-
-        // Compute stress utilizing the child class's AD implementation
-        this->computeStressAD( responseAD, deformationAD, timeIncrement );
-
-        // Extract and return the dual stress tensor for differentiation
-        Tensor33t< scalar > res = responseAD.tau;
-
-        return res;
-      };
-
-    // Compute Kirchhoff stress (tau) and algorithmic tangent (dTau_dF) with autodiff
-    std::tie( response.tau, tangents.dTau_dF ) = Marmot::AutomaticDifferentiation::dF_dT( computeTauAD, deformation.F );
-    response.elasticEnergyDensity              = responseAD.elasticEnergyDensity;
-    response.dissipation                       = responseAD.dissipation;
-  }
-
-  /**
-   * @brief Compute the constitutive response in automatic differentiation (AD) form.
-   *
-   * This pure virtual function must be implemented by derived material models to compute
-   * the Kirchhoff stress tensor in \p response.tau for a given deformation in dual number
-   * form. The base class uses this AD formulation together with
-   * Marmot::AutomaticDifferentiation utilities to obtain algorithmic tangents by
-   * differentiating the stress with respect to the deformation gradient.
-   *
-   * Implementations may update the provided state variables via \p response.stateVars
-   * according to the given time increment.
-   *
-   * @param[out] response    Constitutive response in AD form (3D), with \p response.tau
-   *                         to be filled with the computed Kirchhoff stress.
-   * @param[in]  deformation Deformation state in AD form (3D), providing the deformation
-   *                         gradient \f$\boldsymbol{F}\f$ as dual numbers.
-   * @param[in]  timeIncrement Current time increment information for the constitutive update.
-   */
-  virtual void computeStressAD( ConstitutiveResponseAD< 3 >& response,
-                                const DeformationAD< 3 >&    deformation,
-                                const TimeIncrement&         timeIncrement ) const = 0;
-};
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainAD.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainAD.h
@@ -130,7 +130,6 @@ namespace Marmot {
                         const Deformation< 3 >&    deformation,
                         const TimeIncrement&       timeIncrement ) const override
     {
-      using namespace Marmot;
       using namespace FastorStandardTensors;
       using scalar = autodiff::dual;
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
@@ -43,7 +43,9 @@ namespace MarmotLibrary {
   public:
     /// Factory function type: creates a MarmotMaterialFiniteStrain from properties and a material number.
     using materialFactoryFunction = std::function<
-      MarmotMaterialFiniteStrain*( const double* materialProperties, int nMaterialProperties, int materialNumber ) >;
+      Marmot::MarmotMaterialFiniteStrain*( const double* materialProperties,
+                                           int           nMaterialProperties,
+                                           int           materialNumber ) >;
 
     MarmotMaterialFiniteStrainFactory() = delete;
 
@@ -55,10 +57,10 @@ namespace MarmotLibrary {
      * @param[in] materialNumber Unique identifier for the material instance.
      * @return Pointer to the created MarmotMaterialFiniteStrain instance.
      */
-    static MarmotMaterialFiniteStrain* createMaterial( const std::string& materialName,
-                                                       const double*      materialProperties,
-                                                       int                nMaterialProperties,
-                                                       int                materialNumber );
+    static Marmot::MarmotMaterialFiniteStrain* createMaterial( const std::string& materialName,
+                                                               const double*      materialProperties,
+                                                               int                nMaterialProperties,
+                                                               int                materialNumber );
 
     /**
      * @brief Register a material type with its name.
@@ -74,8 +76,11 @@ namespace MarmotLibrary {
 
       assert( map.find( materialName ) == map.end() && "Material already registered!" );
 
-      map[materialName] = []( const double* materialProperties, int nMaterialProperties, int materialNumber )
-        -> MarmotMaterialFiniteStrain* { return new T( materialProperties, nMaterialProperties, materialNumber ); };
+      map[materialName] = []( const double* materialProperties,
+                              int           nMaterialProperties,
+                              int           materialNumber ) -> Marmot::MarmotMaterialFiniteStrain* {
+        return new T( materialProperties, nMaterialProperties, materialNumber );
+      };
       return true;
     }
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialFiniteStrainFactory.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @class MarmotMaterialFiniteStrainFactory
@@ -88,4 +88,4 @@ namespace MarmotLibrary {
     using MaterialFactoryMap = std::unordered_map< std::string, materialFactoryFunction >;
     static MaterialFactoryMap& materialFactoryFunctionByName();
   };
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialPointSolverFiniteStrain.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotMaterialPointSolverFiniteStrain.h
@@ -31,315 +31,313 @@
 #include <utility>
 #include <vector>
 
-namespace Marmot {
-  namespace Solvers {
+namespace Marmot::Solvers {
+  /**
+   * @class Marmot::Solvers::MarmotMaterialPointSolverFiniteStrain
+   * @brief Solver for material point problems with finite strain materials
+   * @details This class implements a solver for material point problems
+   * using finite strain material models. It supports loading steps with
+   * controlled displacement gradient and stress components, adaptive time stepping,
+   * and history recording.
+   */
+  class MarmotMaterialPointSolverFiniteStrain {
+
+  public:
     /**
-     * @class Marmot::Solvers::MarmotMaterialPointSolverFiniteStrain
-     * @brief Solver for material point problems with finite strain materials
-     * @details This class implements a solver for material point problems
-     * using finite strain material models. It supports loading steps with
-     * controlled displacement gradient and stress components, adaptive time stepping,
-     * and history recording.
+     * @struct Step
+     * @brief Struct to define a loading step
+     * @details Each step contains targets for displacement gradient and stress states,
+     * time information and time step control parameters.
      */
-    class MarmotMaterialPointSolverFiniteStrain {
+    struct Step {
+      FastorStandardTensors::Tensor33d gradUIncrementTarget;  ///< Target displacement gradient increment for the step
+      FastorStandardTensors::Tensor33d stressIncrementTarget; ///< Target Kirchhoff stress increment for the step
+      FastorStandardTensors::Tensor33t< bool > isGradUComponentControlled; ///< Flags to indicate which displacement
+                                                                           ///< gradient components are controlled
+      FastorStandardTensors::Tensor33t< bool >
+             isStressComponentControlled; ///< Flags to indicate which stress components are controlled
+      double timeStart     = 0.0;         ///< Start time of the step
+      double timeEnd       = 1.0;         ///< End time of the step
+      double dTStart       = 0.1;         ///< Initial time step size
+      double dTMin         = 1e-6;        ///< Minimum time step size
+      double dTMax         = 0.5;         ///< Maximum time step size
+      int    maxIncrements = 100;         ///< Maximum number of increments in the step
 
-    public:
       /**
-       * @struct Step
-       * @brief Struct to define a loading step
-       * @details Each step contains targets for displacement gradient and stress states,
-       * time information and time step control parameters.
+       * @brief Check that for each component, either deformation or stress is controlled
+       * @throws std::runtime_error if the condition is not met
        */
-      struct Step {
-        FastorStandardTensors::Tensor33d gradUIncrementTarget;  ///< Target displacement gradient increment for the step
-        FastorStandardTensors::Tensor33d stressIncrementTarget; ///< Target Kirchhoff stress increment for the step
-        FastorStandardTensors::Tensor33t< bool > isGradUComponentControlled; ///< Flags to indicate which displacement
-                                                                             ///< gradient components are controlled
-        FastorStandardTensors::Tensor33t< bool >
-               isStressComponentControlled; ///< Flags to indicate which stress components are controlled
-        double timeStart     = 0.0;         ///< Start time of the step
-        double timeEnd       = 1.0;         ///< End time of the step
-        double dTStart       = 0.1;         ///< Initial time step size
-        double dTMin         = 1e-6;        ///< Minimum time step size
-        double dTMax         = 0.5;         ///< Maximum time step size
-        int    maxIncrements = 100;         ///< Maximum number of increments in the step
-
-        /**
-         * @brief Check that for each component, either deformation or stress is controlled
-         * @throws std::runtime_error if the condition is not met
-         */
-        void checkControl() const
-        {
-          for ( int i = 0; i < 9; i++ ) {
-            if ( reshape< 9 >( isGradUComponentControlled )[i] == reshape< 9 >( isStressComponentControlled )[i] ) {
-              throw std::runtime_error(
-                "exactly one of displacement gradient or stress component must be controlled for each component." );
-            }
+      void checkControl() const
+      {
+        for ( int i = 0; i < 9; i++ ) {
+          if ( reshape< 9 >( isGradUComponentControlled )[i] == reshape< 9 >( isStressComponentControlled )[i] ) {
+            throw std::runtime_error(
+              "exactly one of displacement gradient or stress component must be controlled for each component." );
           }
         }
-      };
-      /**
-       * @struct Increment
-       * @brief Struct to define a loading increment
-       * @details Each increment contains displacement gradient and stress increments,
-       * control flags, time information, and iteration limits.
-       */
-      struct Increment {
-        FastorStandardTensors::Tensor9d         gradUIncrement; ///< Target displacement gradient increment for the step
-        FastorStandardTensors::Tensor9d         stressIncrement; ///< Target Kirchhoff stress increment for the step
-        FastorStandardTensors::Tensor9t< bool > isGradUComponentControlled; ///< Flags to indicate which displecement
-                                                                            ///< gradient components are controlled
-        FastorStandardTensors::Tensor9t< bool >
-               isStressComponentControlled; ///< Flags to indicate which stress components are controlled
-        double timeOld;                     ///< Old time at the beginning of the increment
-        double dT;                          ///< Time step size for the increment
-      };
-      /**
-       * @struct HistoryEntry
-       * @brief Struct to record the history of the simulation
-       * @details Each entry contains time, stress, deformation, and state variables.
-       */
-      struct HistoryEntry {
-        double                             time;      ///< Time at the history entry
-        FastorStandardTensors::Tensor33d   stress;    ///< Stress at the history entry
-        FastorStandardTensors::Tensor33d   F;         ///< deformation gradient at the history entry
-        FastorStandardTensors::Tensor3333d dTau_dF;   ///< Material tangent at the history entry
-        Eigen::VectorXd                    stateVars; ///< State variables at the history entry
+      }
+    };
+    /**
+     * @struct Increment
+     * @brief Struct to define a loading increment
+     * @details Each increment contains displacement gradient and stress increments,
+     * control flags, time information, and iteration limits.
+     */
+    struct Increment {
+      FastorStandardTensors::Tensor9d         gradUIncrement;  ///< Target displacement gradient increment for the step
+      FastorStandardTensors::Tensor9d         stressIncrement; ///< Target Kirchhoff stress increment for the step
+      FastorStandardTensors::Tensor9t< bool > isGradUComponentControlled; ///< Flags to indicate which displecement
+                                                                          ///< gradient components are controlled
+      FastorStandardTensors::Tensor9t< bool >
+             isStressComponentControlled; ///< Flags to indicate which stress components are controlled
+      double timeOld;                     ///< Old time at the beginning of the increment
+      double dT;                          ///< Time step size for the increment
+    };
+    /**
+     * @struct HistoryEntry
+     * @brief Struct to record the history of the simulation
+     * @details Each entry contains time, stress, deformation, and state variables.
+     */
+    struct HistoryEntry {
+      double                             time;      ///< Time at the history entry
+      FastorStandardTensors::Tensor33d   stress;    ///< Stress at the history entry
+      FastorStandardTensors::Tensor33d   F;         ///< deformation gradient at the history entry
+      FastorStandardTensors::Tensor3333d dTau_dF;   ///< Material tangent at the history entry
+      Eigen::VectorXd                    stateVars; ///< State variables at the history entry
 
-        /**
-         * @brief Print the history entry to the console
-         */
-        void print() const
-        {
-          std::cout.precision( 6 );
-          std::cout << std::scientific << "  Material state for time: " << time << std::endl;
-          std::cout << "  tau:" << std::endl;
-          std::cout << "   [" << stress( 0, 0 ) << ", " << stress( 0, 1 ) << ", " << stress( 0, 2 ) << std::endl;
-          std::cout << "    " << stress( 1, 0 ) << ", " << stress( 1, 1 ) << ", " << stress( 1, 2 ) << std::endl;
-          std::cout << "    " << stress( 2, 0 ) << ", " << stress( 2, 1 ) << ", " << stress( 2, 2 ) << "]" << std::endl;
+      /**
+       * @brief Print the history entry to the console
+       */
+      void print() const
+      {
+        std::cout.precision( 6 );
+        std::cout << std::scientific << "  Material state for time: " << time << std::endl;
+        std::cout << "  tau:" << std::endl;
+        std::cout << "   [" << stress( 0, 0 ) << ", " << stress( 0, 1 ) << ", " << stress( 0, 2 ) << std::endl;
+        std::cout << "    " << stress( 1, 0 ) << ", " << stress( 1, 1 ) << ", " << stress( 1, 2 ) << std::endl;
+        std::cout << "    " << stress( 2, 0 ) << ", " << stress( 2, 1 ) << ", " << stress( 2, 2 ) << "]" << std::endl;
 
-          std::cout << "\n  F:" << std::endl;
-          std::cout << "   [" << F( 0, 0 ) << ", " << F( 0, 1 ) << ", " << F( 0, 2 ) << std::endl;
-          std::cout << "    " << F( 1, 0 ) << ", " << F( 1, 1 ) << ", " << F( 1, 2 ) << std::endl;
-          std::cout << "    " << F( 2, 0 ) << ", " << F( 2, 1 ) << ", " << F( 2, 2 ) << "]" << std::endl;
-          if ( stateVars.size() > 0 ) {
-            std::cout << "\n  state variables: " << std::endl;
-            // print 3 per line
-            std::cout << "   [";
-            for ( int i = 0; i < stateVars.size(); i++ ) {
-              std::cout << stateVars[i];
-              if ( ( i + 1 ) % 3 == 0 )
-                std::cout << "," << std::endl << "    ";
-              else if ( i != stateVars.size() - 1 )
-                std::cout << ", ";
-            }
-            std::cout << "]" << std::endl;
+        std::cout << "\n  F:" << std::endl;
+        std::cout << "   [" << F( 0, 0 ) << ", " << F( 0, 1 ) << ", " << F( 0, 2 ) << std::endl;
+        std::cout << "    " << F( 1, 0 ) << ", " << F( 1, 1 ) << ", " << F( 1, 2 ) << std::endl;
+        std::cout << "    " << F( 2, 0 ) << ", " << F( 2, 1 ) << ", " << F( 2, 2 ) << "]" << std::endl;
+        if ( stateVars.size() > 0 ) {
+          std::cout << "\n  state variables: " << std::endl;
+          // print 3 per line
+          std::cout << "   [";
+          for ( int i = 0; i < stateVars.size(); i++ ) {
+            std::cout << stateVars[i];
+            if ( ( i + 1 ) % 3 == 0 )
+              std::cout << "," << std::endl << "    ";
+            else if ( i != stateVars.size() - 1 )
+              std::cout << ", ";
           }
+          std::cout << "]" << std::endl;
         }
-        /**
-         * @brief Constructor for HistoryEntry
-         * @param time Time at the history entry
-         * @param stress Stress tensor at the history entry
-         * @param F Deformation gradient at the history entry
-         * @param dTau_dF Material tangent at the history entry
-         * @param stateVars State variables at the history entry
-         */
-        HistoryEntry( double                                    time,
-                      const FastorStandardTensors::Tensor33d&   stress,
-                      const FastorStandardTensors::Tensor33d&   F,
-                      const FastorStandardTensors::Tensor3333d& dTau_dF,
-                      const Eigen::VectorXd&                    stateVars )
-          : time( time ), stress( stress ), F( F ), dTau_dF( dTau_dF ), stateVars( stateVars )
-        {
-        }
-        // default constructor
-        HistoryEntry()
-          : time( 0.0 ),
-            stress( FastorStandardTensors::Tensor33d( 0.0 ) ),
-            F( FastorStandardTensors::Tensor33d( 0.0 ) ),
-            dTau_dF( FastorStandardTensors::Tensor3333d( 0.0 ) ),
-            stateVars( Eigen::VectorXd() )
-        {
-        }
-      };
-
+      }
       /**
-       * @struct SolverOptions
-       * @brief Struct to define solver options
-       * @details Contains parameters for controlling the solver's behavior.
+       * @brief Constructor for HistoryEntry
+       * @param time Time at the history entry
+       * @param stress Stress tensor at the history entry
+       * @param F Deformation gradient at the history entry
+       * @param dTau_dF Material tangent at the history entry
+       * @param stateVars State variables at the history entry
        */
-      struct SolverOptions {
-        int    maxIterations       = 25;    ///< Maximum number of iterations per increment (default: 25)
-        double residualTolerance   = 1e-10; ///< Convergence tolerance (default: 1e-10)
-        double correctionTolerance = 1e-10; ///< Correction tolerance (default: 1e-10)
-      };
-
-      /**
-       * @brief Constructor for the MarmotMaterialPointSolverFiniteStrain class
-       * @param materialName Name of the finite strain material model
-       * @param materialProperties Array of material properties
-       * @param nMaterialProperties Number of material properties
-       * @param options Solver options controlling nonlinear iteration settings
-       */
-      MarmotMaterialPointSolverFiniteStrain( const std::string&   materialName,
-                                             const double*        materialProperties,
-                                             const int            nMaterialProperties,
-                                             const SolverOptions& options );
-
-      /**
-       * @brief Add a loading step to the solver
-       * @param step The Step to be added
-       */
-      void addStep( const Step& step );
-
-      /**
-       * @brief Get the list of added loading steps
-       * @return A vector of Step containing the added steps
-       */
-      std::vector< Step > getSteps() const { return steps; }
-
-      /**
-       * @brief Clear all added loading steps
-       */
-      void clearSteps() { steps.clear(); }
-
-      /**
-       * @brief Set the initial state of the material model
-       * @param initialStress The initial stress in Voigt notation
-       * @param initialStateVars The initial state variables
-       */
-      void setInitialState( const FastorStandardTensors::Tensor33d& initialStress,
-                            const Eigen::VectorXd&                  initialStateVars );
-
-      /**
-       * @brief Get the number of state variables in the material model
-       * @return The number of state variables
-       */
-      int getNumberOfStateVariables() const { return nStateVars; }
-
-      /**
-       * @brief Reset the solver to the initial state
-       * @details This function resets the initial stress
-       * and state variables of the material model.
-       */
-      void resetToInitialState();
-
-      /**
-       * @brief Solve the material point problem for all added steps
-       */
-      void solve();
-
-      /**
-       * @brief Get the recorded history of the simulation
-       * @return A vector of HistoryEntry containing the recorded history
-       */
-      const std::vector< HistoryEntry >& getHistory() const { return history; }
-
-      /**
-       * @brief Clear the recorded history
-       */
-      void clearHistory() { history.clear(); }
-
-      /**
-       * @brief Print the recorded history to the console
-       */
-      void printHistory();
-
-      /**
-       * @brief Export the recorded history to a CSV file
-       * @param filename The name of the CSV file to export to
-       */
-      void exportHistoryToCSV( const std::string& filename );
-
-    private:
-      /**
-       * @brief Solve a single loading step
-       * @param step The Step to be solved
-       *
-       * @details This function iterates over the increments
-       * defined in the step, calling solveIncrement for each increment.
-       * It manages time stepping and ensures that the entire step
-       * is covered.
-       */
-      void solveStep( const Step& step );
-
-      /**
-       * @brief Solve a single increment within a loading step
-       * @param increment The Increment to be solved
-       * @throws std::runtime_error if the solver does not converge
-       *
-       * @details This function implements a Newton-Raphson iterative
-       * solver to compute the stress and deformation state for the given increment.
-       * It updates the material state variables and records the history
-       * after convergence.
-       */
-      void solveIncrement( const Increment& increment );
-
-      /**
-       * @brief Compute the residual for the current increment
-       * @param stressIncrement The computed stress increment
-       * @param target The target (mixed) stress/strain increment
-       * @param increment The Increment containing control information
-       * @return The computed residual vector
-       *
-       * @details This function calculates the residual vector
-       * based on the difference between the computed stress increment
-       * and the target increment, taking into account which components
-       * are controlled by strain or stress.
-       */
-      FastorStandardTensors::Tensor9d computeResidual( const FastorStandardTensors::Tensor9d& stressIncrement,
-                                                       const FastorStandardTensors::Tensor9d& target,
-                                                       const Increment&                       increment );
-
-      /**
-       * @brief Modify the material tangent matrix based on control type
-       * @param tangent The material tangent matrix to be modified
-       * @param increment The Increment containing control information
-       *
-       * @details This function adjusts the tangent matrix to account for
-       * the components that are controlled by displacement gradient  or stress, ensuring
-       * that the solver correctly handles mixed control scenarios.
-       * This is done by zeroing out rows corresponding to displacement gradient controlled
-       * components and setting their diagonal entries to one.
-       */
-      void modifyTangent( FastorStandardTensors::Tensor99d& tangent, const Increment& increment );
-
-      /// @brief The finite strain material model
-      std::unique_ptr< MarmotMaterialFiniteStrain > material;
-
-      /// @brief Number of state variables in the material model
-      int nStateVars;
-
-      /// @brief Current state variables
-      Eigen::VectorXd stateVars;
-
-      /// @brief Initial state variables
-      Eigen::VectorXd _initialStateVars;
-
-      /// @brief Temporary state variables for computations
-      Eigen::VectorXd stateVarsTemp;
-
-      /// @brief The Kirchhoff stress
-      FastorStandardTensors::Tensor33d stress = FastorStandardTensors::Tensor33d( 0.0 );
-
-      /// @brief The initial Kirchhoff stress
-      FastorStandardTensors::Tensor33d _initialStress = FastorStandardTensors::Tensor33d( 0.0 );
-
-      /// @brief The displacement gradient
-      FastorStandardTensors::Tensor33d gradU = FastorStandardTensors::Tensor33d( 0.0 );
-
-      /// @brief The material tangent dTau/dF
-      FastorStandardTensors::Tensor3333d dTau_dF = FastorStandardTensors::Tensor3333d( 0.0 );
-
-      /// @brief List of loading steps
-      std::vector< Step > steps;
-
-      /// @brief History of the simulation
-      std::vector< HistoryEntry > history = std::vector< HistoryEntry >();
-
-      /// @brief Solver options
-      const SolverOptions options;
+      HistoryEntry( double                                    time,
+                    const FastorStandardTensors::Tensor33d&   stress,
+                    const FastorStandardTensors::Tensor33d&   F,
+                    const FastorStandardTensors::Tensor3333d& dTau_dF,
+                    const Eigen::VectorXd&                    stateVars )
+        : time( time ), stress( stress ), F( F ), dTau_dF( dTau_dF ), stateVars( stateVars )
+      {
+      }
+      // default constructor
+      HistoryEntry()
+        : time( 0.0 ),
+          stress( FastorStandardTensors::Tensor33d( 0.0 ) ),
+          F( FastorStandardTensors::Tensor33d( 0.0 ) ),
+          dTau_dF( FastorStandardTensors::Tensor3333d( 0.0 ) ),
+          stateVars( Eigen::VectorXd() )
+      {
+      }
     };
 
-  } // namespace Solvers
-} // namespace Marmot
+    /**
+     * @struct SolverOptions
+     * @brief Struct to define solver options
+     * @details Contains parameters for controlling the solver's behavior.
+     */
+    struct SolverOptions {
+      int    maxIterations       = 25;    ///< Maximum number of iterations per increment (default: 25)
+      double residualTolerance   = 1e-10; ///< Convergence tolerance (default: 1e-10)
+      double correctionTolerance = 1e-10; ///< Correction tolerance (default: 1e-10)
+    };
+
+    /**
+     * @brief Constructor for the MarmotMaterialPointSolverFiniteStrain class
+     * @param materialName Name of the finite strain material model
+     * @param materialProperties Array of material properties
+     * @param nMaterialProperties Number of material properties
+     * @param options Solver options controlling nonlinear iteration settings
+     */
+    MarmotMaterialPointSolverFiniteStrain( const std::string&   materialName,
+                                           const double*        materialProperties,
+                                           const int            nMaterialProperties,
+                                           const SolverOptions& options );
+
+    /**
+     * @brief Add a loading step to the solver
+     * @param step The Step to be added
+     */
+    void addStep( const Step& step );
+
+    /**
+     * @brief Get the list of added loading steps
+     * @return A vector of Step containing the added steps
+     */
+    std::vector< Step > getSteps() const { return steps; }
+
+    /**
+     * @brief Clear all added loading steps
+     */
+    void clearSteps() { steps.clear(); }
+
+    /**
+     * @brief Set the initial state of the material model
+     * @param initialStress The initial stress in Voigt notation
+     * @param initialStateVars The initial state variables
+     */
+    void setInitialState( const FastorStandardTensors::Tensor33d& initialStress,
+                          const Eigen::VectorXd&                  initialStateVars );
+
+    /**
+     * @brief Get the number of state variables in the material model
+     * @return The number of state variables
+     */
+    int getNumberOfStateVariables() const { return nStateVars; }
+
+    /**
+     * @brief Reset the solver to the initial state
+     * @details This function resets the initial stress
+     * and state variables of the material model.
+     */
+    void resetToInitialState();
+
+    /**
+     * @brief Solve the material point problem for all added steps
+     */
+    void solve();
+
+    /**
+     * @brief Get the recorded history of the simulation
+     * @return A vector of HistoryEntry containing the recorded history
+     */
+    const std::vector< HistoryEntry >& getHistory() const { return history; }
+
+    /**
+     * @brief Clear the recorded history
+     */
+    void clearHistory() { history.clear(); }
+
+    /**
+     * @brief Print the recorded history to the console
+     */
+    void printHistory();
+
+    /**
+     * @brief Export the recorded history to a CSV file
+     * @param filename The name of the CSV file to export to
+     */
+    void exportHistoryToCSV( const std::string& filename );
+
+  private:
+    /**
+     * @brief Solve a single loading step
+     * @param step The Step to be solved
+     *
+     * @details This function iterates over the increments
+     * defined in the step, calling solveIncrement for each increment.
+     * It manages time stepping and ensures that the entire step
+     * is covered.
+     */
+    void solveStep( const Step& step );
+
+    /**
+     * @brief Solve a single increment within a loading step
+     * @param increment The Increment to be solved
+     * @throws std::runtime_error if the solver does not converge
+     *
+     * @details This function implements a Newton-Raphson iterative
+     * solver to compute the stress and deformation state for the given increment.
+     * It updates the material state variables and records the history
+     * after convergence.
+     */
+    void solveIncrement( const Increment& increment );
+
+    /**
+     * @brief Compute the residual for the current increment
+     * @param stressIncrement The computed stress increment
+     * @param target The target (mixed) stress/strain increment
+     * @param increment The Increment containing control information
+     * @return The computed residual vector
+     *
+     * @details This function calculates the residual vector
+     * based on the difference between the computed stress increment
+     * and the target increment, taking into account which components
+     * are controlled by strain or stress.
+     */
+    FastorStandardTensors::Tensor9d computeResidual( const FastorStandardTensors::Tensor9d& stressIncrement,
+                                                     const FastorStandardTensors::Tensor9d& target,
+                                                     const Increment&                       increment );
+
+    /**
+     * @brief Modify the material tangent matrix based on control type
+     * @param tangent The material tangent matrix to be modified
+     * @param increment The Increment containing control information
+     *
+     * @details This function adjusts the tangent matrix to account for
+     * the components that are controlled by displacement gradient  or stress, ensuring
+     * that the solver correctly handles mixed control scenarios.
+     * This is done by zeroing out rows corresponding to displacement gradient controlled
+     * components and setting their diagonal entries to one.
+     */
+    void modifyTangent( FastorStandardTensors::Tensor99d& tangent, const Increment& increment );
+
+    /// @brief The finite strain material model
+    std::unique_ptr< MarmotMaterialFiniteStrain > material;
+
+    /// @brief Number of state variables in the material model
+    int nStateVars;
+
+    /// @brief Current state variables
+    Eigen::VectorXd stateVars;
+
+    /// @brief Initial state variables
+    Eigen::VectorXd _initialStateVars;
+
+    /// @brief Temporary state variables for computations
+    Eigen::VectorXd stateVarsTemp;
+
+    /// @brief The Kirchhoff stress
+    FastorStandardTensors::Tensor33d stress = FastorStandardTensors::Tensor33d( 0.0 );
+
+    /// @brief The initial Kirchhoff stress
+    FastorStandardTensors::Tensor33d _initialStress = FastorStandardTensors::Tensor33d( 0.0 );
+
+    /// @brief The displacement gradient
+    FastorStandardTensors::Tensor33d gradU = FastorStandardTensors::Tensor33d( 0.0 );
+
+    /// @brief The material tangent dTau/dF
+    FastorStandardTensors::Tensor3333d dTau_dF = FastorStandardTensors::Tensor3333d( 0.0 );
+
+    /// @brief List of loading steps
+    std::vector< Step > steps;
+
+    /// @brief History of the simulation
+    std::vector< HistoryEntry > history = std::vector< HistoryEntry >();
+
+    /// @brief Solver options
+    const SolverOptions options;
+  };
+
+} // namespace Marmot::Solvers

--- a/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotStressMeasures.h
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/include/Marmot/MarmotStressMeasures.h
@@ -28,17 +28,42 @@
 #include "Marmot/MarmotFastorTensorBasics.h"
 #include <Fastor/tensor/Tensor.h>
 
-namespace Marmot::ContinuumMechanics {
+namespace Marmot::ContinuumMechanics::StressMeasures {
 
-  namespace StressMeasures {
+  using namespace FastorIndices;
+  using namespace FastorStandardTensors;
 
-    using namespace FastorIndices;
-    using namespace FastorStandardTensors;
+  /**
+   * @brief Computes the Kirchhoff stress from the 2nd Piola-Kirchhoff stress and the deformation gradient.
+   *
+   * The Kirchhoff stress is computed as
+   * \f[
+   *   \boldsymbol{\tau} = \boldsymbol{F}  \boldsymbol{S}  \boldsymbol{F}^T
+   * \f]
+   * or in index notation
+   * \f[
+   * \tau_{ij} = F_{iI} S_{IJ} F_{jJ}.
+   * \f]
+   *
+   * @tparam T Scalar type, e.g. double, float
+   * @param PK2 2nd Piola-Kirchhoff stress
+   * @param F Deformation gradient
+   * @return Kirchhoff stress
+   */
+  template < typename T >
+  Tensor33t< T > KirchhoffStressFromPK2( const Tensor33t< T >& PK2, const Tensor33t< T >& F )
+  {
+    const Tensor33t< T > tau = einsum< iI, IJ, jJ, to_ij >( F, PK2, F );
 
-    /**
-     * @brief Computes the Kirchhoff stress from the 2nd Piola-Kirchhoff stress and the deformation gradient.
+    return tau;
+  }
+
+  namespace FirstOrderDerived {
+
+    /** @brief Computes the Kirchhoff stress from the 2nd Piola-Kirchhoff stress and the deformation gradient and the
+     * respective partial derivatives.
      *
-     * The Kirchhoff stress is computed as
+     * The Kirchoff stress is computed as
      * \f[
      *   \boldsymbol{\tau} = \boldsymbol{F}  \boldsymbol{S}  \boldsymbol{F}^T
      * \f]
@@ -46,61 +71,31 @@ namespace Marmot::ContinuumMechanics {
      * \f[
      * \tau_{ij} = F_{iI} S_{IJ} F_{jJ}.
      * \f]
+     * Additionally, the derivatives with respect to \f$ \boldsymbol{S} \f$ and \f$ \boldsymbol{F} \f$ are computed
+     * in index notation as \f[ \frac{\partial \tau_{ij}}{\partial S_{IJ}} = F_{iI} F_{jJ} \f] and \f[ \frac{\partial
+     * \tau_{ij}}{\partial F_{kL}} = \delta_{ik} S_{LJ} F_{jJ} + F_{iI} S_{IL} \delta_{jk} \f]
      *
      * @tparam T Scalar type, e.g. double, float
      * @param PK2 2nd Piola-Kirchhoff stress
      * @param F Deformation gradient
-     * @return Kirchhoff stress
+     * @return A tuple containing Kirchhoff stress and its derivatives w.r.t \f$\boldsymbol{S}\f$ and
+     * \f$\boldsymbol{F}\f$
      */
     template < typename T >
-    Tensor33t< T > KirchhoffStressFromPK2( const Tensor33t< T >& PK2, const Tensor33t< T >& F )
+    std::tuple< Tensor33t< T >, Tensor3333t< T >, Tensor3333t< T > > KirchhoffStressFromPK2( const Tensor33t< T >& PK2,
+                                                                                             const Tensor33t< T >& F )
     {
+      const auto&          I   = Spatial3D::I;
       const Tensor33t< T > tau = einsum< iI, IJ, jJ, to_ij >( F, PK2, F );
 
-      return tau;
+      const Tensor3333t< T > dTau_dPK2 = einsum< iI, jJ, to_ijIJ >( F, F );
+
+      const Tensor33t< T >   S_F     = einsum< KJ, jJ >( PK2, F );
+      const Tensor3333t< T > dTau_dF = einsum< ik, jK, to_ijkK >( I, transpose( S_F ) ) +
+                                       einsum< Ki, jk, to_ijkK >( S_F, I );
+
+      return { tau, dTau_dPK2, dTau_dF };
     }
+  } // namespace FirstOrderDerived
 
-    namespace FirstOrderDerived {
-
-      /** @brief Computes the Kirchhoff stress from the 2nd Piola-Kirchhoff stress and the deformation gradient and the
-       * respective partial derivatives.
-       *
-       * The Kirchoff stress is computed as
-       * \f[
-       *   \boldsymbol{\tau} = \boldsymbol{F}  \boldsymbol{S}  \boldsymbol{F}^T
-       * \f]
-       * or in index notation
-       * \f[
-       * \tau_{ij} = F_{iI} S_{IJ} F_{jJ}.
-       * \f]
-       * Additionally, the derivatives with respect to \f$ \boldsymbol{S} \f$ and \f$ \boldsymbol{F} \f$ are computed
-       * in index notation as \f[ \frac{\partial \tau_{ij}}{\partial S_{IJ}} = F_{iI} F_{jJ} \f] and \f[ \frac{\partial
-       * \tau_{ij}}{\partial F_{kL}} = \delta_{ik} S_{LJ} F_{jJ} + F_{iI} S_{IL} \delta_{jk} \f]
-       *
-       * @tparam T Scalar type, e.g. double, float
-       * @param PK2 2nd Piola-Kirchhoff stress
-       * @param F Deformation gradient
-       * @return A tuple containing Kirchhoff stress and its derivatives w.r.t \f$\boldsymbol{S}\f$ and
-       * \f$\boldsymbol{F}\f$
-       */
-      template < typename T >
-      std::tuple< Tensor33t< T >, Tensor3333t< T >, Tensor3333t< T > > KirchhoffStressFromPK2(
-        const Tensor33t< T >& PK2,
-        const Tensor33t< T >& F )
-      {
-        const auto&          I   = Spatial3D::I;
-        const Tensor33t< T > tau = einsum< iI, IJ, jJ, to_ij >( F, PK2, F );
-
-        const Tensor3333t< T > dTau_dPK2 = einsum< iI, jJ, to_ijIJ >( F, F );
-
-        const Tensor33t< T >   S_F     = einsum< KJ, jJ >( PK2, F );
-        const Tensor3333t< T > dTau_dF = einsum< ik, jK, to_ijkK >( I, transpose( S_F ) ) +
-                                         einsum< Ki, jk, to_ijkK >( S_F, I );
-
-        return { tau, dTau_dPK2, dTau_dF };
-      }
-    } // namespace FirstOrderDerived
-
-  }   // namespace StressMeasures
-
-} // namespace Marmot::ContinuumMechanics
+} // namespace Marmot::ContinuumMechanics::StressMeasures

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotEnergyDensityFunctions.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotEnergyDensityFunctions.cpp
@@ -1,110 +1,104 @@
 #include "Marmot/MarmotEnergyDensityFunctions.h"
 #include "Marmot/MarmotAutomaticDifferentiationForFastor.h"
-namespace Marmot::ContinuumMechanics {
+namespace Marmot::ContinuumMechanics::EnergyDensityFunctions::ThirdOrderDerived {
+  using namespace Fastor;
+  using namespace Marmot::FastorStandardTensors;
+  std::tuple< double, FastorStandardTensors::Tensor33d, FastorStandardTensors::Tensor3333d, FastorStandardTensors::Tensor333333d > standardNeoHooke(
+    const FastorStandardTensors::Tensor33d& C,
+    const double&                           K,
+    const double&                           G )
+  {
 
-  namespace EnergyDensityFunctions {
+    const double lambda = K - 2.0 / 3.0 * G;
 
-    namespace ThirdOrderDerived {
-      using namespace Fastor;
-      using namespace Marmot::FastorStandardTensors;
-      std::tuple< double, FastorStandardTensors::Tensor33d, FastorStandardTensors::Tensor3333d, FastorStandardTensors::Tensor333333d > standardNeoHooke(
-        const FastorStandardTensors::Tensor33d& C,
-        const double&                           K,
-        const double&                           G )
-      {
+    /*
+     * we use the potential in terms of C
+     * Psi = G/2 ( tr(C) - 3 - 2 ln(J) ) + lambda/2 ( 0.5 ( J^2 - 1 ) - ln(J) )
+     * where J = sqrt( det(C) ) and ln(J) = 0.5 ln( det(C) )
+     *
+     * we can the rewrite as
+     * Psi = G/2 ( tr(C) - 3 - ln(det(C)) ) + lambda/2 ( 0.5 ( det(C) - 1 ) - 0.5 ln(det(C)) )
+     *
+     */
 
-        const double lambda = K - 2.0 / 3.0 * G;
+    const double trC    = trace( C );
+    const double detC   = determinant( C );
+    const double lnDetC = log( detC );
+    // energy density
+    const double psi = G / 2 * ( trC - 3.0 - lnDetC ) + lambda / 4 * ( detC - 1.0 - lnDetC );
 
-        /*
-         * we use the potential in terms of C
-         * Psi = G/2 ( tr(C) - 3 - 2 ln(J) ) + lambda/2 ( 0.5 ( J^2 - 1 ) - ln(J) )
-         * where J = sqrt( det(C) ) and ln(J) = 0.5 ln( det(C) )
-         *
-         * we can the rewrite as
-         * Psi = G/2 ( tr(C) - 3 - ln(det(C)) ) + lambda/2 ( 0.5 ( det(C) - 1 ) - 0.5 ln(det(C)) )
-         *
-         */
+    // first derivative quantities
+    const Tensor33d& dTrC_dC    = Spatial3D::I;
+    const Tensor33d  invCt      = transpose( inverse( C ) );
+    const Tensor33d  dDetC_dC   = detC * invCt;
+    const Tensor33d& dLnDetC_dC = invCt;
 
-        const double trC    = trace( C );
-        const double detC   = determinant( C );
-        const double lnDetC = log( detC );
-        // energy density
-        const double psi = G / 2 * ( trC - 3.0 - lnDetC ) + lambda / 4 * ( detC - 1.0 - lnDetC );
+    // first derivative with respect to C
+    const Tensor33d dPsi_dC = G / 2 * ( dTrC_dC - dLnDetC_dC ) + lambda / 4 * ( dDetC_dC - dLnDetC_dC );
 
-        // first derivative quantities
-        const Tensor33d& dTrC_dC    = Spatial3D::I;
-        const Tensor33d  invCt      = transpose( inverse( C ) );
-        const Tensor33d  dDetC_dC   = detC * invCt;
-        const Tensor33d& dLnDetC_dC = invCt;
+    // second derivative quantities
+    using namespace FastorIndices;
+    using lj                        = Index< l_, j_ >;
+    using li                        = Index< l_, i_ >;
+    const Tensor3333d  dInvCt_dC    = -0.5 * ( einsum< ik, lj, to_ijkl >( invCt, invCt ) +
+                                           einsum< jk, li, to_ijkl >( invCt, invCt ) );
+    const Tensor3333d  d2DetC_dC2   = detC * dInvCt_dC + einsum< ij, kl, to_ijkl >( invCt, dDetC_dC );
+    const Tensor3333d& d2LnDetC_dC2 = dInvCt_dC;
 
-        // first derivative with respect to C
-        const Tensor33d dPsi_dC = G / 2 * ( dTrC_dC - dLnDetC_dC ) + lambda / 4 * ( dDetC_dC - dLnDetC_dC );
+    // second derivative with respect to C
+    const Tensor3333d d2Psi_dC2 = lambda / 4.0 * d2DetC_dC2 - ( G / 2.0 + lambda / 4.0 ) * d2LnDetC_dC2;
 
-        // second derivative quantities
-        using namespace FastorIndices;
-        using lj                        = Index< l_, j_ >;
-        using li                        = Index< l_, i_ >;
-        const Tensor3333d  dInvCt_dC    = -0.5 * ( einsum< ik, lj, to_ijkl >( invCt, invCt ) +
-                                               einsum< jk, li, to_ijkl >( invCt, invCt ) );
-        const Tensor3333d  d2DetC_dC2   = detC * dInvCt_dC + einsum< ij, kl, to_ijkl >( invCt, dDetC_dC );
-        const Tensor3333d& d2LnDetC_dC2 = dInvCt_dC;
+    // // third derivative quantities
+    // using nk = Index<n_, k_>;
+    // using nj = Index<n_, j_>;
+    // using ni = Index<n_, i_>;
+    // using im = Index<i_, m_>;
+    // using jm = Index<j_, m_>;
+    // using nl = Index<n_, l_>;
+    // using il = Index<i_, l_>;
+    // using klmn = Index<k_, l_, m_, n_>;
+    // using to_ijklmn = OIndex<i_, j_, k_, l_, m_, n_>;
+    // const Tensor333333d d2InvCt_dC2_analytical = 0.25 * (
+    //          // derivative of C^-1_ik C^-1_lj w.r.t. C_mn
+    //          einsum< im, nk, jl, to_ijklmn >( invCt, invCt, invCt )
+    //         + einsum< km, ni, jl, to_ijklmn >( invCt, invCt, invCt )
+    //         + einsum< jm, nl, ik, to_ijklmn >( invCt, invCt, invCt )
+    //         + einsum< lm, nj, ik, to_ijklmn >( invCt, invCt, invCt )
+    //         // derivative of C^-1_jk C^-1_li w.r.t. C_mn
+    //         // replace indices accordingly
+    //         // iklj -> jkli
+    //         + einsum< jm, nk, il, to_ijklmn >( invCt, invCt, invCt )
+    //         + einsum< km, nj, il, to_ijklmn >( invCt, invCt, invCt )
+    //         + einsum< im, nl, jk, to_ijklmn >( invCt, invCt, invCt )
+    //         + einsum< lm, ni, jk, to_ijklmn >( invCt, invCt, invCt )
+    //         );
+    // const Tensor333333d& d3LnDetC_dC3_analytical = d2InvCt_dC2_analytical;
+    // const Tensor333333d d3DetC_dC3_analytical = detC * d2InvCt_dC2_analytical
+    //         + einsum< mn, ijkl, to_ijklmn >( dDetC_dC, dInvCt_dC )
+    //         + einsum< ij, klmn, to_ijklmn >( invCt,d2DetC_dC2 );
+    //         + einsum< kl, ijmn, to_ijklmn >( dDetC_dC, dInvCt_dC );
 
-        // second derivative with respect to C
-        const Tensor3333d d2Psi_dC2 = lambda / 4.0 * d2DetC_dC2 - ( G / 2.0 + lambda / 4.0 ) * d2LnDetC_dC2;
+    // workaround with autodiff for third derivative
+    auto detC_func = [=]( const Tensor33t< autodiff::dual3rd >& C_var ) {
+      autodiff::dual3rd res = determinant( C_var );
+      return res;
+    };
 
-        // // third derivative quantities
-        // using nk = Index<n_, k_>;
-        // using nj = Index<n_, j_>;
-        // using ni = Index<n_, i_>;
-        // using im = Index<i_, m_>;
-        // using jm = Index<j_, m_>;
-        // using nl = Index<n_, l_>;
-        // using il = Index<i_, l_>;
-        // using klmn = Index<k_, l_, m_, n_>;
-        // using to_ijklmn = OIndex<i_, j_, k_, l_, m_, n_>;
-        // const Tensor333333d d2InvCt_dC2_analytical = 0.25 * (
-        //          // derivative of C^-1_ik C^-1_lj w.r.t. C_mn
-        //          einsum< im, nk, jl, to_ijklmn >( invCt, invCt, invCt )
-        //         + einsum< km, ni, jl, to_ijklmn >( invCt, invCt, invCt )
-        //         + einsum< jm, nl, ik, to_ijklmn >( invCt, invCt, invCt )
-        //         + einsum< lm, nj, ik, to_ijklmn >( invCt, invCt, invCt )
-        //         // derivative of C^-1_jk C^-1_li w.r.t. C_mn
-        //         // replace indices accordingly
-        //         // iklj -> jkli
-        //         + einsum< jm, nk, il, to_ijklmn >( invCt, invCt, invCt )
-        //         + einsum< km, nj, il, to_ijklmn >( invCt, invCt, invCt )
-        //         + einsum< im, nl, jk, to_ijklmn >( invCt, invCt, invCt )
-        //         + einsum< lm, ni, jk, to_ijklmn >( invCt, invCt, invCt )
-        //         );
-        // const Tensor333333d& d3LnDetC_dC3_analytical = d2InvCt_dC2_analytical;
-        // const Tensor333333d d3DetC_dC3_analytical = detC * d2InvCt_dC2_analytical
-        //         + einsum< mn, ijkl, to_ijklmn >( dDetC_dC, dInvCt_dC )
-        //         + einsum< ij, klmn, to_ijklmn >( invCt,d2DetC_dC2 );
-        //         + einsum< kl, ijmn, to_ijklmn >( dDetC_dC, dInvCt_dC );
+    auto lnDetC_func = [=]( const Tensor33t< autodiff::dual3rd >& C_var ) { return log( determinant( C_var ) ); };
 
-        // workaround with autodiff for third derivative
-        auto detC_func = [=]( const Tensor33t< autodiff::dual3rd >& C_var ) {
-          autodiff::dual3rd res = determinant( C_var );
-          return res;
-        };
+    Tensor333333d d3DetC_dC3 = std::get< 3 >(
+      Marmot::AutomaticDifferentiation::ThirdOrder::d3f_dT3< 3 >( detC_func, C ) );
 
-        auto lnDetC_func = [=]( const Tensor33t< autodiff::dual3rd >& C_var ) { return log( determinant( C_var ) ); };
+    Tensor333333d d3LnDetC_dC3 = std::get< 3 >(
+      Marmot::AutomaticDifferentiation::ThirdOrder::d3f_dT3< 3 >( lnDetC_func, C ) );
 
-        Tensor333333d d3DetC_dC3 = std::get< 3 >(
-          Marmot::AutomaticDifferentiation::ThirdOrder::d3f_dT3< 3 >( detC_func, C ) );
+    // compare with analytical
+    // std::cout << "Max abs diff d3DetC_dC3: " <<  d3DetC_dC3 - d3DetC_dC3_analytical << std::endl;
+    // std::cout << "Max abs diff d3LnDetC_dC3: " << d3LnDetC_dC3 - d3LnDetC_dC3_analytical << std::endl;
 
-        Tensor333333d d3LnDetC_dC3 = std::get< 3 >(
-          Marmot::AutomaticDifferentiation::ThirdOrder::d3f_dT3< 3 >( lnDetC_func, C ) );
+    // third derivative with respect to C
+    const Tensor333333d d3Psi_dC3 = lambda / 4.0 * d3DetC_dC3 - ( G / 2.0 + lambda / 4.0 ) * d3LnDetC_dC3;
 
-        // compare with analytical
-        // std::cout << "Max abs diff d3DetC_dC3: " <<  d3DetC_dC3 - d3DetC_dC3_analytical << std::endl;
-        // std::cout << "Max abs diff d3LnDetC_dC3: " << d3LnDetC_dC3 - d3LnDetC_dC3_analytical << std::endl;
-
-        // third derivative with respect to C
-        const Tensor333333d d3Psi_dC3 = lambda / 4.0 * d3DetC_dC3 - ( G / 2.0 + lambda / 4.0 ) * d3LnDetC_dC3;
-
-        return { psi, dPsi_dC, d2Psi_dC2, d3Psi_dC3 };
-      }
-    } // namespace ThirdOrderDerived
-  }   // namespace EnergyDensityFunctions
-} // namespace Marmot::ContinuumMechanics
+    return { psi, dPsi_dC, d2Psi_dC2, d3Psi_dC3 };
+  }
+} // namespace Marmot::ContinuumMechanics::EnergyDensityFunctions::ThirdOrderDerived

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotFiniteStrainPlasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotFiniteStrainPlasticity.cpp
@@ -1,38 +1,30 @@
 #include "Marmot/MarmotFiniteStrainPlasticity.h"
 #include "Marmot/MarmotTensorExponential.h"
 
-namespace Marmot {
-  namespace ContinuumMechanics::FiniteStrain::Plasticity {
-    namespace FlowIntegration {
+namespace Marmot::ContinuumMechanics::FiniteStrain::Plasticity::FlowIntegration::FirstOrderDerived {
 
-      namespace FirstOrderDerived {
+  using namespace Fastor;
+  using namespace FastorStandardTensors;
+  using namespace FastorIndices;
 
-        using namespace Fastor;
-        using namespace FastorStandardTensors;
-        using namespace FastorIndices;
+  std::pair< Tensor33d, Tensor3333d > explicitIntegration( const Tensor33d& dGp )
+  {
+    const auto&              I       = Spatial3D::I;
+    const Tensor33d          dFp     = permute< Index< 1, 0 > >( I + dGp );
+    const static Tensor3333d dFp_dGp = einsum< in, Im, to_iImn >( I, I ); // TODO: Simply Transposition operator..
+    return { dFp, dFp_dGp };
+  }
 
-        std::pair< Tensor33d, Tensor3333d > explicitIntegration( const Tensor33d& dGp )
-        {
-          const auto&              I       = Spatial3D::I;
-          const Tensor33d          dFp     = permute< Index< 1, 0 > >( I + dGp );
-          const static Tensor3333d dFp_dGp = einsum< in, Im, to_iImn >( I, I ); // TODO: Simply Transposition operator..
-          return { dFp, dFp_dGp };
-        }
-
-        std::pair< Tensor33d, Tensor3333d > exponentialMap( const Tensor33d& dGp )
-        {
-          const auto [dFpT, dFpT_dGp] = TensorUtility::TensorExponential::FirstOrderDerived::
-            computeTensorExponential( dGp, 15, 1e-14 );
-          // clang-format off
+  std::pair< Tensor33d, Tensor3333d > exponentialMap( const Tensor33d& dGp )
+  {
+    const auto [dFpT,
+                dFpT_dGp] = TensorUtility::TensorExponential::FirstOrderDerived::computeTensorExponential( dGp,
+                                                                                                           15,
+                                                                                                           1e-14 );
+    // clang-format off
             return { permute< Index< 1, 0 > >      ( dFpT     ),
                      permute< Index< 1, 0, 2, 3 > >( dFpT_dGp ) };
-          // clang-format on
-        }
+    // clang-format on
+  }
 
-      } // namespace FirstOrderDerived
-
-    }   // namespace FlowIntegration
-
-  }     // namespace ContinuumMechanics::FiniteStrain::Plasticity
-
-} // namespace Marmot
+} // namespace Marmot::ContinuumMechanics::FiniteStrain::Plasticity::FlowIntegration::FirstOrderDerived

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotFiniteStrainViscoelasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotFiniteStrainViscoelasticity.cpp
@@ -4,150 +4,148 @@
 #include <cstring>
 #include <vector>
 
-namespace Marmot {
-  namespace ContinuumMechanics::FiniteStrain::Viscoelasticity {
+namespace Marmot::ContinuumMechanics::FiniteStrain::Viscoelasticity {
 
-    MaxwellProperties createMaxwellProperties( int nMaxwell, const double* gammaTauPairVector )
-    {
-      if ( nMaxwell < 0 )
-        throw std::invalid_argument( "Number of Maxwell elements cannot be negative." );
-      if ( nMaxwell == 0 )
-        return MaxwellProperties( 0, {}, 0.0, {} );
-      if ( gammaTauPairVector == nullptr )
-        throw std::invalid_argument( "gammaTauPairVector cannot be null when number of Maxwell elements is positive." );
+  MaxwellProperties createMaxwellProperties( int nMaxwell, const double* gammaTauPairVector )
+  {
+    if ( nMaxwell < 0 )
+      throw std::invalid_argument( "Number of Maxwell elements cannot be negative." );
+    if ( nMaxwell == 0 )
+      return MaxwellProperties( 0, {}, 0.0, {} );
+    if ( gammaTauPairVector == nullptr )
+      throw std::invalid_argument( "gammaTauPairVector cannot be null when number of Maxwell elements is positive." );
 
-      std::vector< double > gamma( nMaxwell );
-      std::vector< double > tau( nMaxwell );
-      double                sumGamma = 0.0;
-      for ( int i = 0; i < nMaxwell; ++i ) {
-        const double gammaValue = gammaTauPairVector[i * 2];
-        const double tauValue   = gammaTauPairVector[i * 2 + 1];
-        if ( tauValue <= 0.0 )
-          throw std::invalid_argument( "Relaxation times of Maxwell elements must be positive." );
+    std::vector< double > gamma( nMaxwell );
+    std::vector< double > tau( nMaxwell );
+    double                sumGamma = 0.0;
+    for ( int i = 0; i < nMaxwell; ++i ) {
+      const double gammaValue = gammaTauPairVector[i * 2];
+      const double tauValue   = gammaTauPairVector[i * 2 + 1];
+      if ( tauValue <= 0.0 )
+        throw std::invalid_argument( "Relaxation times of Maxwell elements must be positive." );
 
-        gamma[i] = gammaValue;
-        tau[i]   = tauValue;
-        sumGamma += gammaValue;
-      }
-      return MaxwellProperties( nMaxwell, gamma, sumGamma, tau );
+      gamma[i] = gammaValue;
+      tau[i]   = tauValue;
+      sumGamma += gammaValue;
     }
+    return MaxwellProperties( nMaxwell, gamma, sumGamma, tau );
+  }
 
-    void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&           stress,
-                                          FastorStandardTensors::Tensor3333d&         tangent,
-                                          const FastorStandardTensors::Tensor333333d& dTangent_dDeformation,
-                                          const FastorStandardTensors::Tensor3333d&   initialCompliance,
-                                          const FastorStandardTensors::Tensor33d&     dStress,
-                                          const double                                dT,
-                                          const MaxwellProperties&                    maxwellProperties,
-                                          double*                                     stateVars )
-    {
+  void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&           stress,
+                                        FastorStandardTensors::Tensor3333d&         tangent,
+                                        const FastorStandardTensors::Tensor333333d& dTangent_dDeformation,
+                                        const FastorStandardTensors::Tensor3333d&   initialCompliance,
+                                        const FastorStandardTensors::Tensor33d&     dStress,
+                                        const double                                dT,
+                                        const MaxwellProperties&                    maxwellProperties,
+                                        double*                                     stateVars )
+  {
 
-      if ( maxwellProperties.nMaxwell == 0 )
-        return;
+    if ( maxwellProperties.nMaxwell == 0 )
+      return;
 
-      using namespace Fastor;
-      using namespace Marmot::FastorStandardTensors;
-      using namespace Marmot::FastorIndices;
+    using namespace Fastor;
+    using namespace Marmot::FastorStandardTensors;
+    using namespace Marmot::FastorIndices;
 
-      // copy of tangent to be incremented
-      const Tensor3333d initialTangent = tangent;
+    // copy of tangent to be incremented
+    const Tensor3333d initialTangent = tangent;
 
-      // scale equilibrium stress contribution
-      stress  = stress * ( 1.0 - maxwellProperties.sumGamma );
-      tangent = tangent * ( 1.0 - maxwellProperties.sumGamma );
+    // scale equilibrium stress contribution
+    stress  = stress * ( 1.0 - maxwellProperties.sumGamma );
+    tangent = tangent * ( 1.0 - maxwellProperties.sumGamma );
 
-      for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
-        // get old  maxewell element stress from state variables
-        const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
+    for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
+      // get old  maxewell element stress from state variables
+      const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
 
-        // get parameters of maxwell element
-        const double& tau   = maxwellProperties.tau[i];
-        const double& gamma = maxwellProperties.gamma[i];
+      // get parameters of maxwell element
+      const double& tau   = maxwellProperties.tau[i];
+      const double& gamma = maxwellProperties.gamma[i];
 
-        const double dT_tau    = std::max( dT / tau, 1e-15 );
-        const double expFactor = Math::exp( -dT_tau );
+      const double dT_tau    = std::max( dT / tau, 1e-15 );
+      const double expFactor = Math::exp( -dT_tau );
 
-        double alpha = expFactor;
-        double beta  = gamma / dT_tau * ( 1.0 - expFactor );
+      double alpha = expFactor;
+      double beta  = gamma / dT_tau * ( 1.0 - expFactor );
 
-        if ( dT_tau < 1e-6 ) {
-          // use taylor expansion for small dt/tau
-          alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
-          beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
-        }
-
-        // compute new stress in maxwell element
-        const Tensor33d Q_np = alpha * Q_n + beta * dStress;
-
-        // add contribution to stress
-        const Tensor33d H_np = einsum< ijkl, kl >( initialCompliance, Q_np );
-        stress += einsum< ij, ijkl >( H_np, initialTangent );
-
-        const Tensor3333d dH_np_dDeformation = einsum< ijmn, mnKL >( initialCompliance,
-                                                                     evaluate( beta * initialTangent ) );
-
-        tangent += einsum< ijkl, ijmn >( initialTangent, dH_np_dDeformation );
-        tangent += einsum< ij, ijklmn >( H_np, dTangent_dDeformation );
-
-        // update state variables
-        memcpy( stateVars + i * 9, Q_np.data(), 9 * sizeof( double ) );
+      if ( dT_tau < 1e-6 ) {
+        // use taylor expansion for small dt/tau
+        alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
+        beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
       }
+
+      // compute new stress in maxwell element
+      const Tensor33d Q_np = alpha * Q_n + beta * dStress;
+
+      // add contribution to stress
+      const Tensor33d H_np = einsum< ijkl, kl >( initialCompliance, Q_np );
+      stress += einsum< ij, ijkl >( H_np, initialTangent );
+
+      const Tensor3333d dH_np_dDeformation = einsum< ijmn, mnKL >( initialCompliance,
+                                                                   evaluate( beta * initialTangent ) );
+
+      tangent += einsum< ijkl, ijmn >( initialTangent, dH_np_dDeformation );
+      tangent += einsum< ij, ijklmn >( H_np, dTangent_dDeformation );
+
+      // update state variables
+      memcpy( stateVars + i * 9, Q_np.data(), 9 * sizeof( double ) );
     }
+  }
 
-    void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&       stress,
-                                          FastorStandardTensors::Tensor3333d&     tangent,
-                                          const FastorStandardTensors::Tensor33d& dStress,
-                                          const double                            dT,
-                                          const MaxwellProperties&                maxwellProperties,
-                                          double*                                 stateVars )
-    {
+  void evaluateGeneralizedMaxwellModel( FastorStandardTensors::Tensor33d&       stress,
+                                        FastorStandardTensors::Tensor3333d&     tangent,
+                                        const FastorStandardTensors::Tensor33d& dStress,
+                                        const double                            dT,
+                                        const MaxwellProperties&                maxwellProperties,
+                                        double*                                 stateVars )
+  {
 
-      if ( maxwellProperties.nMaxwell == 0 )
-        return;
+    if ( maxwellProperties.nMaxwell == 0 )
+      return;
 
-      using namespace Fastor;
-      using namespace Marmot::FastorStandardTensors;
-      using namespace Marmot::FastorIndices;
+    using namespace Fastor;
+    using namespace Marmot::FastorStandardTensors;
+    using namespace Marmot::FastorIndices;
 
-      // copy of tangent to be incremented
-      const Tensor3333d initialTangent = tangent;
+    // copy of tangent to be incremented
+    const Tensor3333d initialTangent = tangent;
 
-      // scale equilibrium stress contribution
-      stress  = stress * ( 1.0 - maxwellProperties.sumGamma );
-      tangent = tangent * ( 1.0 - maxwellProperties.sumGamma );
+    // scale equilibrium stress contribution
+    stress  = stress * ( 1.0 - maxwellProperties.sumGamma );
+    tangent = tangent * ( 1.0 - maxwellProperties.sumGamma );
 
-      for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
-        // get old  maxewell element stress from state variables
-        const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
+    for ( int i = 0; i < maxwellProperties.nMaxwell; ++i ) {
+      // get old  maxewell element stress from state variables
+      const Tensor33d& Q_n = Tensor33d( stateVars + i * 9 );
 
-        // get parameters of maxwell element
-        const double& tau   = maxwellProperties.tau[i];
-        const double& gamma = maxwellProperties.gamma[i];
+      // get parameters of maxwell element
+      const double& tau   = maxwellProperties.tau[i];
+      const double& gamma = maxwellProperties.gamma[i];
 
-        const double dT_tau    = std::max( dT / tau, 1e-15 );
-        const double expFactor = Math::exp( -dT_tau );
+      const double dT_tau    = std::max( dT / tau, 1e-15 );
+      const double expFactor = Math::exp( -dT_tau );
 
-        double alpha = expFactor;
-        double beta  = gamma / dT_tau * ( 1.0 - expFactor );
+      double alpha = expFactor;
+      double beta  = gamma / dT_tau * ( 1.0 - expFactor );
 
-        if ( dT_tau < 1e-6 ) {
-          // use taylor expansion for small dt/tau
-          alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
-          beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
-        }
-
-        // compute new stress in maxwell element
-        const Tensor33d Q_np = alpha * Q_n + beta * dStress;
-
-        // add contribution to stress
-        stress += Q_np;
-
-        tangent += beta * initialTangent;
-
-        // update state variables
-        memcpy( stateVars + i * 9, Q_np.data(), 9 * sizeof( double ) );
+      if ( dT_tau < 1e-6 ) {
+        // use taylor expansion for small dt/tau
+        alpha = 1.0 - dT_tau + 0.5 * dT_tau * dT_tau;
+        beta  = gamma * ( 1.0 - 0.5 * dT_tau + 1.0 / 6.0 * dT_tau * dT_tau );
       }
-    }
 
-  } // namespace ContinuumMechanics::FiniteStrain::Viscoelasticity
-} // namespace Marmot
+      // compute new stress in maxwell element
+      const Tensor33d Q_np = alpha * Q_n + beta * dStress;
+
+      // add contribution to stress
+      stress += Q_np;
+
+      tangent += beta * initialTangent;
+
+      // update state variables
+      memcpy( stateVars + i * 9, Q_np.data(), 9 * sizeof( double ) );
+    }
+  }
+
+} // namespace Marmot::ContinuumMechanics::FiniteStrain::Viscoelasticity

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrain.cpp
@@ -2,141 +2,148 @@
 #include "Marmot/MarmotJournal.h"
 #include "Marmot/MarmotTypedefs.h"
 
-void applyEigenDeformation_( Fastor::Tensor< double, 3, 3 >& F, double F0_XX, double F0_YY, double F0_ZZ )
-{
-  F( 0, 0 ) *= F0_XX;
-  F( 1, 1 ) *= F0_YY;
-  F( 2, 2 ) *= F0_ZZ;
-}
+namespace Marmot {
 
-void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3 >& dT0_dF, double F0_XX, double F0_YY, double F0_ZZ )
-{
-  dT0_dF( 0, 0 ) *= F0_XX;
-  dT0_dF( 1, 1 ) *= F0_YY;
-  dT0_dF( 2, 2 ) *= F0_ZZ;
-}
+  void applyEigenDeformation_( Fastor::Tensor< double, 3, 3 >& F, double F0_XX, double F0_YY, double F0_ZZ )
+  {
+    F( 0, 0 ) *= F0_XX;
+    F( 1, 1 ) *= F0_YY;
+    F( 2, 2 ) *= F0_ZZ;
+  }
 
-void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3, 3, 3 >& dT2_dF,
-                                      double                                F0_XX,
-                                      double                                F0_YY,
-                                      double                                F0_ZZ )
-{
-  for ( int i = 0; i < 3; i++ ) {
-    for ( int j = 0; j < 3; j++ ) {
-      dT2_dF( i, j, 0, 0 ) *= F0_XX;
-      dT2_dF( i, j, 1, 1 ) *= F0_YY;
-      dT2_dF( i, j, 2, 2 ) *= F0_ZZ;
+  void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3 >& dT0_dF,
+                                        double                          F0_XX,
+                                        double                          F0_YY,
+                                        double                          F0_ZZ )
+  {
+    dT0_dF( 0, 0 ) *= F0_XX;
+    dT0_dF( 1, 1 ) *= F0_YY;
+    dT0_dF( 2, 2 ) *= F0_ZZ;
+  }
+
+  void applyEigenDeformationToTangent_( Fastor::Tensor< double, 3, 3, 3, 3 >& dT2_dF,
+                                        double                                F0_XX,
+                                        double                                F0_YY,
+                                        double                                F0_ZZ )
+  {
+    for ( int i = 0; i < 3; i++ ) {
+      for ( int j = 0; j < 3; j++ ) {
+        dT2_dF( i, j, 0, 0 ) *= F0_XX;
+        dT2_dF( i, j, 1, 1 ) *= F0_YY;
+        dT2_dF( i, j, 2, 2 ) *= F0_ZZ;
+      }
     }
   }
-}
-void MarmotMaterialFiniteStrain::computeStress( ConstitutiveResponse< 3 >&                  response,
-                                                AlgorithmicModuli< 3 >&                     tangents,
-                                                const Deformation< 3 >&                     deformation,
-                                                const TimeIncrement&                        timeIncrement,
-                                                const std::tuple< double, double, double >& eigenDeformation ) const
-{
-  // TODO: Think about if we simply modify the input increment.
+  void MarmotMaterialFiniteStrain::computeStress( ConstitutiveResponse< 3 >&                  response,
+                                                  AlgorithmicModuli< 3 >&                     tangents,
+                                                  const Deformation< 3 >&                     deformation,
+                                                  const TimeIncrement&                        timeIncrement,
+                                                  const std::tuple< double, double, double >& eigenDeformation ) const
+  {
+    // TODO: Think about if we simply modify the input increment.
 
-  const auto& [F0_XX, F0_YY, F0_ZZ]    = eigenDeformation;
-  auto deformationWithEigenDeformation = deformation;
-  applyEigenDeformation_( deformationWithEigenDeformation.F, F0_XX, F0_YY, F0_ZZ );
+    const auto& [F0_XX, F0_YY, F0_ZZ]    = eigenDeformation;
+    auto deformationWithEigenDeformation = deformation;
+    applyEigenDeformation_( deformationWithEigenDeformation.F, F0_XX, F0_YY, F0_ZZ );
 
-  computeStress( response, tangents, deformationWithEigenDeformation, timeIncrement );
+    computeStress( response, tangents, deformationWithEigenDeformation, timeIncrement );
 
-  applyEigenDeformationToTangent_( tangents.dTau_dF, F0_XX, F0_YY, F0_ZZ );
+    applyEigenDeformationToTangent_( tangents.dTau_dF, F0_XX, F0_YY, F0_ZZ );
 
-  return;
-}
-
-void MarmotMaterialFiniteStrain::computePlaneStrain( ConstitutiveResponse< 3 >& response,
-                                                     AlgorithmicModuli< 3 >&    algorithmicModuli,
-                                                     const Deformation< 3 >&    deformation,
-                                                     const TimeIncrement&       timeIncrement ) const
-{
-  return computeStress( response, algorithmicModuli, deformation, timeIncrement );
-}
-
-void MarmotMaterialFiniteStrain::computePlaneStrain(
-  ConstitutiveResponse< 3 >&                  response,
-  AlgorithmicModuli< 3 >&                     algorithmicModuli,
-  const Deformation< 3 >&                     deformation,
-  const TimeIncrement&                        timeIncrement,
-  const std::tuple< double, double, double >& eigenDeformation ) const
-{
-  return computeStress( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
-}
-
-void MarmotMaterialFiniteStrain::computePlaneStress( ConstitutiveResponse< 2 >& response,
-                                                     AlgorithmicModuli< 2 >&    algorithmicModuli,
-                                                     const Deformation< 2 >&    deformation,
-                                                     const TimeIncrement&       timeIncrement ) const
-{
-  throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented." );
-}
-
-/** The basic implementation here assumes non-chirial, isotropic elastic behavior.
- */
-std::tuple< double, double, double > MarmotMaterialFiniteStrain::findEigenDeformationForEigenStress(
-  const std::tuple< double, double, double >& initialGuess,
-  const std::tuple< double, double, double >& eigenStressComponents,
-  double*                                     stateVars ) const
-{
-  using namespace Marmot;
-
-  Deformation< 3 >          deformation = { 0.0 };
-  ConstitutiveResponse< 3 > response;
-  response.stateVars = stateVars;
-  AlgorithmicModuli< 3 > tangents;
-
-  const double        time[] = { 0.0, 0.0 };
-  const TimeIncrement timeIncrement{ time[0], 0.0 };
-
-  Eigen::Map< Eigen::VectorXd > theStateVars( stateVars, stateLayout.totalSize() );
-
-  auto evaluateStress = [&]( const Vector3d& F0 ) {
-    deformation.F( 0, 0 ) = F0( 0 );
-    deformation.F( 1, 1 ) = F0( 1 );
-    deformation.F( 2, 2 ) = F0( 2 );
-
-    computeStress( response, tangents, deformation, timeIncrement );
-
-    Vector3d tau = { response.tau( 0, 0 ), response.tau( 1, 1 ), response.tau( 2, 2 ) };
-    Matrix3d dTau_dF;
-    dTau_dF << tangents.dTau_dF( 0, 0, 0, 0 ), tangents.dTau_dF( 0, 0, 1, 1 ), tangents.dTau_dF( 0, 0, 2, 2 ),
-      tangents.dTau_dF( 1, 1, 0, 0 ), tangents.dTau_dF( 1, 1, 1, 1 ), tangents.dTau_dF( 1, 1, 2, 2 ),
-      tangents.dTau_dF( 2, 2, 0, 0 ), tangents.dTau_dF( 2, 2, 1, 1 ), tangents.dTau_dF( 2, 2, 2, 2 );
-
-    return std::tuple< Eigen::Vector3d, Eigen::Matrix3d >( tau, dTau_dF );
-  };
-
-  const auto& [F0_XX, F0_YY, F0_ZZ] = initialGuess;
-  const auto& [S_XX, S_YY, S_ZZ]    = eigenStressComponents;
-  Eigen::Vector3d def               = { F0_XX, F0_YY, F0_ZZ };
-  Eigen::Vector3d eigenNormalStress = { S_XX, S_YY, S_ZZ };
-  Eigen::Vector3d R, dF;
-
-  Eigen::VectorXd materialStateVarsBackup = theStateVars;
-
-  int itCounter = 0;
-  while ( true ) {
-    auto [normalStress, dNormalStress_dF] = evaluateStress( def );
-    theStateVars                          = materialStateVarsBackup;
-
-    R = normalStress - eigenNormalStress;
-
-    if ( R.norm() / std::min( normalStress.norm(), 1.0 ) <= 1e-10 )
-      break;
-
-    if ( itCounter > 5 )
-      throw std::invalid_argument( MakeString()
-                                   << __PRETTY_FUNCTION__ << ": failed to find eigen deformation within 5 iterations" );
-
-    itCounter++;
-
-    dF = -dNormalStress_dF.inverse() * R;
-
-    def += dF;
+    return;
   }
 
-  return { def( 0 ), def( 1 ), def( 2 ) };
-}
+  void MarmotMaterialFiniteStrain::computePlaneStrain( ConstitutiveResponse< 3 >& response,
+                                                       AlgorithmicModuli< 3 >&    algorithmicModuli,
+                                                       const Deformation< 3 >&    deformation,
+                                                       const TimeIncrement&       timeIncrement ) const
+  {
+    return computeStress( response, algorithmicModuli, deformation, timeIncrement );
+  }
+
+  void MarmotMaterialFiniteStrain::computePlaneStrain(
+    ConstitutiveResponse< 3 >&                  response,
+    AlgorithmicModuli< 3 >&                     algorithmicModuli,
+    const Deformation< 3 >&                     deformation,
+    const TimeIncrement&                        timeIncrement,
+    const std::tuple< double, double, double >& eigenDeformation ) const
+  {
+    return computeStress( response, algorithmicModuli, deformation, timeIncrement, eigenDeformation );
+  }
+
+  void MarmotMaterialFiniteStrain::computePlaneStress( ConstitutiveResponse< 2 >& response,
+                                                       AlgorithmicModuli< 2 >&    algorithmicModuli,
+                                                       const Deformation< 2 >&    deformation,
+                                                       const TimeIncrement&       timeIncrement ) const
+  {
+    throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << "Not yet implemented." );
+  }
+
+  /** The basic implementation here assumes non-chirial, isotropic elastic behavior.
+   */
+  std::tuple< double, double, double > MarmotMaterialFiniteStrain::findEigenDeformationForEigenStress(
+    const std::tuple< double, double, double >& initialGuess,
+    const std::tuple< double, double, double >& eigenStressComponents,
+    double*                                     stateVars ) const
+  {
+    using namespace Marmot;
+
+    Deformation< 3 >          deformation = { 0.0 };
+    ConstitutiveResponse< 3 > response;
+    response.stateVars = stateVars;
+    AlgorithmicModuli< 3 > tangents;
+
+    const double        time[] = { 0.0, 0.0 };
+    const TimeIncrement timeIncrement{ time[0], 0.0 };
+
+    Eigen::Map< Eigen::VectorXd > theStateVars( stateVars, stateLayout.totalSize() );
+
+    auto evaluateStress = [&]( const Vector3d& F0 ) {
+      deformation.F( 0, 0 ) = F0( 0 );
+      deformation.F( 1, 1 ) = F0( 1 );
+      deformation.F( 2, 2 ) = F0( 2 );
+
+      computeStress( response, tangents, deformation, timeIncrement );
+
+      Vector3d tau = { response.tau( 0, 0 ), response.tau( 1, 1 ), response.tau( 2, 2 ) };
+      Matrix3d dTau_dF;
+      dTau_dF << tangents.dTau_dF( 0, 0, 0, 0 ), tangents.dTau_dF( 0, 0, 1, 1 ), tangents.dTau_dF( 0, 0, 2, 2 ),
+        tangents.dTau_dF( 1, 1, 0, 0 ), tangents.dTau_dF( 1, 1, 1, 1 ), tangents.dTau_dF( 1, 1, 2, 2 ),
+        tangents.dTau_dF( 2, 2, 0, 0 ), tangents.dTau_dF( 2, 2, 1, 1 ), tangents.dTau_dF( 2, 2, 2, 2 );
+
+      return std::tuple< Eigen::Vector3d, Eigen::Matrix3d >( tau, dTau_dF );
+    };
+
+    const auto& [F0_XX, F0_YY, F0_ZZ] = initialGuess;
+    const auto& [S_XX, S_YY, S_ZZ]    = eigenStressComponents;
+    Eigen::Vector3d def               = { F0_XX, F0_YY, F0_ZZ };
+    Eigen::Vector3d eigenNormalStress = { S_XX, S_YY, S_ZZ };
+    Eigen::Vector3d R, dF;
+
+    Eigen::VectorXd materialStateVarsBackup = theStateVars;
+
+    int itCounter = 0;
+    while ( true ) {
+      auto [normalStress, dNormalStress_dF] = evaluateStress( def );
+      theStateVars                          = materialStateVarsBackup;
+
+      R = normalStress - eigenNormalStress;
+
+      if ( R.norm() / std::min( normalStress.norm(), 1.0 ) <= 1e-10 )
+        break;
+
+      if ( itCounter > 5 )
+        throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__
+                                                  << ": failed to find eigen deformation within 5 iterations" );
+
+      itCounter++;
+
+      dF = -dNormalStress_dF.inverse() * R;
+
+      def += dF;
+    }
+
+    return { def( 0 ), def( 1 ), def( 2 ) };
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
@@ -3,10 +3,10 @@
 
 using namespace MarmotLibrary;
 
-MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( const std::string& materialName,
-                                                                               const double*      materialProperties,
-                                                                               int                nMaterialProperties,
-                                                                               int                materialNumber )
+Marmot::MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( const std::string& materialName,
+                                                                                       const double* materialProperties,
+                                                                                       int nMaterialProperties,
+                                                                                       int materialNumber )
 {
   auto& map = materialFactoryFunctionByName();
   auto  it  = map.find( materialName );
@@ -15,7 +15,7 @@ MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( c
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialFiniteStrainFactory.cpp
@@ -1,7 +1,7 @@
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 #include "Marmot/MarmotJournal.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 Marmot::MarmotMaterialFiniteStrain* MarmotMaterialFiniteStrainFactory::createMaterial( const std::string& materialName,
                                                                                        const double* materialProperties,

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialPointSolverFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialPointSolverFiniteStrain.cpp
@@ -11,315 +11,310 @@ using namespace Marmot;
 using namespace Fastor;
 using namespace FastorStandardTensors;
 
-namespace Marmot {
-  namespace Solvers {
+namespace Marmot::Solvers {
 
-    MarmotMaterialPointSolverFiniteStrain::MarmotMaterialPointSolverFiniteStrain( const std::string& materialName,
-                                                                                  const double*      materialProperties,
-                                                                                  const int nMaterialProperties,
-                                                                                  const SolverOptions& options )
-      : options( options )
-    {
-      using namespace Marmot::Registration;
+  MarmotMaterialPointSolverFiniteStrain::MarmotMaterialPointSolverFiniteStrain( const std::string& materialName,
+                                                                                const double*      materialProperties,
+                                                                                const int          nMaterialProperties,
+                                                                                const SolverOptions& options )
+    : options( options )
+  {
+    using namespace Marmot::Registration;
 
-      // create material instance
-      material = std::unique_ptr< MarmotMaterialFiniteStrain >( dynamic_cast< MarmotMaterialFiniteStrain* >(
-        MarmotMaterialFiniteStrainFactory::createMaterial( materialName,
-                                                           materialProperties,
-                                                           nMaterialProperties,
-                                                           1 ) ) );
+    // create material instance
+    material = std::unique_ptr< MarmotMaterialFiniteStrain >( dynamic_cast< MarmotMaterialFiniteStrain* >(
+      MarmotMaterialFiniteStrainFactory::createMaterial( materialName, materialProperties, nMaterialProperties, 1 ) ) );
 
-      // get number of state variables
-      nStateVars = material->getNumberOfRequiredStateVars();
-      // initialize state variables
-      stateVars = Eigen::VectorXd::Zero( nStateVars );
-      // initialize material
-      material->initializeYourself( stateVars.data(), nStateVars );
-      // store initial state
-      _initialStateVars = stateVars;
-      stateVarsTemp     = stateVars;
+    // get number of state variables
+    nStateVars = material->getNumberOfRequiredStateVars();
+    // initialize state variables
+    stateVars = Eigen::VectorXd::Zero( nStateVars );
+    // initialize material
+    material->initializeYourself( stateVars.data(), nStateVars );
+    // store initial state
+    _initialStateVars = stateVars;
+    stateVarsTemp     = stateVars;
+  }
+
+  void MarmotMaterialPointSolverFiniteStrain::addStep( const Step& step )
+  {
+    step.checkControl();
+    steps.push_back( step );
+  }
+
+  void MarmotMaterialPointSolverFiniteStrain::solve()
+  {
+    for ( const auto& step : steps ) {
+      std::cout << "Solving step from " << step.timeStart << " to " << step.timeEnd << std::endl;
+      solveStep( step );
+      std::cout << "+" + std::string( 78, '-' ) + "+" << std::endl;
     }
+  }
 
-    void MarmotMaterialPointSolverFiniteStrain::addStep( const Step& step )
-    {
-      step.checkControl();
-      steps.push_back( step );
-    }
+  void MarmotMaterialPointSolverFiniteStrain::setInitialState( const FastorStandardTensors::Tensor33d& initialStress,
+                                                               const Eigen::VectorXd& initialStateVars )
+  {
+    _initialStress    = initialStress;
+    _initialStateVars = initialStateVars;
+    stress            = _initialStress;
+    stateVars         = _initialStateVars;
+  }
 
-    void MarmotMaterialPointSolverFiniteStrain::solve()
-    {
-      for ( const auto& step : steps ) {
-        std::cout << "Solving step from " << step.timeStart << " to " << step.timeEnd << std::endl;
-        solveStep( step );
+  void MarmotMaterialPointSolverFiniteStrain::resetToInitialState()
+  {
+    stress    = _initialStress;
+    gradU     = Tensor33d( 0.0 );
+    stateVars = _initialStateVars;
+    stateVarsTemp.setZero();
+    history.clear();
+  }
+
+  void MarmotMaterialPointSolverFiniteStrain::solveStep( const Step& step )
+  {
+    double time     = step.timeStart;
+    double dT       = 0.0;
+    double stepTime = step.timeEnd - step.timeStart;
+
+    int counter = 0;
+
+    while ( time < step.timeEnd && counter <= step.maxIncrements ) {
+
+      // adjust time step if overshooting
+      if ( time + dT > step.timeEnd )
+        dT = step.timeEnd - time;
+      if ( counter == 1 )
+        dT = step.dTStart; // use initial time step for the first increment, then adjust based on convergence
+
+      // setup increment
+      Increment increment;
+      increment.timeOld                     = time;
+      increment.dT                          = dT;
+      increment.gradUIncrement              = dT / stepTime * reshape< 9 >( step.gradUIncrementTarget );
+      increment.stressIncrement             = dT / stepTime * reshape< 9 >( step.stressIncrementTarget );
+      increment.isGradUComponentControlled  = reshape< 9 >( step.isGradUComponentControlled );
+      increment.isStressComponentControlled = reshape< 9 >( step.isStressComponentControlled );
+
+      // solve increment
+      try {
         std::cout << "+" + std::string( 78, '-' ) + "+" << std::endl;
+        std::cout << std::scientific << "  Solving increment " << counter + 1 << ", time: " << time << " to "
+                  << time + dT << ", dT: " << dT << std::endl;
+        solveIncrement( increment );
+        history.back().print();
+        time += dT;
+        stateVars = stateVarsTemp;
+        counter++;
+      }
+      catch ( const Marmot::StressUpdateFailed& e ) {
+        // if failed, reduce time step and retry
+        if ( dT <= step.dTMin )
+          throw Marmot::SolverTimestepExhausted( "Minimum time step reached, cannot proceed." );
+        dT = std::max( dT / 2.0, step.dTMin );
       }
     }
 
-    void MarmotMaterialPointSolverFiniteStrain::setInitialState( const FastorStandardTensors::Tensor33d& initialStress,
-                                                                 const Eigen::VectorXd& initialStateVars )
-    {
-      _initialStress    = initialStress;
-      _initialStateVars = initialStateVars;
-      stress            = _initialStress;
-      stateVars         = _initialStateVars;
-    }
+    if ( std::abs( time - step.timeEnd ) > 1e-12 )
+      throw Marmot::SolverIncrementsExhausted( "Maximum number of increments reached, cannot proceed." );
+  }
 
-    void MarmotMaterialPointSolverFiniteStrain::resetToInitialState()
-    {
-      stress    = _initialStress;
-      gradU     = Tensor33d( 0.0 );
-      stateVars = _initialStateVars;
-      stateVarsTemp.setZero();
-      history.clear();
-    }
+  void MarmotMaterialPointSolverFiniteStrain::solveIncrement( const Increment& increment )
+  {
+    // set initial strain increment, set not controlled components to zero
+    // use element-wise multiplication
+    Tensor9d dGradU = increment.gradUIncrement * increment.isGradUComponentControlled.cast< double >();
 
-    void MarmotMaterialPointSolverFiniteStrain::solveStep( const Step& step )
-    {
-      double time     = step.timeStart;
-      double dT       = 0.0;
-      double stepTime = step.timeEnd - step.timeStart;
+    // create the mixed-control target
+    Tensor9d target = reshape< 9 >( increment.stressIncrement );
+    for ( int i = 0; i < 9; i++ )
+      if ( increment.isGradUComponentControlled[i] )
+        target[i] = increment.gradUIncrement[i];
 
-      int counter = 0;
+    int    counter = 0;
+    double resNorm = 1e12;
+    double corNorm = 0.0;
 
-      while ( time < step.timeEnd && counter <= step.maxIncrements ) {
+    // temporary variables for material state
+    MarmotMaterialFiniteStrain::ConstitutiveResponse< 3 > state;
+    MarmotMaterialFiniteStrain::Deformation< 3 >          deformation;
+    MarmotMaterialFiniteStrain::AlgorithmicModuli< 3 >    algorithmicModuli;
+    MarmotMaterialFiniteStrain::TimeIncrement             timeInfo = { increment.timeOld + increment.dT, increment.dT };
 
-        // adjust time step if overshooting
-        if ( time + dT > step.timeEnd )
-          dT = step.timeEnd - time;
-        if ( counter == 1 )
-          dT = step.dTStart; // use initial time step for the first increment, then adjust based on convergence
+    // store identical rows
+    std::vector< std::pair< size_t, size_t > > identicalRows;
 
-        // setup increment
-        Increment increment;
-        increment.timeOld                     = time;
-        increment.dT                          = dT;
-        increment.gradUIncrement              = dT / stepTime * reshape< 9 >( step.gradUIncrementTarget );
-        increment.stressIncrement             = dT / stepTime * reshape< 9 >( step.stressIncrementTarget );
-        increment.isGradUComponentControlled  = reshape< 9 >( step.isGradUComponentControlled );
-        increment.isStressComponentControlled = reshape< 9 >( step.isStressComponentControlled );
+    // Newton-Raphson iteration
+    while ( counter < options.maxIterations ) {
+      std::cout << "    Iteration " << counter;
 
-        // solve increment
-        try {
-          std::cout << "+" + std::string( 78, '-' ) + "+" << std::endl;
-          std::cout << std::scientific << "  Solving increment " << counter + 1 << ", time: " << time << " to "
-                    << time + dT << ", dT: " << dT << std::endl;
-          solveIncrement( increment );
-          history.back().print();
-          time += dT;
-          stateVars = stateVarsTemp;
-          counter++;
-        }
-        catch ( const Marmot::StressUpdateFailed& e ) {
-          // if failed, reduce time step and retry
-          if ( dT <= step.dTMin )
-            throw Marmot::SolverTimestepExhausted( "Minimum time step reached, cannot proceed." );
-          dT = std::max( dT / 2.0, step.dTMin );
-        }
-      }
+      // assign state variables to material
+      stateVarsTemp = stateVars;
 
-      if ( std::abs( time - step.timeEnd ) > 1e-12 )
-        throw Marmot::SolverIncrementsExhausted( "Maximum number of increments reached, cannot proceed." );
-    }
+      // set state to previously converged state
+      state.tau                  = stress;
+      state.elasticEnergyDensity = 0.0;
+      state.stateVars            = stateVarsTemp.data();
 
-    void MarmotMaterialPointSolverFiniteStrain::solveIncrement( const Increment& increment )
-    {
-      // set initial strain increment, set not controlled components to zero
-      // use element-wise multiplication
-      Tensor9d dGradU = increment.gradUIncrement * increment.isGradUComponentControlled.cast< double >();
+      // set deformation gradient
+      deformation.F = Spatial3D::I + gradU + reshape< 3, 3 >( dGradU );
 
-      // create the mixed-control target
-      Tensor9d target = reshape< 9 >( increment.stressIncrement );
-      for ( int i = 0; i < 9; i++ )
-        if ( increment.isGradUComponentControlled[i] )
-          target[i] = increment.gradUIncrement[i];
+      // compute stress and tangent
+      material->computeStress( state, algorithmicModuli, deformation, timeInfo );
 
-      int    counter = 0;
-      double resNorm = 1e12;
-      double corNorm = 0.0;
+      // initialize residual with stress increment
+      Tensor9d residual = computeResidual( state.tau - stress, target, increment );
 
-      // temporary variables for material state
-      MarmotMaterialFiniteStrain::ConstitutiveResponse< 3 > state;
-      MarmotMaterialFiniteStrain::Deformation< 3 >          deformation;
-      MarmotMaterialFiniteStrain::AlgorithmicModuli< 3 >    algorithmicModuli;
-      MarmotMaterialFiniteStrain::TimeIncrement timeInfo = { increment.timeOld + increment.dT, increment.dT };
+      // set tangent
+      Tensor99d fullTangent = reshape< 9, 9 >( algorithmicModuli.dTau_dF );
 
-      // store identical rows
-      std::vector< std::pair< size_t, size_t > > identicalRows;
+      // modify tangent for mixed control
+      modifyTangent( fullTangent, increment );
 
-      // Newton-Raphson iteration
-      while ( counter < options.maxIterations ) {
-        std::cout << "    Iteration " << counter;
+      // find identical rows which will be removed for inversion
+      // only do this in the first iteration
+      if ( counter == 0 ) {
+        Tensor9d rand;
+        rand.random();
 
-        // assign state variables to material
-        stateVarsTemp = stateVars;
-
-        // set state to previously converged state
-        state.tau                  = stress;
-        state.elasticEnergyDensity = 0.0;
-        state.stateVars            = stateVarsTemp.data();
-
-        // set deformation gradient
-        deformation.F = Spatial3D::I + gradU + reshape< 3, 3 >( dGradU );
-
-        // compute stress and tangent
-        material->computeStress( state, algorithmicModuli, deformation, timeInfo );
-
-        // initialize residual with stress increment
-        Tensor9d residual = computeResidual( state.tau - stress, target, increment );
-
-        // set tangent
-        Tensor99d fullTangent = reshape< 9, 9 >( algorithmicModuli.dTau_dF );
-
-        // modify tangent for mixed control
-        modifyTangent( fullTangent, increment );
-
-        // find identical rows which will be removed for inversion
-        // only do this in the first iteration
-        if ( counter == 0 ) {
-          Tensor9d rand;
-          rand.random();
-
-          Tensor9d identicalRowCheck = fullTangent % rand;
-          for ( size_t i = 0; i < 9; ++i ) {
-            Tensor9d diff = abs( identicalRowCheck - identicalRowCheck[i] );
-            for ( size_t j = i + 1; j < 9; ++j ) {
-              if ( diff( j ) < 1e-10 ) {
-                identicalRows.push_back( std::make_pair( i, j ) );
-              }
+        Tensor9d identicalRowCheck = fullTangent % rand;
+        for ( size_t i = 0; i < 9; ++i ) {
+          Tensor9d diff = abs( identicalRowCheck - identicalRowCheck[i] );
+          for ( size_t j = i + 1; j < 9; ++j ) {
+            if ( diff( j ) < 1e-10 ) {
+              identicalRows.push_back( std::make_pair( i, j ) );
             }
           }
         }
-
-        // set the rows of the tangent matrix to zero for the identical rows and diagonal to 1
-        // this ensures that the inversion will work correctly
-        for ( const auto& rowPair : identicalRows ) {
-          fullTangent( rowPair.second, all )            = 0.0;
-          fullTangent( rowPair.second, rowPair.second ) = 1.0;
-          residual( rowPair.second )                    = 0.0;
-        }
-
-        // compute residual norm
-        resNorm = norm( residual );
-
-        std::cout << std::scientific << ", ||ddGradU||: " << corNorm << ", ||R||: " << resNorm << std::endl;
-
-        // if nan encountered
-        if ( std::isnan( resNorm ) || std::isnan( corNorm ) )
-          throw Marmot::SolverConvergenceFailed( "NaN encountered in Newton-Raphson iteration." );
-
-        // convergence check
-        if ( corNorm < options.correctionTolerance && resNorm < options.residualTolerance )
-          break;
-
-        // if not converged,
-        if ( counter == options.maxIterations - 1 )
-          throw Marmot::SolverConvergenceFailed( "Maximum number of iterations reached, no convergence." );
-
-        // solve for correction
-        Tensor9d correction = Fastor::solve( fullTangent, residual );
-
-        // set the correction for the identical rows to the correction of the first row
-        for ( const auto& rowPair : identicalRows ) {
-          correction( rowPair.second ) = correction( rowPair.first );
-        }
-
-        // compute correction norm
-        corNorm = norm( correction );
-
-        // update displacement gradient increment
-        dGradU -= correction;
-        counter++;
       }
 
-      std::cout << "    Converged after " << counter << " iterations." << std::endl;
+      // set the rows of the tangent matrix to zero for the identical rows and diagonal to 1
+      // this ensures that the inversion will work correctly
+      for ( const auto& rowPair : identicalRows ) {
+        fullTangent( rowPair.second, all )            = 0.0;
+        fullTangent( rowPair.second, rowPair.second ) = 1.0;
+        residual( rowPair.second )                    = 0.0;
+      }
 
-      stress = state.tau;
-      gradU += dGradU;
-      dTau_dF = algorithmicModuli.dTau_dF;
+      // compute residual norm
+      resNorm = norm( residual );
 
-      // copy back updated state variables
-      stateVars = stateVarsTemp;
-      history.push_back(
-        HistoryEntry( increment.timeOld + increment.dT, stress, Spatial3D::I + gradU, dTau_dF, stateVars ) );
+      std::cout << std::scientific << ", ||ddGradU||: " << corNorm << ", ||R||: " << resNorm << std::endl;
+
+      // if nan encountered
+      if ( std::isnan( resNorm ) || std::isnan( corNorm ) )
+        throw Marmot::SolverConvergenceFailed( "NaN encountered in Newton-Raphson iteration." );
+
+      // convergence check
+      if ( corNorm < options.correctionTolerance && resNorm < options.residualTolerance )
+        break;
+
+      // if not converged,
+      if ( counter == options.maxIterations - 1 )
+        throw Marmot::SolverConvergenceFailed( "Maximum number of iterations reached, no convergence." );
+
+      // solve for correction
+      Tensor9d correction = Fastor::solve( fullTangent, residual );
+
+      // set the correction for the identical rows to the correction of the first row
+      for ( const auto& rowPair : identicalRows ) {
+        correction( rowPair.second ) = correction( rowPair.first );
+      }
+
+      // compute correction norm
+      corNorm = norm( correction );
+
+      // update displacement gradient increment
+      dGradU -= correction;
+      counter++;
     }
 
-    FastorStandardTensors::Tensor9d MarmotMaterialPointSolverFiniteStrain::computeResidual(
-      const FastorStandardTensors::Tensor9d& stressIncrement,
-      const FastorStandardTensors::Tensor9d& target,
-      const Increment&                       increment )
-    {
-      Tensor9d residual = stressIncrement;
-      // replace displacement gradient controlled components
-      for ( int i = 0; i < 9; i++ )
-        if ( increment.isGradUComponentControlled[i] )
-          residual[i] = increment.gradUIncrement[i];
+    std::cout << "    Converged after " << counter << " iterations." << std::endl;
 
-      residual -= target;
+    stress = state.tau;
+    gradU += dGradU;
+    dTau_dF = algorithmicModuli.dTau_dF;
 
-      return residual;
-    }
+    // copy back updated state variables
+    stateVars = stateVarsTemp;
+    history.push_back(
+      HistoryEntry( increment.timeOld + increment.dT, stress, Spatial3D::I + gradU, dTau_dF, stateVars ) );
+  }
 
-    void MarmotMaterialPointSolverFiniteStrain::modifyTangent( FastorStandardTensors::Tensor99d& tangent,
-                                                               const Increment&                  increment )
-    {
-      // modify the tangent matrix based on control type
-      for ( int i = 0; i < 9; i++ ) {
-        if ( increment.isGradUComponentControlled[i] ) {
-          tangent( i, all ) = 0.0;
-          tangent( i, i )   = 1.0;
-        }
+  FastorStandardTensors::Tensor9d MarmotMaterialPointSolverFiniteStrain::computeResidual(
+    const FastorStandardTensors::Tensor9d& stressIncrement,
+    const FastorStandardTensors::Tensor9d& target,
+    const Increment&                       increment )
+  {
+    Tensor9d residual = stressIncrement;
+    // replace displacement gradient controlled components
+    for ( int i = 0; i < 9; i++ )
+      if ( increment.isGradUComponentControlled[i] )
+        residual[i] = increment.gradUIncrement[i];
+
+    residual -= target;
+
+    return residual;
+  }
+
+  void MarmotMaterialPointSolverFiniteStrain::modifyTangent( FastorStandardTensors::Tensor99d& tangent,
+                                                             const Increment&                  increment )
+  {
+    // modify the tangent matrix based on control type
+    for ( int i = 0; i < 9; i++ ) {
+      if ( increment.isGradUComponentControlled[i] ) {
+        tangent( i, all ) = 0.0;
+        tangent( i, i )   = 1.0;
       }
     }
+  }
 
-    void MarmotMaterialPointSolverFiniteStrain::printHistory()
-    {
-      std::cout << "Material Point History:" << std::endl;
-      for ( const auto& entry : history ) {
-        entry.print();
-      }
+  void MarmotMaterialPointSolverFiniteStrain::printHistory()
+  {
+    std::cout << "Material Point History:" << std::endl;
+    for ( const auto& entry : history ) {
+      entry.print();
     }
+  }
 
-    void MarmotMaterialPointSolverFiniteStrain::exportHistoryToCSV( const std::string& filename )
-    {
-      std::ofstream file( filename );
-      if ( !file.is_open() )
-        throw std::runtime_error( "Could not open file for writing: " + filename );
+  void MarmotMaterialPointSolverFiniteStrain::exportHistoryToCSV( const std::string& filename )
+  {
+    std::ofstream file( filename );
+    if ( !file.is_open() )
+      throw std::runtime_error( "Could not open file for writing: " + filename );
 
-      // write header with fixed-width formatting
-      const int w           = 15;
-      const int ordering[9] = { 11, 12, 13, 21, 22, 23, 31, 32, 33 };
-      file << std::scientific << "#" << std::setw( w - 1 ) << "Time,";
+    // write header with fixed-width formatting
+    const int w           = 15;
+    const int ordering[9] = { 11, 12, 13, 21, 22, 23, 31, 32, 33 };
+    file << std::scientific << "#" << std::setw( w - 1 ) << "Time,";
 
-      // get ordering from array and write stress and strain components
+    // get ordering from array and write stress and strain components
+    for ( int i = 0; i < 9; i++ )
+      file << std::setw( w ) << "tau" + std::to_string( ordering[i] ) + ",";
+
+    for ( int i = 0; i < 9; i++ )
+      file << std::setw( w ) << "F" + std::to_string( ordering[i] ) + ",";
+
+    for ( int i = 0; i < nStateVars; i++ )
+      file << std::setw( w - ( i < nStateVars - 1 ? 1 : 2 ) ) << "SV" << i + 1 << ( i < nStateVars - 1 ? "," : "\n" );
+    if ( nStateVars == 0 )
+      file << "\n";
+
+    // write data with fixed-width formatting
+    for ( const auto& entry : history ) {
+      file << std::scientific << std::setw( w - 1 ) << entry.time << ",";
+
       for ( int i = 0; i < 9; i++ )
-        file << std::setw( w ) << "tau" + std::to_string( ordering[i] ) + ",";
+        file << std::setw( w - 1 ) << flatten( entry.stress )[i] << ( i < 8 ? "," : "," );
 
       for ( int i = 0; i < 9; i++ )
-        file << std::setw( w ) << "F" + std::to_string( ordering[i] ) + ",";
+        file << std::setw( w - 1 ) << flatten( entry.F )[i] << ( i < 8 ? "," : ( nStateVars > 0 ? "," : "\n" ) );
 
       for ( int i = 0; i < nStateVars; i++ )
-        file << std::setw( w - ( i < nStateVars - 1 ? 1 : 2 ) ) << "SV" << i + 1 << ( i < nStateVars - 1 ? "," : "\n" );
+        file << std::setw( w - 1 ) << entry.stateVars[i] << ( i < nStateVars - 1 ? "," : "\n" );
       if ( nStateVars == 0 )
         file << "\n";
-
-      // write data with fixed-width formatting
-      for ( const auto& entry : history ) {
-        file << std::scientific << std::setw( w - 1 ) << entry.time << ",";
-
-        for ( int i = 0; i < 9; i++ )
-          file << std::setw( w - 1 ) << flatten( entry.stress )[i] << ( i < 8 ? "," : "," );
-
-        for ( int i = 0; i < 9; i++ )
-          file << std::setw( w - 1 ) << flatten( entry.F )[i] << ( i < 8 ? "," : ( nStateVars > 0 ? "," : "\n" ) );
-
-        for ( int i = 0; i < nStateVars; i++ )
-          file << std::setw( w - 1 ) << entry.stateVars[i] << ( i < nStateVars - 1 ? "," : "\n" );
-        if ( nStateVars == 0 )
-          file << "\n";
-      }
-
-      file.close();
     }
 
-  } // namespace Solvers
-} // namespace Marmot
+    file.close();
+  }
+
+} // namespace Marmot::Solvers

--- a/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialPointSolverFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/src/MarmotMaterialPointSolverFiniteStrain.cpp
@@ -20,7 +20,7 @@ namespace Marmot {
                                                                                   const SolverOptions& options )
       : options( options )
     {
-      using namespace MarmotLibrary;
+      using namespace Marmot::Registration;
 
       // create material instance
       material = std::unique_ptr< MarmotMaterialFiniteStrain >( dynamic_cast< MarmotMaterialFiniteStrain* >(

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotEnergyDensityFunctions.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotEnergyDensityFunctions.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotEnergyDensityFunctions.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainPlasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainPlasticity.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotFiniteStrainPlasticity.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainViscoelasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainViscoelasticity.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstring>
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 using namespace Marmot::ContinuumMechanics::FiniteStrain::Viscoelasticity;

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotDecreasingInteractions.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotDecreasingInteractions.h
@@ -27,60 +27,56 @@
 #include <cmath>
 #include <tuple>
 
-namespace Marmot::GradientDamage {
+namespace Marmot::GradientDamage::DecreasingInteractions {
 
-  namespace DecreasingInteractions {
+  /**
+   * @brief Damage dependent nonlocal interaction function acc. Poh & Sun (2017)
+   * @param omega damage variable
+   * @param eta parameter controlling the rate of decrease of interactions with damage
+   * @param R parameter controlling the residual interactions at full damage
+   * @tparam T type of the interaction function value (e.g., double, dual, etc.)
+   * @return interaction function value
+   *
+   * @details The function is defined as:
+   * \f[ g(\omega) = \frac{(1 - R) \exp(-\eta \, \omega) + R - \exp(-\eta) }{ 1 - \exp(-\eta)} \f]
+   * where \f$ \omega \f$ is the damage variable, \f$ \eta \f$ controls the rate of decrease of interactions with
+   * damage, and \f$ R \f$ controls the residual interactions at full damage. The function is designed to decrease as
+   * damage increases, with a residual interaction value of \f$ R \f$ at full damage (\f$ \omega = 1 \f$).
+   *
+   */
+  template < typename T >
+  T poh( T omega, double eta, double R )
+  {
+    const T g = ( ( 1. - R ) * exp( -eta * omega ) + R - exp( -eta ) ) / ( 1. - exp( -eta ) );
+    return g;
+  }
+
+  namespace FirstOrderDerived {
 
     /**
-     * @brief Damage dependent nonlocal interaction function acc. Poh & Sun (2017)
+     * @brief First-order derivative of the Poh & Sun (2017) interaction function with respect to damage
      * @param omega damage variable
      * @param eta parameter controlling the rate of decrease of interactions with damage
      * @param R parameter controlling the residual interactions at full damage
-     * @tparam T type of the interaction function value (e.g., double, dual, etc.)
-     * @return interaction function value
-     *
-     * @details The function is defined as:
-     * \f[ g(\omega) = \frac{(1 - R) \exp(-\eta \, \omega) + R - \exp(-\eta) }{ 1 - \exp(-\eta)} \f]
-     * where \f$ \omega \f$ is the damage variable, \f$ \eta \f$ controls the rate of decrease of interactions with
-     * damage, and \f$ R \f$ controls the residual interactions at full damage. The function is designed to decrease as
-     * damage increases, with a residual interaction value of \f$ R \f$ at full damage (\f$ \omega = 1 \f$).
-     *
+     * @return a tuple containing the interaction function value and its first derivative with respect to damage
+     * @details The first-order derivative variant of the interaction function @p poh.
      */
-    template < typename T >
-    T poh( T omega, double eta, double R )
-    {
-      const T g = ( ( 1. - R ) * exp( -eta * omega ) + R - exp( -eta ) ) / ( 1. - exp( -eta ) );
-      return g;
-    }
+    std::tuple< double, double > poh( double omega, double eta, double R );
 
-    namespace FirstOrderDerived {
+  } // namespace FirstOrderDerived
 
-      /**
-       * @brief First-order derivative of the Poh & Sun (2017) interaction function with respect to damage
-       * @param omega damage variable
-       * @param eta parameter controlling the rate of decrease of interactions with damage
-       * @param R parameter controlling the residual interactions at full damage
-       * @return a tuple containing the interaction function value and its first derivative with respect to damage
-       * @details The first-order derivative variant of the interaction function @p poh.
-       */
-      std::tuple< double, double > poh( double omega, double eta, double R );
+  namespace SecondOrderDerived {
 
-    } // namespace FirstOrderDerived
+    /**
+     * @brief Second-order derivative of the Poh & Sun (2017) interaction function with respect to damage
+     * @param omega damage variable
+     * @param eta parameter controlling the rate of decrease of interactions with damage
+     * @param R parameter controlling the residual interactions at full damage
+     * @return a tuple containing the interaction function value, its first derivative, and its second derivative with
+     * respect to damage
+     * @details The second-order derivative variant of the interaction function @p poh.
+     */
+    std::tuple< double, double, double > poh( double omega, double eta, double R );
 
-    namespace SecondOrderDerived {
-
-      /**
-       * @brief Second-order derivative of the Poh & Sun (2017) interaction function with respect to damage
-       * @param omega damage variable
-       * @param eta parameter controlling the rate of decrease of interactions with damage
-       * @param R parameter controlling the residual interactions at full damage
-       * @return a tuple containing the interaction function value, its first derivative, and its second derivative with
-       * respect to damage
-       * @details The second-order derivative variant of the interaction function @p poh.
-       */
-      std::tuple< double, double, double > poh( double omega, double eta, double R );
-
-    } // namespace SecondOrderDerived
-  }   // namespace DecreasingInteractions
-
-} // namespace Marmot::GradientDamage
+  } // namespace SecondOrderDerived
+} // namespace Marmot::GradientDamage::DecreasingInteractions

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
@@ -187,7 +187,6 @@ namespace Marmot {
      */
     virtual void computePlaneStress( response& res, tangents& tan, const increment& inc ) const
     {
-      using namespace Marmot;
       using namespace Eigen;
 
       Map< VectorXd > stateVars( res.stateVars, stateLayout.totalSize() );

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h
@@ -32,316 +32,324 @@
 #include <cmath>
 #include <vector>
 
-/**
- * @brief Base class for general gradient-enhanced hypoelastic material models.
- * @details This class defines the interface for general gradient-enhanced hypoelastic material models,
- * including methods for computing stress, plane stress response, and managing state variables.
- * The template parameter `nNonlocalVariables` specifies the number of nonlocal variables used in the material model.
- *
- * In addition to the standard balance of linear momentum each nonlocal variable introduces an additional balance
- * equation, which is solved simultaneously with the balance of linear momentum. This balance equation is defined as:
- * \f[ \knl_i - \nabla ( c( \knl_i )\, \nabla \knl_i ) = s_i (\boldsymbol \varepsilon,\, \knl_i ) \f]
- * where \f$ \knl_i \f$ is the nonlocal variable, \f$ c( \knl_i ) \f$ is the nonlocal interaction parameter, and
- * \f$ s_i \f$ is the local driving variable for the nonlocal variable \f$ \knl_i \f$. The interaction
- * parameter
- * \f$ c( \knl_i ) \f$ defines the influence of the nonlocal variable on its own gradient and can be used to model
- * phenomena such as damage-dependent interactions. Also phase-field models can be implemented in this framework by
- * defining the nonlocal variable as the phase-field variable and the local driving variable as a function of the strain
- * tensor.
- */
-template < int nNonlocalVariables >
-class MarmotMaterialGeneralGradientEnhancedHypoElastic {
-
-protected:
-  /// @brief Pointer to the array of material properties.
-  const double* materialProperties;
-  /// @brief Number of material properties.
-  const int nMaterialProperties;
-
-public:
-  /// @brief Material number (identifier for the material).
-  const int materialNumber;
+namespace Marmot {
 
   /**
-   * @brief Constructor for the general gradient-enhanced hypoelastic material model.
-   * @param matProperties_ Pointer to the array of material properties.
-   * @param nMaterialProperties_ Number of material properties.
-   * @param materialNumber_ Material number (identifier for the material).
-   */
-  MarmotMaterialGeneralGradientEnhancedHypoElastic( const double* matProperties_,
-                                                    int           nMaterialProperties_,
-                                                    int           materialNumber_ )
-    : materialProperties( matProperties_ ),
-      nMaterialProperties( nMaterialProperties_ ),
-      materialNumber( materialNumber_ )
-  {
-  }
-
-  /**
-   * @brief Virtual destructor.
+   * @brief Base class for general gradient-enhanced hypoelastic material models.
+   * @details This class defines the interface for general gradient-enhanced hypoelastic material models,
+   * including methods for computing stress, plane stress response, and managing state variables.
+   * The template parameter `nNonlocalVariables` specifies the number of nonlocal variables used in the material model.
    *
-   * This class is abstract and instances are owned through base-class pointers
-   * (e.g. the std::unique_ptr held by the gradient-enhanced elements), so the
-   * destructor must be virtual — destroying a derived object through a base
-   * pointer with a non-virtual destructor is undefined behaviour. libstdc++
-   * silently invokes the wrong destructor, while libc++/clang diagnoses it
-   * (-Wdelete-abstract-non-virtual-dtor) and emits a trap instruction, which
-   * aborted every simulation using such a material on macOS/arm64.
+   * In addition to the standard balance of linear momentum each nonlocal variable introduces an additional balance
+   * equation, which is solved simultaneously with the balance of linear momentum. This balance equation is defined as:
+   * \f[ \knl_i - \nabla ( c( \knl_i )\, \nabla \knl_i ) = s_i (\boldsymbol \varepsilon,\, \knl_i ) \f]
+   * where \f$ \knl_i \f$ is the nonlocal variable, \f$ c( \knl_i ) \f$ is the nonlocal interaction parameter, and
+   * \f$ s_i \f$ is the local driving variable for the nonlocal variable \f$ \knl_i \f$. The interaction
+   * parameter
+   * \f$ c( \knl_i ) \f$ defines the influence of the nonlocal variable on its own gradient and can be used to model
+   * phenomena such as damage-dependent interactions. Also phase-field models can be implemented in this framework by
+   * defining the nonlocal variable as the phase-field variable and the local driving variable as a function of the
+   * strain tensor.
    */
-  virtual ~MarmotMaterialGeneralGradientEnhancedHypoElastic() = default;
+  template < int nNonlocalVariables >
+  class MarmotMaterialGeneralGradientEnhancedHypoElastic {
 
-  /// @brief Struct to hold the increment information.
-  struct increment {
-    Marmot::Vector6d                            dStrain; ///< Increment of the strain tensor in Voigt notation
-    Eigen::Vector< double, nNonlocalVariables > K;       ///< Nonlocal variables at the current increment
-    Eigen::Vector< double, nNonlocalVariables > dK;      ///< Increment of the nonlocal variables
-    double                                      time;    ///< Current time
-    double                                      dT;      ///< Time increment
-  };
+  protected:
+    /// @brief Pointer to the array of material properties.
+    const double* materialProperties;
+    /// @brief Number of material properties.
+    const int nMaterialProperties;
 
-  /// @brief Struct to hold the material response information.
-  struct response {
-    Marmot::Vector6d                            stress;    ///< Stress tensor in Voigt notation
-    Eigen::Vector< double, nNonlocalVariables > KLocal;    ///< Local driving variables at the current increment
-    Eigen::Vector< double, nNonlocalVariables > c;         ///< Nonlocal interaction parameters at the current increment
-    double*                                     stateVars; ///< Pointer to the array of state variables
-    double                                      elasticEnergyDensity; ///< Elastic strain energy density
-    double                                      dissipation;          ///< Dissipation (if applicable)
-  };
+  public:
+    /// @brief Material number (identifier for the material).
+    const int materialNumber;
 
-  /// @brief Struct to hold the algorithmic tangent matrices for the material model.
-  struct tangents {
-    /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of strain.
-    Marmot::Matrix6d dStressddStrain = Marmot::Matrix6d::Zero();
-    /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of nonlocal variables.
-    Eigen::Matrix< double, 6, nNonlocalVariables > dStressddK = Eigen::Matrix< double, 6, nNonlocalVariables >::Zero();
-    /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of strain.
-    Eigen::Matrix< double, nNonlocalVariables, 6 >
-      dKLocalddStrain = Eigen::Matrix< double, nNonlocalVariables, 6 >::Zero();
-    /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of nonlocal
-    /// variables.
-    Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
-      dKLocalddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
-    /// @brief First derivative of nonlocal interaction parameters with respect to nonlocal variables.
-    Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
-      dcddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
-    /// @brief Second derivative of nonlocal interaction parameters with respect to nonlocal variables.
-    Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
-      d2cddK2 = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
-  };
-
-  /**
-   * @brief Layout of the state variables for the material model.
-   * @note Must be defined in derived classes to specify the structure and organization of the state variables used in
-   * the material model.
-   */
-  MarmotStateLayoutDynamic stateLayout;
-
-  /**
-   * @brief Compute the stress response of the material model including the algorithmic tangents.
-   * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
-   * variables.
-   * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method must be implemented in derived classes to compute the stress response based on the specific material
-   * model.
-   */
-  virtual void computeStress( response& res, tangents& tan, const increment& inc ) const = 0;
-
-  /**
-   * @brief Compute the stress response of the material model.
-   * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
-   * variables.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method can be used when only the stress response is needed without the tangents, e.g., for explicit dynamics.
-   * The default implementation calls the `computeStress` method and ignores the tangents, which can be computationally
-   * expensive to compute.
-   */
-  virtual void computeStressExplicit( response& res, const increment& inc ) const
-  {
-    tangents tan;
-    computeStress( res, tan, inc );
-  }
-
-  /**
-   * @brief Compute the plane stress response of the material model.
-   * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other response
-   * variables.
-   * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices for
-   * plane stress.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method provides a default implementation for computing the plane stress response using an iterative approach.
-   * It assumes an initial guess of isochoric deformation and iteratively corrects the out-of-plane strain until
-   * convergence is achieved. Derived classes can override this method if a different approach for plane stress
-   * computation is desired.
-   */
-  virtual void computePlaneStress( response& res, tangents& tan, const increment& inc ) const
-  {
-    using namespace Marmot;
-    using namespace Eigen;
-
-    Map< VectorXd > stateVars( res.stateVars, stateLayout.totalSize() );
-
-    VectorXd  stateVarsOld = stateVars;
-    response  resTemp = { res.stress, res.KLocal, res.c, res.stateVars, res.elasticEnergyDensity, res.dissipation };
-    increment incTemp = { inc.dStrain, inc.K, inc.dK, inc.time, inc.dT };
-
-    double residual          = 1;
-    double tangentCompliance = 1.;
-    // assumption of isochoric deformation for initial guess
-    double strainIncrement = ( -incTemp.dStrain( 0 ) - incTemp.dStrain( 1 ) );
-    incTemp.dStrain( 2 )   = strainIncrement;
-
-    int planeStressCount = 1;
-    while ( true ) {
-
-      // set old response
-      resTemp = { .stress               = res.stress,
-                  .KLocal               = res.KLocal,
-                  .c                    = res.c,
-                  .stateVars            = res.stateVars,
-                  .elasticEnergyDensity = res.elasticEnergyDensity,
-                  .dissipation          = res.dissipation };
-      // set old state variables
-      stateVars = stateVarsOld;
-      // compute stress
-      computeStress( resTemp, tan, incTemp );
-
-      // evauate residual
-      residual = std::abs( resTemp.stress.array().abs()[2] / std::max( resTemp.stress.array().abs().maxCoeff(), 1. ) );
-      if ( ( residual < 1e-10 && std::abs( strainIncrement ) < 1e-8 ) || ( planeStressCount > 7 && residual < 1e-5 ) ) {
-        break;
-      }
-
-      // correct strain increment
-      tangentCompliance = 1. / tan.dStressddStrain( 2, 2 );
-      if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 ) {
-        tangentCompliance = 1e10;
-      }
-
-      strainIncrement = -resTemp.stress( 2 ) * tangentCompliance;
-      incTemp.dStrain( 2 ) += strainIncrement;
-
-      planeStressCount += 1;
-      if ( planeStressCount > 13 ) {
-        throw Marmot::StressUpdateFailed( "PlaneStressWrapper requires cutback" );
-      }
+    /**
+     * @brief Constructor for the general gradient-enhanced hypoelastic material model.
+     * @param matProperties_ Pointer to the array of material properties.
+     * @param nMaterialProperties_ Number of material properties.
+     * @param materialNumber_ Material number (identifier for the material).
+     */
+    MarmotMaterialGeneralGradientEnhancedHypoElastic( const double* matProperties_,
+                                                      int           nMaterialProperties_,
+                                                      int           materialNumber_ )
+      : materialProperties( matProperties_ ),
+        nMaterialProperties( nMaterialProperties_ ),
+        materialNumber( materialNumber_ )
+    {
     }
 
-    res = resTemp;
-  }
+    /**
+     * @brief Virtual destructor.
+     *
+     * This class is abstract and instances are owned through base-class pointers
+     * (e.g. the std::unique_ptr held by the gradient-enhanced elements), so the
+     * destructor must be virtual — destroying a derived object through a base
+     * pointer with a non-virtual destructor is undefined behaviour. libstdc++
+     * silently invokes the wrong destructor, while libc++/clang diagnoses it
+     * (-Wdelete-abstract-non-virtual-dtor) and emits a trap instruction, which
+     * aborted every simulation using such a material on macOS/arm64.
+     */
+    virtual ~MarmotMaterialGeneralGradientEnhancedHypoElastic() = default;
 
-  /**
-   * @brief Compute the plane stress response of the material model without computing tangents.
-   * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other response
-   * variables.
-   * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments, and
-   * time information.
-   *
-   * This method can be used when only the plane stress response is needed without the tangents, e.g., for explicit
-   * dynamics. The default implementation calls the `computePlaneStress` method ignoring the tangents.
-   * This method maybe overridden in derived classes if a different approach for plane stress computation is desired.
-   */
-  virtual void computePlaneStressExplicit( response& res, const increment& inc ) const
-  {
-    tangents tan;
-    computePlaneStress( res, tan, inc );
-  }
+    /// @brief Struct to hold the increment information.
+    struct increment {
+      Marmot::Vector6d                            dStrain; ///< Increment of the strain tensor in Voigt notation
+      Eigen::Vector< double, nNonlocalVariables > K;       ///< Nonlocal variables at the current increment
+      Eigen::Vector< double, nNonlocalVariables > dK;      ///< Increment of the nonlocal variables
+      double                                      time;    ///< Current time
+      double                                      dT;      ///< Time increment
+    };
 
-  /**
-   * @brief Get a view to the state variables.
-   * @param stateName Name of the state variable
-   * @param stateVars Pointer to the state variable array
-   * @return StatView to access the state variable
-   */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
-  {
-    return stateLayout.getStateView( stateVars, stateName );
-  }
+    /// @brief Struct to hold the material response information.
+    struct response {
+      Marmot::Vector6d                            stress; ///< Stress tensor in Voigt notation
+      Eigen::Vector< double, nNonlocalVariables > KLocal; ///< Local driving variables at the current increment
+      Eigen::Vector< double, nNonlocalVariables > c;      ///< Nonlocal interaction parameters at the current increment
+      double*                                     stateVars;            ///< Pointer to the array of state variables
+      double                                      elasticEnergyDensity; ///< Elastic strain energy density
+      double                                      dissipation;          ///< Dissipation (if applicable)
+    };
 
-  /**
-   * @brief Get the total number of required state variables.
-   * @return Total number of required state variables
-   */
-  int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
+    /// @brief Struct to hold the algorithmic tangent matrices for the material model.
+    struct tangents {
+      /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of strain.
+      Marmot::Matrix6d dStressddStrain = Marmot::Matrix6d::Zero();
+      /// @brief Algorithmic tangent matrix relating the increment of stress to the increment of nonlocal variables.
+      Eigen::Matrix< double, 6, nNonlocalVariables >
+        dStressddK = Eigen::Matrix< double, 6, nNonlocalVariables >::Zero();
+      /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of
+      /// strain.
+      Eigen::Matrix< double, nNonlocalVariables, 6 >
+        dKLocalddStrain = Eigen::Matrix< double, nNonlocalVariables, 6 >::Zero();
+      /// @brief Algorithmic tangent matrix relating the increment of local driving variables to the increment of
+      /// nonlocal variables.
+      Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
+        dKLocalddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
+      /// @brief First derivative of nonlocal interaction parameters with respect to nonlocal variables.
+      Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
+        dcddK = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
+      /// @brief Second derivative of nonlocal interaction parameters with respect to nonlocal variables.
+      Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >
+        d2cddK2 = Eigen::Matrix< double, nNonlocalVariables, nNonlocalVariables >::Zero();
+    };
 
-  /**
-   * @brief Initialize the state variables at a material point.
-   * @param stateVars Pointer to the state variable array
-   * @param nStateVars Number of state variables
-   *
-   * @note The default implementation initializes all state variables to zero.
-   */
-  virtual void initializeYourself( double* stateVars, int nStateVars )
-  {
-    for ( int i = 0; i < nStateVars; ++i ) {
-      stateVars[i] = 0.0;
+    /**
+     * @brief Layout of the state variables for the material model.
+     * @note Must be defined in derived classes to specify the structure and organization of the state variables used in
+     * the material model.
+     */
+    MarmotStateLayoutDynamic stateLayout;
+
+    /**
+     * @brief Compute the stress response of the material model including the algorithmic tangents.
+     * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
+     * variables.
+     * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method must be implemented in derived classes to compute the stress response based on the specific material
+     * model.
+     */
+    virtual void computeStress( response& res, tangents& tan, const increment& inc ) const = 0;
+
+    /**
+     * @brief Compute the stress response of the material model.
+     * @param[in,out] res Reference to the response struct to be filled with the computed stress and other response
+     * variables.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method can be used when only the stress response is needed without the tangents, e.g., for explicit
+     * dynamics. The default implementation calls the `computeStress` method and ignores the tangents, which can be
+     * computationally expensive to compute.
+     */
+    virtual void computeStressExplicit( response& res, const increment& inc ) const
+    {
+      tangents tan;
+      computeStress( res, tan, inc );
     }
-  }
-  /**
-   * @brief Get the density of the material.
-   * @param stateVars Pointer to the array of state variables
-   * @return Density of the material
-   *
-   * This method must be implemented in derived classes to return the density of the material, which is required for
-   * dynamic analyses.
-   */
-  virtual double getDensity( const double* stateVars ) const = 0;
 
-  /**
-   * @brief Get the maximum wave speed for the current response state.
-   * @param currentResponse Current response state
-   * @return Maximum wave speed
-   * @details The default implementation computes the 3D algorithmic tangent and returns
-   *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
-   */
-  virtual double getMaximumWaveSpeed( const response& currentResponse ) const
-  {
-    const int nStateVars = getNumberOfRequiredStateVars();
+    /**
+     * @brief Compute the plane stress response of the material model.
+     * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other
+     * response variables.
+     * @param[in,out] tan Reference to the tangents struct to be filled with the computed algorithmic tangent matrices
+     * for plane stress.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method provides a default implementation for computing the plane stress response using an iterative
+     * approach. It assumes an initial guess of isochoric deformation and iteratively corrects the out-of-plane strain
+     * until convergence is achieved. Derived classes can override this method if a different approach for plane stress
+     * computation is desired.
+     */
+    virtual void computePlaneStress( response& res, tangents& tan, const increment& inc ) const
+    {
+      using namespace Marmot;
+      using namespace Eigen;
 
-    std::vector< double > stateVarsCopy( nStateVars, 0.0 );
-    if ( currentResponse.stateVars != nullptr && nStateVars > 0 ) {
-      std::copy_n( currentResponse.stateVars, nStateVars, stateVarsCopy.begin() );
+      Map< VectorXd > stateVars( res.stateVars, stateLayout.totalSize() );
+
+      VectorXd  stateVarsOld = stateVars;
+      response  resTemp = { res.stress, res.KLocal, res.c, res.stateVars, res.elasticEnergyDensity, res.dissipation };
+      increment incTemp = { inc.dStrain, inc.K, inc.dK, inc.time, inc.dT };
+
+      double residual          = 1;
+      double tangentCompliance = 1.;
+      // assumption of isochoric deformation for initial guess
+      double strainIncrement = ( -incTemp.dStrain( 0 ) - incTemp.dStrain( 1 ) );
+      incTemp.dStrain( 2 )   = strainIncrement;
+
+      int planeStressCount = 1;
+      while ( true ) {
+
+        // set old response
+        resTemp = { .stress               = res.stress,
+                    .KLocal               = res.KLocal,
+                    .c                    = res.c,
+                    .stateVars            = res.stateVars,
+                    .elasticEnergyDensity = res.elasticEnergyDensity,
+                    .dissipation          = res.dissipation };
+        // set old state variables
+        stateVars = stateVarsOld;
+        // compute stress
+        computeStress( resTemp, tan, incTemp );
+
+        // evauate residual
+        residual = std::abs( resTemp.stress.array().abs()[2] /
+                             std::max( resTemp.stress.array().abs().maxCoeff(), 1. ) );
+        if ( ( residual < 1e-10 && std::abs( strainIncrement ) < 1e-8 ) ||
+             ( planeStressCount > 7 && residual < 1e-5 ) ) {
+          break;
+        }
+
+        // correct strain increment
+        tangentCompliance = 1. / tan.dStressddStrain( 2, 2 );
+        if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 ) {
+          tangentCompliance = 1e10;
+        }
+
+        strainIncrement = -resTemp.stress( 2 ) * tangentCompliance;
+        incTemp.dStrain( 2 ) += strainIncrement;
+
+        planeStressCount += 1;
+        if ( planeStressCount > 13 ) {
+          throw Marmot::StressUpdateFailed( "PlaneStressWrapper requires cutback" );
+        }
+      }
+
+      res = resTemp;
     }
 
-    response responseCopy  = currentResponse;
-    responseCopy.stateVars = stateVarsCopy.data();
+    /**
+     * @brief Compute the plane stress response of the material model without computing tangents.
+     * @param[in,out] res Reference to the response struct to be filled with the computed plane stress and other
+     * response variables.
+     * @param[in] inc Reference to the increment struct containing the strain increment, nonlocal variable increments,
+     * and time information.
+     *
+     * This method can be used when only the plane stress response is needed without the tangents, e.g., for explicit
+     * dynamics. The default implementation calls the `computePlaneStress` method ignoring the tangents.
+     * This method maybe overridden in derived classes if a different approach for plane stress computation is desired.
+     */
+    virtual void computePlaneStressExplicit( response& res, const increment& inc ) const
+    {
+      tangents tan;
+      computePlaneStress( res, tan, inc );
+    }
 
-    tangents  tan;
-    increment inc;
-    inc.dStrain = Marmot::Vector6d::Zero();
-    inc.K       = Eigen::Vector< double, nNonlocalVariables >::Zero();
-    inc.dK      = Eigen::Vector< double, nNonlocalVariables >::Zero();
-    inc.time    = 0.0;
-    inc.dT      = 1.0;
+    /**
+     * @brief Get a view to the state variables.
+     * @param stateName Name of the state variable
+     * @param stateVars Pointer to the state variable array
+     * @return StatView to access the state variable
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const
+    {
+      return stateLayout.getStateView( stateVars, stateName );
+    }
 
-    computeStress( responseCopy, tan, inc );
+    /**
+     * @brief Get the total number of required state variables.
+     * @return Total number of required state variables
+     */
+    int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
 
-    const double maxStiffnessDiagonal = std::max( { tan.dStressddStrain( 0, 0 ),
-                                                    tan.dStressddStrain( 1, 1 ),
-                                                    tan.dStressddStrain( 2, 2 ),
-                                                    tan.dStressddStrain( 3, 3 ),
-                                                    tan.dStressddStrain( 4, 4 ),
-                                                    tan.dStressddStrain( 5, 5 ) } );
-    const double density              = getDensity( responseCopy.stateVars );
+    /**
+     * @brief Initialize the state variables at a material point.
+     * @param stateVars Pointer to the state variable array
+     * @param nStateVars Number of state variables
+     *
+     * @note The default implementation initializes all state variables to zero.
+     */
+    virtual void initializeYourself( double* stateVars, int nStateVars )
+    {
+      for ( int i = 0; i < nStateVars; ++i ) {
+        stateVars[i] = 0.0;
+      }
+    }
+    /**
+     * @brief Get the density of the material.
+     * @param stateVars Pointer to the array of state variables
+     * @return Density of the material
+     *
+     * This method must be implemented in derived classes to return the density of the material, which is required for
+     * dynamic analyses.
+     */
+    virtual double getDensity( const double* stateVars ) const = 0;
 
-    return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
-  }
+    /**
+     * @brief Get the maximum wave speed for the current response state.
+     * @param currentResponse Current response state
+     * @return Maximum wave speed
+     * @details The default implementation computes the 3D algorithmic tangent and returns
+     *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
+     */
+    virtual double getMaximumWaveSpeed( const response& currentResponse ) const
+    {
+      const int nStateVars = getNumberOfRequiredStateVars();
 
-  /**
-   * @brief Get the nonlocal viscosity of the material.
-   * @param stateVars Pointer to the array of state variables
-   * @return Vector containing the nonlocal viscosity values for each nonlocal variable
-   *
-   * This method must be implemented in derived classes to return the nonlocal viscosity values, which are required for
-   * dynamic analyses involving nonlocal variables. The returned vector should have a length equal to
-   * `nNonlocalVariables`.
-   */
-  virtual std::vector< double > getNonlocalViscosity( const double* stateVars ) const = 0;
-};
+      std::vector< double > stateVarsCopy( nStateVars, 0.0 );
+      if ( currentResponse.stateVars != nullptr && nStateVars > 0 ) {
+        std::copy_n( currentResponse.stateVars, nStateVars, stateVarsCopy.begin() );
+      }
+
+      response responseCopy  = currentResponse;
+      responseCopy.stateVars = stateVarsCopy.data();
+
+      tangents  tan;
+      increment inc;
+      inc.dStrain = Marmot::Vector6d::Zero();
+      inc.K       = Eigen::Vector< double, nNonlocalVariables >::Zero();
+      inc.dK      = Eigen::Vector< double, nNonlocalVariables >::Zero();
+      inc.time    = 0.0;
+      inc.dT      = 1.0;
+
+      computeStress( responseCopy, tan, inc );
+
+      const double maxStiffnessDiagonal = std::max( { tan.dStressddStrain( 0, 0 ),
+                                                      tan.dStressddStrain( 1, 1 ),
+                                                      tan.dStressddStrain( 2, 2 ),
+                                                      tan.dStressddStrain( 3, 3 ),
+                                                      tan.dStressddStrain( 4, 4 ),
+                                                      tan.dStressddStrain( 5, 5 ) } );
+      const double density              = getDensity( responseCopy.stateVars );
+
+      return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
+    }
+
+    /**
+     * @brief Get the nonlocal viscosity of the material.
+     * @param stateVars Pointer to the array of state variables
+     * @return Vector containing the nonlocal viscosity values for each nonlocal variable
+     *
+     * This method must be implemented in derived classes to return the nonlocal viscosity values, which are required
+     * for dynamic analyses involving nonlocal variables. The returned vector should have a length equal to
+     * `nNonlocalVariables`.
+     */
+    virtual std::vector< double > getNonlocalViscosity( const double* stateVars ) const = 0;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
@@ -41,7 +41,7 @@ namespace MarmotLibrary {
   public:
     /// Type alias for the material factory function, which creates instances of
     /// MarmotMaterialGeneralGradientEnhancedHypoElastic.
-    using materialFactoryFunction = std::function< MarmotMaterialGeneralGradientEnhancedHypoElastic<
+    using materialFactoryFunction = std::function< Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic<
       nNonlocalVariables >*( const double* materialProperties, int nMaterialProperties, int materialNumber ) >;
 
     MarmotMaterialGeneralGradientEnhancedHypoElasticFactory() = delete;
@@ -54,7 +54,7 @@ namespace MarmotLibrary {
      * @param[in] materialNumber Unique identifier for the material instance.
      * @return Pointer to the created MarmotMaterial instance, or nullptr if creation failed.
      */
-    static MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* createMaterial(
+    static Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* createMaterial(
       const std::string& materialName,
       const double*      materialProperties,
       int                nMaterialProperties,
@@ -73,7 +73,7 @@ namespace MarmotLibrary {
       assert( map.find( materialName ) == map.end() && "Material already registered!" );
 
       map[materialName] = []( const double* materialProperties, int nMaterialProperties, int materialNumber )
-        -> MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* {
+        -> Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >* {
         return new T( materialProperties, nMaterialProperties, materialNumber );
       };
       return true;

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @brief Factory class for creating MarmotMaterialGeneralGradientEnhancedHypoElastic instances.
@@ -83,4 +83,4 @@ namespace MarmotLibrary {
     /// @brief Get the map of material factory functions by material name.
     static MaterialFactoryMap& materialFactoryFunctionByName();
   };
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotPhaseFieldEnergyDegradation.h
+++ b/modules/core/MarmotGradientMechanicsCore/include/Marmot/MarmotPhaseFieldEnergyDegradation.h
@@ -28,145 +28,142 @@
 #include <cmath>
 #include <tuple>
 
-namespace Marmot::PhaseField {
+namespace Marmot::PhaseField::EnergyDegradationFunctions {
+  // degradation functions acc. Kuhn, Schlüter, Müller (2015)
 
-  namespace EnergyDegradationFunctions {
-    // degradation functions acc. Kuhn, Schlüter, Müller (2015)
+  /**
+   * @brief Quadratic degradation function.
+   * @param pf Phase field variable.
+   * @tparam T Numeric type (e.g., double, float).
+   * @return Degradation function value.
+   * @details This function is defined as
+   * \f[ g(\phi) = (1 - \phi)^2,\f]
+   * where \f$\phi\f$ is the phase field variable.
+   * It represents a quadratic degradation of the material stiffness as the phase field variable increases.
+   */
+  template < typename T >
+  T quadratic( const T pf )
+  {
+    return pow( 1. - pf, 2 );
+  }
+
+  /**
+   * @brief Cubic degradation function.
+   * @param pf Phase field variable.
+   * @tparam T Numeric type (e.g., double, float).
+   * @return Degradation function value.
+   * @details This function is defined as
+   * \f[ g(\phi) = 3(1 - \phi)^2 - 2(1 - \phi)^3,\f]
+   * where \f$\phi\f$ is the phase field variable.
+   * It represents a cubic degradation of the material stiffness as the phase field variable increases,
+   * providing a smoother transition compared to the quadratic function.
+   */
+  template < typename T >
+  T cubic( const T pf )
+  {
+    const T s = 1. - pf;
+    return 3. * pow( s, 2 ) - 2. * pow( s, 3 );
+  }
+
+  /**
+   * @brief Quartic degradation function.
+   * @param pf Phase field variable.
+   * @tparam T Numeric type (e.g., double, float).
+   * @return Degradation function value.
+   * @details This function is defined as
+   * \f[ g(\phi) = 4(1 - \phi)^3 - 3(1 - \phi)^4,\f]
+   * where \f$\phi\f$ is the phase field variable.
+   * It represents a quartic degradation of the material stiffness as the phase field variable increases,
+   * providing an even smoother transition compared to the cubic function.
+   */
+  template < typename T >
+  T quartic( const T pf )
+  {
+    const T s = 1. - pf;
+    return 4 * pow( s, 3 ) - 3 * pow( s, 4 );
+  }
+
+  /**
+   * @brief Generic degradation function acc. to Wu, JMPS (2017).
+   * @param pf Phase field variable.
+   * @param p Exponent parameter controlling the shape of the degradation function.
+   * @param a1 Coefficient for the linear term in the denominator.
+   * @param a2 Coefficient for the quadratic term in the denominator.
+   * @param a3 Coefficient for the cubic term in the denominator.
+   * @tparam T Numeric type (e.g., double, float).
+   * @return Degradation function value.
+   * @details This function is defined as
+   * \f[ g(\phi) = \frac{(1 - \phi)^p}{(1 - \phi)^p + a_1 \phi (1 + a_2 \phi (1 + a_3 \phi))},\f]
+   * where \f$\phi\f$ is the phase field variable, and \f$p\f$, \f$a_1\f$, \f$a_2\f$, and \f$a_3\f$ are parameters
+   * that control the shape of the degradation function. This generic form allows for a wide range of degradation
+   * behaviors by adjusting the parameters accordingly.
+   */
+  template < typename T >
+  T generic( const T pf, const double p, const double a1, const double a2, const double a3 )
+  {
+    const T s      = 1. - pf;
+    const T P      = 1. + a2 * pf * ( 1. + a3 * pf );
+    const T Q      = a1 * pf * P;
+    const T result = pow( s, p ) / ( pow( s, p ) + Q );
+
+    return result;
+  }
+
+  namespace SecondOrderDerived {
 
     /**
-     * @brief Quadratic degradation function.
+     * @brief Quadratic degradation function and its first and second derivatives.
      * @param pf Phase field variable.
-     * @tparam T Numeric type (e.g., double, float).
-     * @return Degradation function value.
-     * @details This function is defined as
-     * \f[ g(\phi) = (1 - \phi)^2,\f]
-     * where \f$\phi\f$ is the phase field variable.
-     * It represents a quadratic degradation of the material stiffness as the phase field variable increases.
+     * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
+     * respect to the phase field variable.
+     * @details This function returns the value of the quadratic degradation function along with its first and second
+     * derivatives. The degradation function is defined as \f[ g(\phi) = (1 - \phi)^2,\f] and its derivatives are
+     * given by \f[ g'(\phi) = -2(1 - \phi), \quad g''(\phi) = 2. \f]
      */
-    template < typename T >
-    T quadratic( const T pf )
-    {
-      return pow( 1. - pf, 2 );
-    }
+    std::tuple< double, double, double > quadratic( const double pf );
 
     /**
-     * @brief Cubic degradation function.
+     * @brief Cubic degradation function and its first and second derivatives.
      * @param pf Phase field variable.
-     * @tparam T Numeric type (e.g., double, float).
-     * @return Degradation function value.
-     * @details This function is defined as
-     * \f[ g(\phi) = 3(1 - \phi)^2 - 2(1 - \phi)^3,\f]
-     * where \f$\phi\f$ is the phase field variable.
-     * It represents a cubic degradation of the material stiffness as the phase field variable increases,
-     * providing a smoother transition compared to the quadratic function.
+     * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
+     * respect to the phase field variable.
+     * @details This function returns the value of the cubic degradation function along with its first and second
+     * derivatives. The degradation function is defined as \f[ g(\phi) = 3(1 - \phi)^2 - 2(1 - \phi)^3,\f] and its
+     * derivatives are given by \f[ g'(\phi) = -6(1 - \phi)\phi, \quad g''(\phi) = 12\phi - 6. \f]
      */
-    template < typename T >
-    T cubic( const T pf )
-    {
-      const T s = 1. - pf;
-      return 3. * pow( s, 2 ) - 2. * pow( s, 3 );
-    }
+    std::tuple< double, double, double > cubic( const double pf );
 
     /**
-     * @brief Quartic degradation function.
+     * @brief Quartic degradation function and its first and second derivatives.
      * @param pf Phase field variable.
-     * @tparam T Numeric type (e.g., double, float).
-     * @return Degradation function value.
-     * @details This function is defined as
-     * \f[ g(\phi) = 4(1 - \phi)^3 - 3(1 - \phi)^4,\f]
-     * where \f$\phi\f$ is the phase field variable.
-     * It represents a quartic degradation of the material stiffness as the phase field variable increases,
-     * providing an even smoother transition compared to the cubic function.
+     * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
+     * respect to the phase field variable.
+     * @details This function returns the value of the quartic degradation function along with its first and second
+     * derivatives. The degradation function is defined as \f[ g(\phi) = 4(1 - \phi)^3 - 3(1 - \phi)^4,\f] and its
+     * derivatives are given by \f[ g'(\phi) = -12(1 - \phi)^2 + 12(1 - \phi)^3, \quad g''(\phi) = 24(1 - \phi) -
+     * 36(1 - \phi)^2. \f]
      */
-    template < typename T >
-    T quartic( const T pf )
-    {
-      const T s = 1. - pf;
-      return 4 * pow( s, 3 ) - 3 * pow( s, 4 );
-    }
+    std::tuple< double, double, double > quartic( const double pf );
 
     /**
-     * @brief Generic degradation function acc. to Wu, JMPS (2017).
+     * @brief Generic degradation function and its first and second derivatives.
      * @param pf Phase field variable.
      * @param p Exponent parameter controlling the shape of the degradation function.
      * @param a1 Coefficient for the linear term in the denominator.
      * @param a2 Coefficient for the quadratic term in the denominator.
      * @param a3 Coefficient for the cubic term in the denominator.
-     * @tparam T Numeric type (e.g., double, float).
-     * @return Degradation function value.
-     * @details This function is defined as
-     * \f[ g(\phi) = \frac{(1 - \phi)^p}{(1 - \phi)^p + a_1 \phi (1 + a_2 \phi (1 + a_3 \phi))},\f]
-     * where \f$\phi\f$ is the phase field variable, and \f$p\f$, \f$a_1\f$, \f$a_2\f$, and \f$a_3\f$ are parameters
-     * that control the shape of the degradation function. This generic form allows for a wide range of degradation
-     * behaviors by adjusting the parameters accordingly.
+     * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
+     * respect to the phase field variable.
+     * @details This function returns the value of the generic degradation function along with its first and second
+     * derivatives. The degradation function is defined as \f[ g(\phi) = \frac{(1 - \phi)^p}{(1 - \phi)^p + a_1 \phi
+     * (1 + a_2 \phi (1 + a_3 \phi))},\f] where \f$\phi\f$ is the phase field variable, and \f$p\f$, \f$a_1\f$,
+     * \f$a_2\f$, and \f$a_3\f$ are parameters that control the shape of the degradation function. The first and
+     * second derivatives are computed using automatic differentiation with hyper-dual numbers.
      */
-    template < typename T >
-    T generic( const T pf, const double p, const double a1, const double a2, const double a3 )
-    {
-      const T s      = 1. - pf;
-      const T P      = 1. + a2 * pf * ( 1. + a3 * pf );
-      const T Q      = a1 * pf * P;
-      const T result = pow( s, p ) / ( pow( s, p ) + Q );
-
-      return result;
-    }
-
-    namespace SecondOrderDerived {
-
-      /**
-       * @brief Quadratic degradation function and its first and second derivatives.
-       * @param pf Phase field variable.
-       * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
-       * respect to the phase field variable.
-       * @details This function returns the value of the quadratic degradation function along with its first and second
-       * derivatives. The degradation function is defined as \f[ g(\phi) = (1 - \phi)^2,\f] and its derivatives are
-       * given by \f[ g'(\phi) = -2(1 - \phi), \quad g''(\phi) = 2. \f]
-       */
-      std::tuple< double, double, double > quadratic( const double pf );
-
-      /**
-       * @brief Cubic degradation function and its first and second derivatives.
-       * @param pf Phase field variable.
-       * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
-       * respect to the phase field variable.
-       * @details This function returns the value of the cubic degradation function along with its first and second
-       * derivatives. The degradation function is defined as \f[ g(\phi) = 3(1 - \phi)^2 - 2(1 - \phi)^3,\f] and its
-       * derivatives are given by \f[ g'(\phi) = -6(1 - \phi)\phi, \quad g''(\phi) = 12\phi - 6. \f]
-       */
-      std::tuple< double, double, double > cubic( const double pf );
-
-      /**
-       * @brief Quartic degradation function and its first and second derivatives.
-       * @param pf Phase field variable.
-       * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
-       * respect to the phase field variable.
-       * @details This function returns the value of the quartic degradation function along with its first and second
-       * derivatives. The degradation function is defined as \f[ g(\phi) = 4(1 - \phi)^3 - 3(1 - \phi)^4,\f] and its
-       * derivatives are given by \f[ g'(\phi) = -12(1 - \phi)^2 + 12(1 - \phi)^3, \quad g''(\phi) = 24(1 - \phi) -
-       * 36(1 - \phi)^2. \f]
-       */
-      std::tuple< double, double, double > quartic( const double pf );
-
-      /**
-       * @brief Generic degradation function and its first and second derivatives.
-       * @param pf Phase field variable.
-       * @param p Exponent parameter controlling the shape of the degradation function.
-       * @param a1 Coefficient for the linear term in the denominator.
-       * @param a2 Coefficient for the quadratic term in the denominator.
-       * @param a3 Coefficient for the cubic term in the denominator.
-       * @return A tuple containing the degradation function value, its first derivative, and its second derivative with
-       * respect to the phase field variable.
-       * @details This function returns the value of the generic degradation function along with its first and second
-       * derivatives. The degradation function is defined as \f[ g(\phi) = \frac{(1 - \phi)^p}{(1 - \phi)^p + a_1 \phi
-       * (1 + a_2 \phi (1 + a_3 \phi))},\f] where \f$\phi\f$ is the phase field variable, and \f$p\f$, \f$a_1\f$,
-       * \f$a_2\f$, and \f$a_3\f$ are parameters that control the shape of the degradation function. The first and
-       * second derivatives are computed using automatic differentiation with hyper-dual numbers.
-       */
-      std::tuple< double, double, double > generic( const double pf,
-                                                    const double p,
-                                                    const double a1,
-                                                    const double a2,
-                                                    const double a3 );
-    }; // namespace SecondOrderDerived
-  };   // namespace EnergyDegradationFunctions
-};     // namespace Marmot::PhaseField
+    std::tuple< double, double, double > generic( const double pf,
+                                                  const double p,
+                                                  const double a1,
+                                                  const double a2,
+                                                  const double a3 );
+  }; // namespace SecondOrderDerived
+} // namespace Marmot::PhaseField::EnergyDegradationFunctions

--- a/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
@@ -12,7 +12,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 1 >::MaterialFactoryMap
 }
 
 template <>
-MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
   1 >::createMaterial( const std::string& materialName,
                        const double*      materialProperties,
                        int                nMaterialProperties,
@@ -25,7 +25,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >* MarmotMaterialGeneralGrad
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 
@@ -41,7 +41,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 2 >::MaterialFactoryMap
 }
 
 template <>
-MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
   2 >::createMaterial( const std::string& materialName,
                        const double*      materialProperties,
                        int                nMaterialProperties,
@@ -54,7 +54,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 >* MarmotMaterialGeneralGrad
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 
@@ -70,7 +70,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 6 >::MaterialFactoryMap
 }
 
 template <>
-MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+Marmot::MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 >* MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
   6 >::createMaterial( const std::string& materialName,
                        const double*      materialProperties,
                        int                nMaterialProperties,
@@ -83,7 +83,7 @@ MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 >* MarmotMaterialGeneralGrad
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 

--- a/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
@@ -1,7 +1,7 @@
 #include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h"
 #include "Marmot/MarmotJournal.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 template <>
 MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 1 >::MaterialFactoryMap& MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<

--- a/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialPhaseFieldEnergyDegradation.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/src/MarmotMaterialPhaseFieldEnergyDegradation.cpp
@@ -2,54 +2,46 @@
 #include <autodiff/forward/dual.hpp>
 #include <cmath>
 
-namespace Marmot::PhaseField {
+namespace Marmot::PhaseField::EnergyDegradationFunctions::SecondOrderDerived {
 
-  namespace EnergyDegradationFunctions {
+  std::tuple< double, double, double > quadratic( const double pf )
+  {
 
-    namespace SecondOrderDerived {
+    const double s      = 1. - pf;
+    const double ds_dpf = -1.;
+    return { s * s, ds_dpf * 2. * s, 2. };
+  }
 
-      std::tuple< double, double, double > quadratic( const double pf )
-      {
+  std::tuple< double, double, double > cubic( const double pf )
+  {
 
-        const double s      = 1. - pf;
-        const double ds_dpf = -1.;
-        return { s * s, ds_dpf * 2. * s, 2. };
-      }
+    const double s      = 1. - pf;
+    const double ds_dpf = -1.;
 
-      std::tuple< double, double, double > cubic( const double pf )
-      {
+    return { 3 * s * s - 2 * s * s * s, ds_dpf * 6 * s - ds_dpf * 6 * s * s, 6 - 12 * s };
+  }
+  std::tuple< double, double, double > quartic( const double pf )
+  {
 
-        const double s      = 1. - pf;
-        const double ds_dpf = -1.;
+    const double s      = 1. - pf;
+    const double ds_dpf = -1.;
 
-        return { 3 * s * s - 2 * s * s * s, ds_dpf * 6 * s - ds_dpf * 6 * s * s, 6 - 12 * s };
-      }
-      std::tuple< double, double, double > quartic( const double pf )
-      {
+    return { 4 * s * s * s - 3 * s * s * s * s, ds_dpf * 12 * s * s - ds_dpf * 12 * s * s * s, 24 * s - 36 * s * s };
+  }
+  std::tuple< double, double, double > generic( const double pf,
+                                                const double p,
+                                                const double a1,
+                                                const double a2,
+                                                const double a3 )
+  {
 
-        const double s      = 1. - pf;
-        const double ds_dpf = -1.;
+    using namespace autodiff;
+    autodiff::dual2nd pf_dual( pf );
+    autodiff::seed< 1 >( pf_dual, 1 );
+    autodiff::seed< 2 >( pf_dual, 1 );
 
-        return { 4 * s * s * s - 3 * s * s * s * s,
-                 ds_dpf * 12 * s * s - ds_dpf * 12 * s * s * s,
-                 24 * s - 36 * s * s };
-      }
-      std::tuple< double, double, double > generic( const double pf,
-                                                    const double p,
-                                                    const double a1,
-                                                    const double a2,
-                                                    const double a3 )
-      {
+    const dual2nd result = Marmot::PhaseField::EnergyDegradationFunctions::generic( pf_dual, p, a1, a2, a3 );
 
-        using namespace autodiff;
-        autodiff::dual2nd pf_dual( pf );
-        autodiff::seed< 1 >( pf_dual, 1 );
-        autodiff::seed< 2 >( pf_dual, 1 );
-
-        const dual2nd result = Marmot::PhaseField::EnergyDegradationFunctions::generic( pf_dual, p, a1, a2, a3 );
-
-        return { result.val.val, derivative< 1 >( result ), derivative< 2 >( result ) };
-      }
-    }; // namespace SecondOrderDerived
-  }    // namespace EnergyDegradationFunctions
-};     // namespace Marmot::PhaseField
+    return { result.val.val, derivative< 1 >( result ), derivative< 2 >( result ) };
+  }
+} // namespace Marmot::PhaseField::EnergyDegradationFunctions::SecondOrderDerived

--- a/modules/core/MarmotGradientMechanicsCore/test/TestMarmotDecreasingInteractions.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/test/TestMarmotDecreasingInteractions.cpp
@@ -4,6 +4,7 @@
 #include "Marmot/MarmotTesting.h"
 #include <cmath>
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::NumericalAlgorithms::Differentiation;
 using namespace Marmot::GradientDamage::DecreasingInteractions;

--- a/modules/core/MarmotGradientMechanicsCore/test/TestMarmotPhaseFieldEnergyDegradation.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/test/TestMarmotPhaseFieldEnergyDegradation.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotPhaseFieldEnergyDegradation.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::NumericalAlgorithms::Differentiation;
 using namespace Marmot::PhaseField::EnergyDegradationFunctions;

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotAutomaticDifferentiation.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotAutomaticDifferentiation.h
@@ -28,239 +28,235 @@
 #include <autodiff/forward/dual/dual.hpp>
 #include <functional>
 
-namespace Marmot {
+namespace Marmot::AutomaticDifferentiation {
 
-  namespace AutomaticDifferentiation {
+  using namespace autodiff;
+  using namespace Eigen;
 
-    using namespace autodiff;
-    using namespace Eigen;
+  /** @brief Creates a 2nd order hyper-dual number from a dual number
+   *  @param x Input dual number
+   *  @return 2nd order hyper-dual number
+   *
+   *  This function takes a dual number as input and returns a 2nd order hyper-dual number.
+   *  This is done by keeping the real part and shifting the first derivative part to the second derivative part.
+   */
+  dual2nd shiftTo2ndOrderDual( const dual& x );
 
-    /** @brief Creates a 2nd order hyper-dual number from a dual number
-     *  @param x Input dual number
-     *  @return 2nd order hyper-dual number
-     *
-     *  This function takes a dual number as input and returns a 2nd order hyper-dual number.
-     *  This is done by keeping the real part and shifting the first derivative part to the second derivative part.
-     */
-    dual2nd shiftTo2ndOrderDual( const dual& x );
+  /** @brief Creates a vector of 2nd order hyper-dual numbers from a vector of dual numbers
+   *  @param X Input vector of dual numbers
+   *  @return Vector of 2nd order hyper-dual numbers
+   *
+   *  This function takes a vector of dual numbers as input and returns a vector of 2nd order hyper-dual numbers.
+   *  This is done by keeping the real part and shifting the first derivative part to the second derivative part for
+   * each element in the vector.
+   */
+  VectorXdual2nd shiftTo2ndOrderDual( const VectorXdual& X );
 
-    /** @brief Creates a vector of 2nd order hyper-dual numbers from a vector of dual numbers
-     *  @param X Input vector of dual numbers
-     *  @return Vector of 2nd order hyper-dual numbers
-     *
-     *  This function takes a vector of dual numbers as input and returns a vector of 2nd order hyper-dual numbers.
-     *  This is done by keeping the real part and shifting the first derivative part to the second derivative part for
-     * each element in the vector.
-     */
-    VectorXdual2nd shiftTo2ndOrderDual( const VectorXdual& X );
+  /** @brief Access the value node of a dual number at a specific order
+   *  @tparam order The order of the dual number to access
+   *  @tparam T The type of the value stored in the dual number
+   *  @tparam G The type of the gradient stored in the dual number
+   *  @param dual The dual number to access
+   *  @return A reference to the value node at the specified order
+   *
+   *  This function recursively accesses the value node of a dual number at a specific order.
+   *  It uses template metaprogramming to ensure that the order is valid for the given dual number type.
+   *  If the order is 0, it returns the value of the dual number. If the order is greater than 0,
+   *  it recursively calls itself on the value of the dual number until it reaches the desired order.
+   */
+  template < size_t order, typename T, typename G >
+  const auto& valnode( const Dual< T, G >& dual )
+  {
+    constexpr auto N = detail::Order< Dual< T, G > >;
+    static_assert( order <= N );
+    if constexpr ( order == 0 )
+      return dual.val;
+    else if constexpr ( order == 1 )
+      return dual.val;
+    else
+      return valnode< order - 1 >( dual.val );
+  }
 
-    /** @brief Access the value node of a dual number at a specific order
-     *  @tparam order The order of the dual number to access
-     *  @tparam T The type of the value stored in the dual number
-     *  @tparam G The type of the gradient stored in the dual number
-     *  @param dual The dual number to access
-     *  @return A reference to the value node at the specified order
-     *
-     *  This function recursively accesses the value node of a dual number at a specific order.
-     *  It uses template metaprogramming to ensure that the order is valid for the given dual number type.
-     *  If the order is 0, it returns the value of the dual number. If the order is greater than 0,
-     *  it recursively calls itself on the value of the dual number until it reaches the desired order.
-     */
-    template < size_t order, typename T, typename G >
-    const auto& valnode( const Dual< T, G >& dual )
-    {
-      constexpr auto N = detail::Order< Dual< T, G > >;
-      static_assert( order <= N );
-      if constexpr ( order == 0 )
-        return dual.val;
-      else if constexpr ( order == 1 )
-        return dual.val;
-      else
-        return valnode< order - 1 >( dual.val );
+  template < size_t order, typename T, typename G >
+  auto& valnode( Dual< T, G >& dual )
+  {
+    constexpr auto N = detail::Order< Dual< T, G > >;
+    static_assert( order <= N );
+    if constexpr ( order == 0 )
+      return dual.val;
+    else if constexpr ( order == 1 )
+      return dual.val;
+    else
+      return valnode< order - 1 >( dual.val );
+  }
+
+  /** @brief Increases the order of a hyper-dual number by 1
+   *  @tparam order The current order of the dual number
+   *  @param in The input dual number
+   *  @return A new dual number with order increased by 1
+   *
+   *  This function takes a dual number of a given order and creates a new dual number with the order increased by 1.
+   *  The derivative parts are elevated (shifted) one order.
+   */
+  template < size_t order >
+  autodiff::HigherOrderDual< order + 1, double > increaseDualOrderWithShift(
+    const autodiff::HigherOrderDual< order, double >& in )
+  {
+    using out_scalar_type = autodiff::HigherOrderDual< order + 1, double >;
+    using namespace autodiff::detail;
+
+    out_scalar_type out( 0.0 );
+    const double*   in_point  = &valnode< order >( in );
+    double*         out_point = &valnode< order + 1 >( out );
+
+    for ( size_t i = 0; i < size_t( std::pow( 2, order ) ); i++ ) {
+      *( out_point + i ) = *( in_point + i );
     }
 
-    template < size_t order, typename T, typename G >
-    auto& valnode( Dual< T, G >& dual )
-    {
-      constexpr auto N = detail::Order< Dual< T, G > >;
-      static_assert( order <= N );
-      if constexpr ( order == 0 )
-        return dual.val;
-      else if constexpr ( order == 1 )
-        return dual.val;
-      else
-        return valnode< order - 1 >( dual.val );
+    return out;
+  }
+
+  /** @brief Decreases the order of a hyper-dual number by 1
+   *  @tparam order The current order of the dual number
+   *  @param in The input dual number
+   *  @return A new dual number with order decreased by 1
+   *
+   *  This function takes a dual number of a given order and creates a new dual number with the order decreased by 1.
+   *  The derivative parts are copied to the lower order dual number.
+   *  The highest derivative part of the input dual number is discarded.
+   */
+  template < size_t order >
+  autodiff::HigherOrderDual< order - 1, double > decreaseDualOrder( autodiff::HigherOrderDual< order, double >& in )
+  {
+    using out_scalar_type = autodiff::HigherOrderDual< order - 1, double >;
+    using namespace autodiff::detail;
+
+    out_scalar_type out( 0.0 );
+    double*         in_point  = &valnode< order >( in );
+    double*         out_point = &valnode< order - 1 >( out );
+
+    for ( size_t i = 0; i < size_t( std::pow( 2, order - 1 ) ); i++ ) {
+      *( out_point + i ) = *( in_point + i );
     }
 
-    /** @brief Increases the order of a hyper-dual number by 1
-     *  @tparam order The current order of the dual number
-     *  @param in The input dual number
-     *  @return A new dual number with order increased by 1
-     *
-     *  This function takes a dual number of a given order and creates a new dual number with the order increased by 1.
-     *  The derivative parts are elevated (shifted) one order.
-     */
-    template < size_t order >
-    autodiff::HigherOrderDual< order + 1, double > increaseDualOrderWithShift(
-      const autodiff::HigherOrderDual< order, double >& in )
-    {
-      using out_scalar_type = autodiff::HigherOrderDual< order + 1, double >;
-      using namespace autodiff::detail;
+    return out;
+  }
 
-      out_scalar_type out( 0.0 );
-      const double*   in_point  = &valnode< order >( in );
-      double*         out_point = &valnode< order + 1 >( out );
+  /** @brief Decreases the order of a hyper-dual number by 1 with a shift
+   *  @tparam order The current order of the dual number
+   *  @param in The input dual number
+   *  @return A new dual number with order decreased by 1
+   *
+   *  This function takes a dual number of a given order and creates a new dual number with the order decreased by 1.
+   *  The derivative parts are shifted down by one order.
+   *  The first derivative part of the input dual number is discarded.
+   */
+  template < size_t order >
+  autodiff::HigherOrderDual< order - 1, double > decreaseDualOrderWithShift(
+    autodiff::HigherOrderDual< order, double >& in )
+  {
+    using out_scalar_type = autodiff::HigherOrderDual< order - 1, double >;
+    using namespace autodiff::detail;
 
-      for ( size_t i = 0; i < size_t( std::pow( 2, order ) ); i++ ) {
-        *( out_point + i ) = *( in_point + i );
-      }
+    out_scalar_type out( 0.0 );
+    double*         in_point  = &valnode< order >( in );
+    double*         out_point = &valnode< order - 1 >( out );
 
-      return out;
+    for ( size_t i = 0; i < size_t( std::pow( 2, order - 1 ) ); i++ ) {
+      *( out_point + i ) = *( in_point + i + size_t( std::pow( 2, order - 1 ) ) );
     }
 
-    /** @brief Decreases the order of a hyper-dual number by 1
-     *  @tparam order The current order of the dual number
-     *  @param in The input dual number
-     *  @return A new dual number with order decreased by 1
-     *
-     *  This function takes a dual number of a given order and creates a new dual number with the order decreased by 1.
-     *  The derivative parts are copied to the lower order dual number.
-     *  The highest derivative part of the input dual number is discarded.
-     */
-    template < size_t order >
-    autodiff::HigherOrderDual< order - 1, double > decreaseDualOrder( autodiff::HigherOrderDual< order, double >& in )
-    {
-      using out_scalar_type = autodiff::HigherOrderDual< order - 1, double >;
-      using namespace autodiff::detail;
+    return out;
+  }
 
-      out_scalar_type out( 0.0 );
-      double*         in_point  = &valnode< order >( in );
-      double*         out_point = &valnode< order - 1 >( out );
+  /** @brief Increases the order of a vector of hyper-dual numbers by 1
+   *  @tparam order The current order of the dual numbers in the vector
+   *  @param in The input vector of dual numbers
+   *  @return A new vector of dual numbers with order increased by 1
+   *
+   *  This function takes a vector of dual numbers of a given order and creates a new vector of dual numbers with the
+   * order increased by 1. The derivative parts are elevated (shifted) one order for each element in the vector.
+   */
+  template < size_t order >
+  Vector< HigherOrderDual< order + 1, double >, -1 > increaseDualOrderWithShift(
+    const Vector< HigherOrderDual< order, double >, -1 >& in )
+  {
+    using in_scalar_type  = HigherOrderDual< order, double >;
+    using out_scalar_type = HigherOrderDual< order + 1, double >;
 
-      for ( size_t i = 0; i < size_t( std::pow( 2, order - 1 ) ); i++ ) {
-        *( out_point + i ) = *( in_point + i );
-      }
+    Vector< out_scalar_type, -1 > out      = Vector< out_scalar_type, -1 >( in.size() );
+    out_scalar_type*              out_data = out.data();
+    const in_scalar_type*         in_data  = in.data();
 
-      return out;
+    for ( int i = 0; i < in.size(); i++ ) {
+      out_data[i] = increaseDualOrderWithShift< order >( in_data[i] );
     }
+    return out;
+  }
 
-    /** @brief Decreases the order of a hyper-dual number by 1 with a shift
-     *  @tparam order The current order of the dual number
-     *  @param in The input dual number
-     *  @return A new dual number with order decreased by 1
-     *
-     *  This function takes a dual number of a given order and creates a new dual number with the order decreased by 1.
-     *  The derivative parts are shifted down by one order.
-     *  The first derivative part of the input dual number is discarded.
-     */
-    template < size_t order >
-    autodiff::HigherOrderDual< order - 1, double > decreaseDualOrderWithShift(
-      autodiff::HigherOrderDual< order, double >& in )
-    {
-      using out_scalar_type = autodiff::HigherOrderDual< order - 1, double >;
-      using namespace autodiff::detail;
+  /** @typedef scalar_to_scalar_function_type
+   *  @brief A type alias for a scalar-to-scalar function that takes and returns dual numbers
+   */
+  using scalar_to_scalar_function_type = std::function< dual( const dual& ) >;
 
-      out_scalar_type out( 0.0 );
-      double*         in_point  = &valnode< order >( in );
-      double*         out_point = &valnode< order - 1 >( out );
+  /** @brief Computes the derivative of a scalar-to-scalar function at a given point using automatic differentiation
+   *  @param f The scalar-to-scalar function to differentiate
+   *  @param x The point at which to evaluate the derivative
+   *  @return The derivative of the function at the given point
+   *
+   *  This function takes a scalar-to-scalar function and a point as input, and returns the derivative of the function
+   * at that point. It uses automatic differentiation to compute the derivative accurately.
+   */
+  double df_dx( const scalar_to_scalar_function_type& f, const double& x );
 
-      for ( size_t i = 0; i < size_t( std::pow( 2, order - 1 ) ); i++ ) {
-        *( out_point + i ) = *( in_point + i + size_t( std::pow( 2, order - 1 ) ) );
-      }
+  /** @typedef scalar_to_scalar_function_type_2nd
+   *  @brief A type alias for a scalar-to-scalar function that takes and returns second order dual numbers
+   */
+  using scalar_to_scalar_function_type_2nd = std::function< dual2nd( const dual2nd& ) >;
 
-      return out;
-    }
+  /** @brief Computes the derivative of a dual-valued scalar-to-scalar function at a given point using automatic
+   * differentiation
+   *  @param f The scalar-to-scalar function to differentiate
+   *  @param x The point at which to evaluate the derivative
+   *  @return The derivative of the function at the given point
+   *
+   *  This function takes a 2nd order dual-valued scalar-to-scalar function and a point as input, and returns the
+   * derivative of the function at that point. Note that the function is 2nd order dual-valued, but the input is only
+   * 1st order dual-valued.
+   */
+  dual df_dx( const scalar_to_scalar_function_type_2nd& f, const dual& x );
 
-    /** @brief Increases the order of a vector of hyper-dual numbers by 1
-     *  @tparam order The current order of the dual numbers in the vector
-     *  @param in The input vector of dual numbers
-     *  @return A new vector of dual numbers with order increased by 1
-     *
-     *  This function takes a vector of dual numbers of a given order and creates a new vector of dual numbers with the
-     * order increased by 1. The derivative parts are elevated (shifted) one order for each element in the vector.
-     */
-    template < size_t order >
-    Vector< HigherOrderDual< order + 1, double >, -1 > increaseDualOrderWithShift(
-      const Vector< HigherOrderDual< order, double >, -1 >& in )
-    {
-      using in_scalar_type  = HigherOrderDual< order, double >;
-      using out_scalar_type = HigherOrderDual< order + 1, double >;
+  /** @typedef vector_to_vector_function_type_dual
+   *  @brief A type alias for a vector-to-vector function that takes and returns dual-valued vectors
+   */
+  using vector_to_vector_function_type_dual = std::function< VectorXdual( const VectorXdual& X ) >;
 
-      Vector< out_scalar_type, -1 > out      = Vector< out_scalar_type, -1 >( in.size() );
-      out_scalar_type*              out_data = out.data();
-      const in_scalar_type*         in_data  = in.data();
+  /** @brief Computes the Jacobian of a vector-to-vector function at a given point using automatic differentiation
+   *  @param F The vector-to-vector function to differentiate
+   *  @param X The point at which to evaluate the Jacobian
+   *  @return A pair containing the function value and the Jacobian matrix at the given point
+   *
+   *  This function takes a vector-to-vector function and a point as input, and returns a pair containing the function
+   * value and the Jacobian matrix at that point. It uses automatic differentiation to compute the Jacobian
+   * accurately.
+   */
+  std::pair< VectorXd, MatrixXd > dF_dX( const vector_to_vector_function_type_dual& F, const VectorXd& X );
 
-      for ( int i = 0; i < in.size(); i++ ) {
-        out_data[i] = increaseDualOrderWithShift< order >( in_data[i] );
-      }
-      return out;
-    }
+  /** @typedef vector_to_vector_function_type_dual2nd
+   *  @brief A type alias for a vector-to-vector function that takes and returns second order dual-valued vectors
+   */
+  using vector_to_vector_function_type_dual2nd = std::function< VectorXdual2nd( const VectorXdual2nd& X ) >;
 
-    /** @typedef scalar_to_scalar_function_type
-     *  @brief A type alias for a scalar-to-scalar function that takes and returns dual numbers
-     */
-    using scalar_to_scalar_function_type = std::function< dual( const dual& ) >;
-
-    /** @brief Computes the derivative of a scalar-to-scalar function at a given point using automatic differentiation
-     *  @param f The scalar-to-scalar function to differentiate
-     *  @param x The point at which to evaluate the derivative
-     *  @return The derivative of the function at the given point
-     *
-     *  This function takes a scalar-to-scalar function and a point as input, and returns the derivative of the function
-     * at that point. It uses automatic differentiation to compute the derivative accurately.
-     */
-    double df_dx( const scalar_to_scalar_function_type& f, const double& x );
-
-    /** @typedef scalar_to_scalar_function_type_2nd
-     *  @brief A type alias for a scalar-to-scalar function that takes and returns second order dual numbers
-     */
-    using scalar_to_scalar_function_type_2nd = std::function< dual2nd( const dual2nd& ) >;
-
-    /** @brief Computes the derivative of a dual-valued scalar-to-scalar function at a given point using automatic
-     * differentiation
-     *  @param f The scalar-to-scalar function to differentiate
-     *  @param x The point at which to evaluate the derivative
-     *  @return The derivative of the function at the given point
-     *
-     *  This function takes a 2nd order dual-valued scalar-to-scalar function and a point as input, and returns the
-     * derivative of the function at that point. Note that the function is 2nd order dual-valued, but the input is only
-     * 1st order dual-valued.
-     */
-    dual df_dx( const scalar_to_scalar_function_type_2nd& f, const dual& x );
-
-    /** @typedef vector_to_vector_function_type_dual
-     *  @brief A type alias for a vector-to-vector function that takes and returns dual-valued vectors
-     */
-    using vector_to_vector_function_type_dual = std::function< VectorXdual( const VectorXdual& X ) >;
-
-    /** @brief Computes the Jacobian of a vector-to-vector function at a given point using automatic differentiation
-     *  @param F The vector-to-vector function to differentiate
-     *  @param X The point at which to evaluate the Jacobian
-     *  @return A pair containing the function value and the Jacobian matrix at the given point
-     *
-     *  This function takes a vector-to-vector function and a point as input, and returns a pair containing the function
-     * value and the Jacobian matrix at that point. It uses automatic differentiation to compute the Jacobian
-     * accurately.
-     */
-    std::pair< VectorXd, MatrixXd > dF_dX( const vector_to_vector_function_type_dual& F, const VectorXd& X );
-
-    /** @typedef vector_to_vector_function_type_dual2nd
-     *  @brief A type alias for a vector-to-vector function that takes and returns second order dual-valued vectors
-     */
-    using vector_to_vector_function_type_dual2nd = std::function< VectorXdual2nd( const VectorXdual2nd& X ) >;
-
-    /** @brief Computes the Jacobian of a dual-valued vector-to-vector function at a given point using automatic
-     * differentiation
-     *  @param F The vector-to-vector function to differentiate
-     *  @param X The point at which to evaluate the Jacobian
-     *  @return A pair containing the function value and the Jacobian matrix at the given point
-     *
-     *  This function takes a 2nd order dual-valued vector-to-vector function and a point as input, and returns a
-     * dual-valued pair containing the function value and the Jacobian matrix at that point. Note that the function is
-     * 2nd order dual-valued, but the input is only 1st order dual-valued.
-     */
-    std::pair< VectorXdual, MatrixXdual > dF_dX_2nd( const vector_to_vector_function_type_dual2nd& F,
-                                                     const VectorXdual&                            X );
-  } // namespace AutomaticDifferentiation
-
-} // namespace Marmot
+  /** @brief Computes the Jacobian of a dual-valued vector-to-vector function at a given point using automatic
+   * differentiation
+   *  @param F The vector-to-vector function to differentiate
+   *  @param X The point at which to evaluate the Jacobian
+   *  @return A pair containing the function value and the Jacobian matrix at the given point
+   *
+   *  This function takes a 2nd order dual-valued vector-to-vector function and a point as input, and returns a
+   * dual-valued pair containing the function value and the Jacobian matrix at that point. Note that the function is
+   * 2nd order dual-valued, but the input is only 1st order dual-valued.
+   */
+  std::pair< VectorXdual, MatrixXdual > dF_dX_2nd( const vector_to_vector_function_type_dual2nd& F,
+                                                   const VectorXdual&                            X );
+} // namespace Marmot::AutomaticDifferentiation

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotAutomaticDifferentiationForFastor.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotAutomaticDifferentiationForFastor.h
@@ -32,320 +32,315 @@
 #include <autodiff/forward/dual/dual.hpp>
 #include <functional>
 
-namespace Marmot {
+namespace Marmot::AutomaticDifferentiation {
 
-  namespace AutomaticDifferentiation {
+  using namespace autodiff;
 
-    using namespace autodiff;
+  /** @brief Increase the order of an arbitray order dual-valued Fastor tensor by one and shift the derivatives
+   *  @tparam order current order of the dual numers in the tensor
+   *  @tparam Rest dimensions of the tensor
+   *  @param in input tensor
+   *  @return output tensor with increased order dual numbers
+   */
+  template < size_t order, size_t... Rest >
+  Fastor::Tensor< HigherOrderDual< order + 1, double >, Rest... > increaseDualOrderWithShift(
+    const Fastor::Tensor< HigherOrderDual< order, double >, Rest... >& in )
+  {
+    using in_scalar_type  = HigherOrderDual< order, double >;
+    using out_scalar_type = HigherOrderDual< order + 1, double >;
 
-    /** @brief Increase the order of an arbitray order dual-valued Fastor tensor by one and shift the derivatives
-     *  @tparam order current order of the dual numers in the tensor
-     *  @tparam Rest dimensions of the tensor
-     *  @param in input tensor
-     *  @return output tensor with increased order dual numbers
-     */
-    template < size_t order, size_t... Rest >
-    Fastor::Tensor< HigherOrderDual< order + 1, double >, Rest... > increaseDualOrderWithShift(
-      const Fastor::Tensor< HigherOrderDual< order, double >, Rest... >& in )
-    {
-      using in_scalar_type  = HigherOrderDual< order, double >;
-      using out_scalar_type = HigherOrderDual< order + 1, double >;
+    Fastor::Tensor< out_scalar_type, Rest... > out( 0.0 );
+    out_scalar_type*                           out_data = out.data();
+    in_scalar_type*                            in_data  = in.data();
 
-      Fastor::Tensor< out_scalar_type, Rest... > out( 0.0 );
-      out_scalar_type*                           out_data = out.data();
-      in_scalar_type*                            in_data  = in.data();
-
-      for ( Fastor::FASTOR_INDEX i = 0; i < in.size(); ++i ) {
-        out_data[out.get_mem_index( i )] = increaseDualOrderWithShift< order >( in_data[in.get_mem_index( i )] );
-      }
-      return out;
+    for ( Fastor::FASTOR_INDEX i = 0; i < in.size(); ++i ) {
+      out_data[out.get_mem_index( i )] = increaseDualOrderWithShift< order >( in_data[in.get_mem_index( i )] );
     }
+    return out;
+  }
+
+  /** @typedef tensor_to_scalar_function_type
+   *  @brief Alias for a function mapping a tensor to a scalar with dual numbers
+   *  @tparam Rest dimensions of the tensor
+   * */
+  template < size_t... Rest >
+  using tensor_to_scalar_function_type = std::function< dual( const Fastor::Tensor< dual, Rest... >& T ) >;
+
+  /** @brief Compute the gradient of a tensor-to-scalar function
+   *  @tparam Rest dimensions of the tensor
+   *  @param f function mapping a tensor to a scalar
+   *  @param T input tensor at which the gradient is evaluated
+   *  @return gradient of f with respect to T, same shape as T
+   */
+  template < size_t... Rest >
+  Fastor::Tensor< double, Rest... > df_dT( const tensor_to_scalar_function_type< Rest... >& f,
+                                           const Fastor::Tensor< double, Rest... >&         T )
+  {
+    Fastor::Tensor< double, Rest... > df_dT( 0.0 );
+    Fastor::Tensor< dual, Rest... >   T_right = makeDual( T );
+
+    double* df_dT_data   = df_dT.data();
+    dual*   T_right_data = T_right.data();
+
+    for ( Fastor::FASTOR_INDEX i = 0; i < T.size(); ++i ) {
+      const int T_right_mem_idx = T_right.get_mem_index( i );
+      seed< 1 >( T_right_data[T_right_mem_idx], 1.0 );
+      df_dT_data[df_dT.get_mem_index( i )] = derivative< 1 >( f( T_right ) );
+      seed< 1 >( T_right_data[T_right_mem_idx], 0.0 );
+    }
+
+    return df_dT;
+  }
+
+  /** @typedef tensor_to_scalar_function_type_arbitrary_dual_order
+   *  @brief A type alias for a function mapping a tensor to a scalar with dual numbers of arbitrary order
+   *  @tparam order current order of the dual numbers in the tensor
+   *  @tparam Rest dimensions of the tensor
+   * */
+  template < size_t order, size_t... Rest >
+  using tensor_to_scalar_function_type_arbitrary_dual_order = std::function< HigherOrderDual< order, double >(
+    const Fastor::Tensor< HigherOrderDual< order, double >, Rest... >& T ) >;
+
+  /** @brief Compute the gradient of a tensor-to-scalar function where the with dual numbers of arbitrary order
+   *  @tparam order current order of the dual numers in the tensor
+   *  @tparam Rest dimensions of the tensor
+   *  @param f function mapping a tensor to a scalar
+   *  @param T input tensor at which the gradient is evaluated
+   *  @return pair of function value and gradient of f with respect to T, same shape as T
+   */
+  template < size_t order, size_t... Rest >
+  std::pair< HigherOrderDual< order, double >, Fastor::Tensor< HigherOrderDual< order, double >, Rest... > > df_dT(
+    const tensor_to_scalar_function_type_arbitrary_dual_order< order + 1, Rest... >& f,
+    const Fastor::Tensor< HigherOrderDual< order, double >, Rest... >&               T )
+  {
+
+    using scalartype            = HigherOrderDual< order, double >;
+    using higherOrderScalartype = HigherOrderDual< order + 1, double >;
+
+    higherOrderScalartype                            f_;
+    Fastor::Tensor< scalartype, Rest... >            df_dT_( 0.0 );
+    Fastor::Tensor< higherOrderScalartype, Rest... > T_right = increaseDualOrderWithShift< order >( T );
+
+    higherOrderScalartype* T_right_data = T_right.data();
+    scalartype*            df_dT_data   = df_dT_.data();
+
+    for ( Fastor::FASTOR_INDEX i = 0; i < T.size(); ++i ) {
+      seed< 1 >( T_right_data[T_right.get_mem_index( i )], 1.0 );
+      f_                                    = f( T_right );
+      df_dT_data[df_dT_.get_mem_index( i )] = decreaseDualOrderWithShift< order + 1 >( f_ );
+      seed< 1 >( T_right_data[T_right.get_mem_index( i )], 0.0 );
+    }
+    f_ = f( T_right );
+    return { decreaseDualOrder< order + 1 >( f_ ), df_dT_ };
+  }
+
+  /** @brief Compute the gradient of a tensor-to-tensor function
+   *  @tparam RestF dimensions of the output tensor
+   *  @tparam RestT dimensions of the input tensor
+   *  @param F function mapping a tensor to a tensor
+   *  @param T input tensor at which the gradient is evaluated
+   *  @return pair of function value and gradient of F with respect to T, gradient has shape (RestF..., RestT...)
+   */
+  template < size_t... RestF, size_t... RestT >
+  std::pair< Fastor::Tensor< double, RestF... >, Fastor::Tensor< double, RestF..., RestT... > > dF_dT(
+    std::function< Fastor::Tensor< dual, RestF... >( const Fastor::Tensor< dual, RestT... >& ) >& F,
+    const Fastor::Tensor< double, RestT... >&                                                     T )
+  {
+
+    Fastor::Tensor< double, RestF... >           F_( 0.0 );
+    Fastor::Tensor< double, RestF..., RestT... > dF_dT_( 0.0 );
+    Fastor::Tensor< dual, RestT... >             T_right = makeDual( T );
+
+    Fastor::Tensor< dual, RestF... > F_at_T_right( 0.0 );
+
+    double* dF_dT_data        = dF_dT_.data();
+    dual*   T_right_data      = T_right.data();
+    dual*   F_at_T_right_data = F_at_T_right.data();
+
+    for ( Fastor::FASTOR_INDEX i = 0; i < T.size(); ++i ) {
+      const int T_right_mem_idx = T_right.get_mem_index( i );
+      T_right_data[T_right_mem_idx].grad += 1.0;
+      F_at_T_right = F( T_right );
+
+      for ( Fastor::FASTOR_INDEX j = 0; j < F_at_T_right.size(); ++j ) {
+        dF_dT_data[dF_dT_.get_mem_index( j * T.size() + i )] = F_at_T_right_data[F_at_T_right.get_mem_index( j )].grad;
+      }
+      T_right_data[T_right_mem_idx].grad -= 1.0;
+    }
+
+    F_ = makeReal( F_at_T_right );
+
+    return { F_, dF_dT_ };
+  }
+
+  namespace SecondOrder {
 
     /** @typedef tensor_to_scalar_function_type
-     *  @brief Alias for a function mapping a tensor to a scalar with dual numbers
-     *  @tparam Rest dimensions of the tensor
-     * */
-    template < size_t... Rest >
-    using tensor_to_scalar_function_type = std::function< dual( const Fastor::Tensor< dual, Rest... >& T ) >;
-
-    /** @brief Compute the gradient of a tensor-to-scalar function
-     *  @tparam Rest dimensions of the tensor
-     *  @param f function mapping a tensor to a scalar
-     *  @param T input tensor at which the gradient is evaluated
-     *  @return gradient of f with respect to T, same shape as T
+     *  @brief Alias for a function mapping a tensor to a scalar with second order dual numbers
+     *  @tparam dim dimension of the input tensor (dim x dim)
+     *
+     *  @note The implementation is currently limited to second rank (dim x dim) tensors
      */
-    template < size_t... Rest >
-    Fastor::Tensor< double, Rest... > df_dT( const tensor_to_scalar_function_type< Rest... >& f,
-                                             const Fastor::Tensor< double, Rest... >&         T )
-    {
-      Fastor::Tensor< double, Rest... > df_dT( 0.0 );
-      Fastor::Tensor< dual, Rest... >   T_right = makeDual( T );
+    template < size_t dim >
+    using tensor_to_scalar_function_type = std::function< dual2nd( const Fastor::Tensor< dual2nd, dim, dim >& T ) >;
 
-      double* df_dT_data   = df_dT.data();
-      dual*   T_right_data = T_right.data();
-
-      for ( Fastor::FASTOR_INDEX i = 0; i < T.size(); ++i ) {
-        const int T_right_mem_idx = T_right.get_mem_index( i );
-        seed< 1 >( T_right_data[T_right_mem_idx], 1.0 );
-        df_dT_data[df_dT.get_mem_index( i )] = derivative< 1 >( f( T_right ) );
-        seed< 1 >( T_right_data[T_right_mem_idx], 0.0 );
-      }
-
-      return df_dT;
-    }
-
-    /** @typedef tensor_to_scalar_function_type_arbitrary_dual_order
-     *  @brief A type alias for a function mapping a tensor to a scalar with dual numbers of arbitrary order
-     *  @tparam order current order of the dual numbers in the tensor
-     *  @tparam Rest dimensions of the tensor
-     * */
-    template < size_t order, size_t... Rest >
-    using tensor_to_scalar_function_type_arbitrary_dual_order = std::function< HigherOrderDual< order, double >(
-      const Fastor::Tensor< HigherOrderDual< order, double >, Rest... >& T ) >;
-
-    /** @brief Compute the gradient of a tensor-to-scalar function where the with dual numbers of arbitrary order
-     *  @tparam order current order of the dual numers in the tensor
-     *  @tparam Rest dimensions of the tensor
-     *  @param f function mapping a tensor to a scalar
-     *  @param T input tensor at which the gradient is evaluated
-     *  @return pair of function value and gradient of f with respect to T, same shape as T
+    /** @brief Computes the second derivative of a function that maps a tensor to a scalar
+     *  @tparam dim dimension of the input tensor (dim x dim)
+     *  @param F function mapping a (dim x dim) tensor to a scalar
+     *  @param T input tensor at which the derivative is evaluated
+     *  @return tuple of function value, first derivative and second derivative of F with respect to T
+     *          first derivative has shape (dim, dim)
+     *          second derivative has shape (dim, dim, dim, dim)
+     *
+     *  @note The implementation is currently limited to second rank (dim x dim) tensors
      */
-    template < size_t order, size_t... Rest >
-    std::pair< HigherOrderDual< order, double >, Fastor::Tensor< HigherOrderDual< order, double >, Rest... > > df_dT(
-      const tensor_to_scalar_function_type_arbitrary_dual_order< order + 1, Rest... >& f,
-      const Fastor::Tensor< HigherOrderDual< order, double >, Rest... >&               T )
+    template < size_t dim >
+    std::tuple< double, Fastor::Tensor< double, dim, dim >, Fastor::Tensor< double, dim, dim, dim, dim > > d2f_dT2(
+      const tensor_to_scalar_function_type< dim >& F,
+      const Fastor::Tensor< double, dim, dim >&    T )
     {
+      double                                       F_;
+      dual2nd                                      F_right;
+      Fastor::Tensor< double, dim, dim >           dF_dT_;
+      Fastor::Tensor< double, dim, dim, dim, dim > d2F_dT2;
+      Fastor::Tensor< dual2nd, dim, dim >          T_right = makeHigherOrderDual< 2 >( T );
 
-      using scalartype            = HigherOrderDual< order, double >;
-      using higherOrderScalartype = HigherOrderDual< order + 1, double >;
+      for ( size_t i = 0; i < dim; i++ ) {
+        for ( size_t j = 0; j < dim; j++ ) {
+          seed< 1 >( T_right( i, j ), 1.0 );
 
-      higherOrderScalartype                            f_;
-      Fastor::Tensor< scalartype, Rest... >            df_dT_( 0.0 );
-      Fastor::Tensor< higherOrderScalartype, Rest... > T_right = increaseDualOrderWithShift< order >( T );
+          for ( size_t k = 0; k < dim; k++ ) {
+            for ( size_t l = 0; l < dim; l++ ) {
 
-      higherOrderScalartype* T_right_data = T_right.data();
-      scalartype*            df_dT_data   = df_dT_.data();
+              seed< 2 >( T_right( k, l ), 1.0 );
+              F_right               = F( T_right );
+              d2F_dT2( i, j, k, l ) = derivative< 2 >( F_right );
 
-      for ( Fastor::FASTOR_INDEX i = 0; i < T.size(); ++i ) {
-        seed< 1 >( T_right_data[T_right.get_mem_index( i )], 1.0 );
-        f_                                    = f( T_right );
-        df_dT_data[df_dT_.get_mem_index( i )] = decreaseDualOrderWithShift< order + 1 >( f_ );
-        seed< 1 >( T_right_data[T_right.get_mem_index( i )], 0.0 );
-      }
-      f_ = f( T_right );
-      return { decreaseDualOrder< order + 1 >( f_ ), df_dT_ };
-    }
-
-    /** @brief Compute the gradient of a tensor-to-tensor function
-     *  @tparam RestF dimensions of the output tensor
-     *  @tparam RestT dimensions of the input tensor
-     *  @param F function mapping a tensor to a tensor
-     *  @param T input tensor at which the gradient is evaluated
-     *  @return pair of function value and gradient of F with respect to T, gradient has shape (RestF..., RestT...)
-     */
-    template < size_t... RestF, size_t... RestT >
-    std::pair< Fastor::Tensor< double, RestF... >, Fastor::Tensor< double, RestF..., RestT... > > dF_dT(
-      std::function< Fastor::Tensor< dual, RestF... >( const Fastor::Tensor< dual, RestT... >& ) >& F,
-      const Fastor::Tensor< double, RestT... >&                                                     T )
-    {
-
-      Fastor::Tensor< double, RestF... >           F_( 0.0 );
-      Fastor::Tensor< double, RestF..., RestT... > dF_dT_( 0.0 );
-      Fastor::Tensor< dual, RestT... >             T_right = makeDual( T );
-
-      Fastor::Tensor< dual, RestF... > F_at_T_right( 0.0 );
-
-      double* dF_dT_data        = dF_dT_.data();
-      dual*   T_right_data      = T_right.data();
-      dual*   F_at_T_right_data = F_at_T_right.data();
-
-      for ( Fastor::FASTOR_INDEX i = 0; i < T.size(); ++i ) {
-        const int T_right_mem_idx = T_right.get_mem_index( i );
-        T_right_data[T_right_mem_idx].grad += 1.0;
-        F_at_T_right = F( T_right );
-
-        for ( Fastor::FASTOR_INDEX j = 0; j < F_at_T_right.size(); ++j ) {
-          dF_dT_data[dF_dT_.get_mem_index( j * T.size() + i )] = F_at_T_right_data[F_at_T_right.get_mem_index( j )]
-                                                                   .grad;
-        }
-        T_right_data[T_right_mem_idx].grad -= 1.0;
-      }
-
-      F_ = makeReal( F_at_T_right );
-
-      return { F_, dF_dT_ };
-    }
-
-    namespace SecondOrder {
-
-      /** @typedef tensor_to_scalar_function_type
-       *  @brief Alias for a function mapping a tensor to a scalar with second order dual numbers
-       *  @tparam dim dimension of the input tensor (dim x dim)
-       *
-       *  @note The implementation is currently limited to second rank (dim x dim) tensors
-       */
-      template < size_t dim >
-      using tensor_to_scalar_function_type = std::function< dual2nd( const Fastor::Tensor< dual2nd, dim, dim >& T ) >;
-
-      /** @brief Computes the second derivative of a function that maps a tensor to a scalar
-       *  @tparam dim dimension of the input tensor (dim x dim)
-       *  @param F function mapping a (dim x dim) tensor to a scalar
-       *  @param T input tensor at which the derivative is evaluated
-       *  @return tuple of function value, first derivative and second derivative of F with respect to T
-       *          first derivative has shape (dim, dim)
-       *          second derivative has shape (dim, dim, dim, dim)
-       *
-       *  @note The implementation is currently limited to second rank (dim x dim) tensors
-       */
-      template < size_t dim >
-      std::tuple< double, Fastor::Tensor< double, dim, dim >, Fastor::Tensor< double, dim, dim, dim, dim > > d2f_dT2(
-        const tensor_to_scalar_function_type< dim >& F,
-        const Fastor::Tensor< double, dim, dim >&    T )
-      {
-        double                                       F_;
-        dual2nd                                      F_right;
-        Fastor::Tensor< double, dim, dim >           dF_dT_;
-        Fastor::Tensor< double, dim, dim, dim, dim > d2F_dT2;
-        Fastor::Tensor< dual2nd, dim, dim >          T_right = makeHigherOrderDual< 2 >( T );
-
-        for ( size_t i = 0; i < dim; i++ ) {
-          for ( size_t j = 0; j < dim; j++ ) {
-            seed< 1 >( T_right( i, j ), 1.0 );
-
-            for ( size_t k = 0; k < dim; k++ ) {
-              for ( size_t l = 0; l < dim; l++ ) {
-
-                seed< 2 >( T_right( k, l ), 1.0 );
-                F_right               = F( T_right );
-                d2F_dT2( i, j, k, l ) = derivative< 2 >( F_right );
-
-                seed< 2 >( T_right( k, l ), 0.0 );
-              }
+              seed< 2 >( T_right( k, l ), 0.0 );
             }
-            dF_dT_( i, j ) = derivative< 1 >( F_right );
-            F_             = double( F_right );
-            seed< 1 >( T_right( i, j ), 0.0 );
           }
+          dF_dT_( i, j ) = derivative< 1 >( F_right );
+          F_             = double( F_right );
+          seed< 1 >( T_right( i, j ), 0.0 );
         }
-
-        return { F_, dF_dT_, d2F_dT2 };
       }
 
-      /** @typedef tensor_and_scalar_to_scalar_function_type
-       *  @brief Alias for a function mapping a tensor and a scalar to a scalar with second order dual numbers
-       *  @tparam dim dimension of the input tensor (dim x dim)
-       *
-       *  @note The implementation is currently limited to second rank (dim x dim) tensors
-       */
-      template < size_t dim >
-      using tensor_and_scalar_to_scalar_function_type = std::function<
-        dual2nd( const Fastor::Tensor< dual2nd, dim, dim >& T, const dual2nd scalar ) >;
+      return { F_, dF_dT_, d2F_dT2 };
+    }
 
-      /** @brief Computes the mixed second derivative of a function that maps a tensor and a scalar to a scalar
-       *  @tparam dim dimension of the input tensor (dim x dim)
-       *  @param F function mapping a (dim x dim) tensor and a scalar to a scalar
-       *  @param T input tensor at which the derivative is evaluated
-       *  @param scalar input scalar at which the derivative is evaluated
-       *  @return mixed second derivative of F with respect to T and the scalar, has shape (dim, dim)
-       *
-       *  @note The implementation is currently limited to second rank (dim x dim) tensors
-       */
-      template < size_t dim >
-      Fastor::Tensor< double, dim, dim > d2f_dTensor_dScalar( const tensor_and_scalar_to_scalar_function_type< dim >& F,
-                                                              const Fastor::Tensor< double, dim, dim >&               T,
-                                                              const double scalar )
-      {
-        Fastor::Tensor< double, dim, dim >  d2F_dTdScalar;
-        Fastor::Tensor< dual2nd, dim, dim > T_right = makeHigherOrderDual< 2 >( T );
+    /** @typedef tensor_and_scalar_to_scalar_function_type
+     *  @brief Alias for a function mapping a tensor and a scalar to a scalar with second order dual numbers
+     *  @tparam dim dimension of the input tensor (dim x dim)
+     *
+     *  @note The implementation is currently limited to second rank (dim x dim) tensors
+     */
+    template < size_t dim >
+    using tensor_and_scalar_to_scalar_function_type = std::function<
+      dual2nd( const Fastor::Tensor< dual2nd, dim, dim >& T, const dual2nd scalar ) >;
 
-        dual2nd scalar_right( scalar );
-        seed< 2 >( scalar_right, 1.0 );
+    /** @brief Computes the mixed second derivative of a function that maps a tensor and a scalar to a scalar
+     *  @tparam dim dimension of the input tensor (dim x dim)
+     *  @param F function mapping a (dim x dim) tensor and a scalar to a scalar
+     *  @param T input tensor at which the derivative is evaluated
+     *  @param scalar input scalar at which the derivative is evaluated
+     *  @return mixed second derivative of F with respect to T and the scalar, has shape (dim, dim)
+     *
+     *  @note The implementation is currently limited to second rank (dim x dim) tensors
+     */
+    template < size_t dim >
+    Fastor::Tensor< double, dim, dim > d2f_dTensor_dScalar( const tensor_and_scalar_to_scalar_function_type< dim >& F,
+                                                            const Fastor::Tensor< double, dim, dim >&               T,
+                                                            const double scalar )
+    {
+      Fastor::Tensor< double, dim, dim >  d2F_dTdScalar;
+      Fastor::Tensor< dual2nd, dim, dim > T_right = makeHigherOrderDual< 2 >( T );
 
-        for ( size_t i = 0; i < dim; i++ ) {
-          for ( size_t j = 0; j < dim; j++ ) {
+      dual2nd scalar_right( scalar );
+      seed< 2 >( scalar_right, 1.0 );
 
-            seed< 1 >( T_right( i, j ), 1.0 );
+      for ( size_t i = 0; i < dim; i++ ) {
+        for ( size_t j = 0; j < dim; j++ ) {
 
-            d2F_dTdScalar( i, j ) = derivative< 2 >( F( T_right, scalar_right ) );
+          seed< 1 >( T_right( i, j ), 1.0 );
 
-            seed< 1 >( T_right( i, j ), 0.0 );
-          }
+          d2F_dTdScalar( i, j ) = derivative< 2 >( F( T_right, scalar_right ) );
+
+          seed< 1 >( T_right( i, j ), 0.0 );
         }
-
-        return d2F_dTdScalar;
       }
-    } // namespace SecondOrder
-    namespace ThirdOrder {
 
-      /** @typedef tensor_to_scalar_function_type
-       *  @brief Alias for a function mapping a tensor to a scalar with third order dual numbers
-       *  @tparam dim dimension of the input tensor (dim x dim)
-       *
-       *  @note The implementation is currently limited to second rank (dim x dim) tensors
-       */
-      template < size_t dim >
-      using tensor_to_scalar_function_type = std::function< dual3rd( const Fastor::Tensor< dual3rd, dim, dim >& T ) >;
+      return d2F_dTdScalar;
+    }
+  } // namespace SecondOrder
+  namespace ThirdOrder {
 
-      /** @brief Computes the third derivative of a function that maps a tensor to a scalar
-       *  @tparam dim dimension of the input tensor (dim x dim)
-       *  @param F function mapping a (dim x dim) tensor to a scalar
-       *  @param T input tensor at which the derivative is evaluated
-       *  @return tuple of function value, first derivative, second derivative and third derivative of F with respect to
-       * T first derivative has shape (dim, dim) second derivative has shape (dim, dim, dim, dim) third derivative has
-       * shape (dim, dim, dim, dim, dim, dim)
-       *
-       *  @note The implementation is currently limited to second rank (dim x dim) tensors
-       */
-      template < size_t dim >
-      std::tuple< double,
-                  Fastor::Tensor< double, dim, dim >,
-                  Fastor::Tensor< double, dim, dim, dim, dim >,
-                  Fastor::Tensor< double, dim, dim, dim, dim, dim, dim > >
-      d3f_dT3( const tensor_to_scalar_function_type< dim >& F, const Fastor::Tensor< double, dim, dim >& T )
-      {
-        double                                                 F_;
-        dual3rd                                                F_right;
-        Fastor::Tensor< double, dim, dim >                     dF_dT_;
-        Fastor::Tensor< double, dim, dim, dim, dim >           d2F_dT2;
-        Fastor::Tensor< double, dim, dim, dim, dim, dim, dim > d3F_dT3;
-        Fastor::Tensor< dual3rd, dim, dim >                    T_right = makeHigherOrderDual< 3 >( T );
+    /** @typedef tensor_to_scalar_function_type
+     *  @brief Alias for a function mapping a tensor to a scalar with third order dual numbers
+     *  @tparam dim dimension of the input tensor (dim x dim)
+     *
+     *  @note The implementation is currently limited to second rank (dim x dim) tensors
+     */
+    template < size_t dim >
+    using tensor_to_scalar_function_type = std::function< dual3rd( const Fastor::Tensor< dual3rd, dim, dim >& T ) >;
 
-        for ( size_t i = 0; i < dim; i++ ) {
-          for ( size_t j = 0; j < dim; j++ ) {
-            seed< 1 >( T_right( i, j ), 1.0 );
+    /** @brief Computes the third derivative of a function that maps a tensor to a scalar
+     *  @tparam dim dimension of the input tensor (dim x dim)
+     *  @param F function mapping a (dim x dim) tensor to a scalar
+     *  @param T input tensor at which the derivative is evaluated
+     *  @return tuple of function value, first derivative, second derivative and third derivative of F with respect to
+     * T first derivative has shape (dim, dim) second derivative has shape (dim, dim, dim, dim) third derivative has
+     * shape (dim, dim, dim, dim, dim, dim)
+     *
+     *  @note The implementation is currently limited to second rank (dim x dim) tensors
+     */
+    template < size_t dim >
+    std::tuple< double,
+                Fastor::Tensor< double, dim, dim >,
+                Fastor::Tensor< double, dim, dim, dim, dim >,
+                Fastor::Tensor< double, dim, dim, dim, dim, dim, dim > >
+    d3f_dT3( const tensor_to_scalar_function_type< dim >& F, const Fastor::Tensor< double, dim, dim >& T )
+    {
+      double                                                 F_;
+      dual3rd                                                F_right;
+      Fastor::Tensor< double, dim, dim >                     dF_dT_;
+      Fastor::Tensor< double, dim, dim, dim, dim >           d2F_dT2;
+      Fastor::Tensor< double, dim, dim, dim, dim, dim, dim > d3F_dT3;
+      Fastor::Tensor< dual3rd, dim, dim >                    T_right = makeHigherOrderDual< 3 >( T );
 
-            for ( size_t k = 0; k < dim; k++ ) {
-              for ( size_t l = 0; l < dim; l++ ) {
+      for ( size_t i = 0; i < dim; i++ ) {
+        for ( size_t j = 0; j < dim; j++ ) {
+          seed< 1 >( T_right( i, j ), 1.0 );
 
-                seed< 2 >( T_right( k, l ), 1.0 );
+          for ( size_t k = 0; k < dim; k++ ) {
+            for ( size_t l = 0; l < dim; l++ ) {
 
-                for ( size_t m = 0; m < dim; m++ ) {
-                  for ( size_t n = 0; n < dim; n++ ) {
+              seed< 2 >( T_right( k, l ), 1.0 );
 
-                    seed< 3 >( T_right( m, n ), 1.0 );
-                    F_right                     = F( T_right );
-                    d3F_dT3( i, j, k, l, m, n ) = derivative< 3 >( F_right );
+              for ( size_t m = 0; m < dim; m++ ) {
+                for ( size_t n = 0; n < dim; n++ ) {
 
-                    seed< 3 >( T_right( m, n ), 0.0 );
-                  }
+                  seed< 3 >( T_right( m, n ), 1.0 );
+                  F_right                     = F( T_right );
+                  d3F_dT3( i, j, k, l, m, n ) = derivative< 3 >( F_right );
+
+                  seed< 3 >( T_right( m, n ), 0.0 );
                 }
-
-                d2F_dT2( i, j, k, l ) = derivative< 2 >( F_right );
-
-                seed< 2 >( T_right( k, l ), 0.0 );
               }
-            }
-            dF_dT_( i, j ) = derivative< 1 >( F_right );
-            F_             = double( F_right );
-            seed< 1 >( T_right( i, j ), 0.0 );
-          }
-        }
 
-        return { F_, dF_dT_, d2F_dT2, d3F_dT3 };
+              d2F_dT2( i, j, k, l ) = derivative< 2 >( F_right );
+
+              seed< 2 >( T_right( k, l ), 0.0 );
+            }
+          }
+          dF_dT_( i, j ) = derivative< 1 >( F_right );
+          F_             = double( F_right );
+          seed< 1 >( T_right( i, j ), 0.0 );
+        }
       }
 
-    } // namespace ThirdOrder
+      return { F_, dF_dT_, d2F_dT2, d3F_dT3 };
+    }
 
-  }   // namespace AutomaticDifferentiation
+  } // namespace ThirdOrder
 
-} // namespace Marmot
+} // namespace Marmot::AutomaticDifferentiation

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotConstants.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotConstants.h
@@ -26,58 +26,56 @@
 #pragma once
 #include <cmath>
 
-namespace Marmot {
-  namespace Constants {
-    /** @brief Constant expression for \f$\pi\f$ */
-    constexpr double Pi = 3.141592653589793238463;
-    /** @brief Constant expression for 1e-16 */
-    constexpr double numZeroPos = 1e-16;
-    /**
-     * @brief Inlined function to get the cubic root of machine epsilon for double precision.
-     *
-     * This function computes and returns the cubic root of the machine epsilon for double
-     * precision floating-point numbers. Machine epsilon is the smallest positive number that,
-     * when added to 1.0, results in a value different from 1.0 due to rounding errors.
-     *
-     * @return The cubic root of machine epsilon for double precision.
-     */
-    inline double cubicRootEps()
-    {
-      return std::pow( std::numeric_limits< double >::epsilon(), 1. / 3 );
-    }
+namespace Marmot::Constants {
+  /** @brief Constant expression for \f$\pi\f$ */
+  constexpr double Pi = 3.141592653589793238463;
+  /** @brief Constant expression for 1e-16 */
+  constexpr double numZeroPos = 1e-16;
+  /**
+   * @brief Inlined function to get the cubic root of machine epsilon for double precision.
+   *
+   * This function computes and returns the cubic root of the machine epsilon for double
+   * precision floating-point numbers. Machine epsilon is the smallest positive number that,
+   * when added to 1.0, results in a value different from 1.0 due to rounding errors.
+   *
+   * @return The cubic root of machine epsilon for double precision.
+   */
+  inline double cubicRootEps()
+  {
+    return std::pow( std::numeric_limits< double >::epsilon(), 1. / 3 );
+  }
 
-    /** @brief Inlined function to get the square root of machine epsilon for double precision.
-     *
-     *  This function computes and returns the square root of the machine epsilon for double
-     *  precision floating-point numbers. Machine epsilon is the smallest positive number that,
-     *  when added to 1.0, results in a value different from 1.0 due to rounding errors.
-     *
-     *  @return The square root of machine epsilon for double precision.
-     */
-    inline double squareRootEps()
-    {
-      return std::pow( std::numeric_limits< double >::epsilon(), 0.5 );
-    }
+  /** @brief Inlined function to get the square root of machine epsilon for double precision.
+   *
+   *  This function computes and returns the square root of the machine epsilon for double
+   *  precision floating-point numbers. Machine epsilon is the smallest positive number that,
+   *  when added to 1.0, results in a value different from 1.0 due to rounding errors.
+   *
+   *  @return The square root of machine epsilon for double precision.
+   */
+  inline double squareRootEps()
+  {
+    return std::pow( std::numeric_limits< double >::epsilon(), 0.5 );
+  }
 
-    /**@brief The golden ratio, approximately 1.618033988749895.*/
-    constexpr double GoldenRatio = 1.618033988749895;
-    /** @brief The golden angle in radians, approximately 2.399963229728653. */
-    constexpr double GoldenAngle = 2.399963229728653;
+  /**@brief The golden ratio, approximately 1.618033988749895.*/
+  constexpr double GoldenRatio = 1.618033988749895;
+  /** @brief The golden angle in radians, approximately 2.399963229728653. */
+  constexpr double GoldenAngle = 2.399963229728653;
 
-    const inline double SquareRootEps = squareRootEps();
-    const inline double CubicRootEps  = cubicRootEps();
+  const inline double SquareRootEps = squareRootEps();
+  const inline double CubicRootEps  = cubicRootEps();
 
-    /** @brief Constant expression for \f$\sqrt{3/8}\f$ */
-    constexpr double sqrt3_8 = 0.61237243569579452454932101867647;
-    /** @brief Constant expression for \f$\sqrt{2/3}\f$ */
-    constexpr double sqrt2_3 = 0.8164965809277260327324280249019;
-    /** @brief Constant expression for \f$\sqrt{3/2}\f$ */
-    constexpr double sqrt3_2 = 1.2247448713915890490986420373529;
-    /** @brief Constant expression for \f$\sqrt{2}\f$ */
-    constexpr double sqrt2 = 1.4142135623730950488016887242097;
-    /** @brief Constant expression for \f$\sqrt{3}\f$ */
-    constexpr double sqrt3 = 1.7320508075688772935274463415059;
-    /** @brief Constant expression for \f$\sqrt{6}\f$ */
-    constexpr double sqrt6 = 2.4494897427831780981972840747059;
-  } // namespace Constants
-} // namespace Marmot
+  /** @brief Constant expression for \f$\sqrt{3/8}\f$ */
+  constexpr double sqrt3_8 = 0.61237243569579452454932101867647;
+  /** @brief Constant expression for \f$\sqrt{2/3}\f$ */
+  constexpr double sqrt2_3 = 0.8164965809277260327324280249019;
+  /** @brief Constant expression for \f$\sqrt{3/2}\f$ */
+  constexpr double sqrt3_2 = 1.2247448713915890490986420373529;
+  /** @brief Constant expression for \f$\sqrt{2}\f$ */
+  constexpr double sqrt2 = 1.4142135623730950488016887242097;
+  /** @brief Constant expression for \f$\sqrt{3}\f$ */
+  constexpr double sqrt3 = 1.7320508075688772935274463415059;
+  /** @brief Constant expression for \f$\sqrt{6}\f$ */
+  constexpr double sqrt6 = 2.4494897427831780981972840747059;
+} // namespace Marmot::Constants

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotEigenSystems.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotEigenSystems.h
@@ -30,315 +30,313 @@
 #include <cmath>
 #include <utility>
 
-namespace Marmot {
-  namespace Math {
+namespace Marmot::Math {
 
-    template < typename T = double >
-    std::pair< FastorStandardTensors::Tensor3t< T >, FastorStandardTensors::Tensor33t< T > > computeEigenSystemJacobi(
-      const FastorStandardTensors::Tensor33t< T >& A_in )
-    {
-      using namespace FastorStandardTensors;
+  template < typename T = double >
+  std::pair< FastorStandardTensors::Tensor3t< T >, FastorStandardTensors::Tensor33t< T > > computeEigenSystemJacobi(
+    const FastorStandardTensors::Tensor33t< T >& A_in )
+  {
+    using namespace FastorStandardTensors;
 
-      Tensor33t< T > A = A_in; // Copy to manipulate internally
-      Tensor33t< T > V;
+    Tensor33t< T > A = A_in; // Copy to manipulate internally
+    Tensor33t< T > V;
 
-      // Initialize Eigenvectors to Identity Matrix
-      V( 0, 0 ) = T( 1 );
-      V( 0, 1 ) = T( 0 );
-      V( 0, 2 ) = T( 0 );
-      V( 1, 0 ) = T( 0 );
-      V( 1, 1 ) = T( 1 );
-      V( 1, 2 ) = T( 0 );
-      V( 2, 0 ) = T( 0 );
-      V( 2, 1 ) = T( 0 );
-      V( 2, 2 ) = T( 1 );
+    // Initialize Eigenvectors to Identity Matrix
+    V( 0, 0 ) = T( 1 );
+    V( 0, 1 ) = T( 0 );
+    V( 0, 2 ) = T( 0 );
+    V( 1, 0 ) = T( 0 );
+    V( 1, 1 ) = T( 1 );
+    V( 1, 2 ) = T( 0 );
+    V( 2, 0 ) = T( 0 );
+    V( 2, 1 ) = T( 0 );
+    V( 2, 2 ) = T( 1 );
 
-      int max_sweeps = 50;
+    int max_sweeps = 50;
 
-      for ( int sweep = 0; sweep < max_sweeps; ++sweep ) {
-        // Evaluate primal sum of off-diagonals to check for convergence
-        double sm = std::abs( Math::makeReal( A( 0, 1 ) ) ) + std::abs( Math::makeReal( A( 0, 2 ) ) ) +
-                    std::abs( Math::makeReal( A( 1, 2 ) ) );
+    for ( int sweep = 0; sweep < max_sweeps; ++sweep ) {
+      // Evaluate primal sum of off-diagonals to check for convergence
+      double sm = std::abs( Math::makeReal( A( 0, 1 ) ) ) + std::abs( Math::makeReal( A( 0, 2 ) ) ) +
+                  std::abs( Math::makeReal( A( 1, 2 ) ) );
 
-        if ( sm < 1e-13 )
-          break; // Converged
+      if ( sm < 1e-13 )
+        break; // Converged
 
-        // Iterate over upper off-diagonal elements
-        for ( int p = 0; p < 2; ++p ) {
-          for ( int q = p + 1; q < 3; ++q ) {
+      // Iterate over upper off-diagonal elements
+      for ( int p = 0; p < 2; ++p ) {
+        for ( int q = p + 1; q < 3; ++q ) {
 
-            double apq_real = std::abs( Math::makeReal( A( p, q ) ) );
+          double apq_real = std::abs( Math::makeReal( A( p, q ) ) );
 
-            // Only rotate if the off-diagonal is non-zero in the primal space
-            if ( apq_real > 1e-14 ) {
-              T      h = A( q, q ) - A( p, p );
-              T      t;
-              double h_real = std::abs( Math::makeReal( h ) );
+          // Only rotate if the off-diagonal is non-zero in the primal space
+          if ( apq_real > 1e-14 ) {
+            T      h = A( q, q ) - A( p, p );
+            T      t;
+            double h_real = std::abs( Math::makeReal( h ) );
 
-              // Prevent division by zero and catastrophic cancellation
-              if ( apq_real < 1e-6 * h_real ) {
-                t = A( p, q ) / h;
+            // Prevent division by zero and catastrophic cancellation
+            if ( apq_real < 1e-6 * h_real ) {
+              t = A( p, q ) / h;
+            }
+            else {
+              T theta = T( 0.5 ) * h / A( p, q );
+              T denom = sqrt( T( 1.0 ) + theta * theta );
+              // Branch strictly on primal sign to maintain derivative continuity
+              if ( Math::makeReal( theta ) < 0.0 ) {
+                t = T( -1.0 ) / ( -theta + denom );
               }
               else {
-                T theta = T( 0.5 ) * h / A( p, q );
-                T denom = sqrt( T( 1.0 ) + theta * theta );
-                // Branch strictly on primal sign to maintain derivative continuity
-                if ( Math::makeReal( theta ) < 0.0 ) {
-                  t = T( -1.0 ) / ( -theta + denom );
-                }
-                else {
-                  t = T( 1.0 ) / ( theta + denom );
-                }
-              }
-
-              T c     = T( 1.0 ) / sqrt( T( 1.0 ) + t * t );
-              T s     = t * c;
-              T tau   = s / ( T( 1.0 ) + c );
-              T h_val = t * A( p, q );
-
-              // Apply rotations to A
-              A( p, p ) -= h_val;
-              A( q, q ) += h_val;
-              A( p, q ) = T( 0.0 );
-              A( q, p ) = T( 0.0 );
-
-              for ( int r = 0; r < 3; ++r ) {
-                if ( r != p && r != q ) {
-                  T arp     = A( r, p );
-                  T arq     = A( r, q );
-                  A( r, p ) = arp - s * ( arq + arp * tau );
-                  A( r, q ) = arq + s * ( arp - arq * tau );
-                  A( p, r ) = A( r, p );
-                  A( q, r ) = A( r, q );
-                }
-              }
-
-              // Apply rotations to V (Eigenvectors)
-              for ( int r = 0; r < 3; ++r ) {
-                T vrp     = V( r, p );
-                T vrq     = V( r, q );
-                V( r, p ) = vrp - s * ( vrq + vrp * tau );
-                V( r, q ) = vrq + s * ( vrp - vrq * tau );
+                t = T( 1.0 ) / ( theta + denom );
               }
             }
-          }
-        }
-      }
 
-      Tensor3t< T > eigenvalues;
-      eigenvalues( 0 ) = A( 0, 0 );
-      eigenvalues( 1 ) = A( 1, 1 );
-      eigenvalues( 2 ) = A( 2, 2 );
+            T c     = T( 1.0 ) / sqrt( T( 1.0 ) + t * t );
+            T s     = t * c;
+            T tau   = s / ( T( 1.0 ) + c );
+            T h_val = t * A( p, q );
 
-      // Sort descending (must swap eigenvectors to match)
-      for ( int i = 0; i < 2; ++i ) {
-        for ( int j = i + 1; j < 3; ++j ) {
-          if ( Math::makeReal( eigenvalues( i ) ) < Math::makeReal( eigenvalues( j ) ) ) {
-            std::swap( eigenvalues( i ), eigenvalues( j ) );
+            // Apply rotations to A
+            A( p, p ) -= h_val;
+            A( q, q ) += h_val;
+            A( p, q ) = T( 0.0 );
+            A( q, p ) = T( 0.0 );
+
             for ( int r = 0; r < 3; ++r ) {
-              std::swap( V( r, i ), V( r, j ) );
+              if ( r != p && r != q ) {
+                T arp     = A( r, p );
+                T arq     = A( r, q );
+                A( r, p ) = arp - s * ( arq + arp * tau );
+                A( r, q ) = arq + s * ( arp - arq * tau );
+                A( p, r ) = A( r, p );
+                A( q, r ) = A( r, q );
+              }
+            }
+
+            // Apply rotations to V (Eigenvectors)
+            for ( int r = 0; r < 3; ++r ) {
+              T vrp     = V( r, p );
+              T vrq     = V( r, q );
+              V( r, p ) = vrp - s * ( vrq + vrp * tau );
+              V( r, q ) = vrq + s * ( vrp - vrq * tau );
             }
           }
         }
       }
-
-      return std::make_pair( eigenvalues, V );
     }
 
-    template < typename T = double >
-    std::pair< FastorStandardTensors::Tensor3t< T >, FastorStandardTensors::Tensor33t< T > > computeEigenSystemWithCardano(
-      const FastorStandardTensors::Tensor33t< T >& A )
-    {
-      using namespace FastorStandardTensors;
+    Tensor3t< T > eigenvalues;
+    eigenvalues( 0 ) = A( 0, 0 );
+    eigenvalues( 1 ) = A( 1, 1 );
+    eigenvalues( 2 ) = A( 2, 2 );
 
-      const T trA = trace( A );
-
-      const T p1 = -trA;
-      const T p2 = 0.5 * ( trA * trA - trace( A % A ) );
-      const T p3 = -det( A );
-
-      const T a = p2 - ( p1 * p1 ) / 3.0;
-      const T b = ( 2.0 * p1 * p1 * p1 ) / 27.0 - ( p1 * p2 ) / 3.0 + p3;
-
-      Tensor3t< T > eigenvalues;
-
-      // 1. SAFE BRANCHING: Use the primal value to check for isotropic/repeated states
-      // This prevents the derivative of sqrt(-a) from exploding when 'a' approaches 0.
-      if ( std::abs( Math::makeReal( a ) ) < 1e-14 ) {
-        T root           = -p1 / 3.0;
-        eigenvalues( 0 ) = root;
-        eigenvalues( 1 ) = root;
-        eigenvalues( 2 ) = root;
-      }
-      else {
-        T r = sqrt( -a / 3.0 );
-
-        // Protect against division by zero in the dual part
-        T aux = 3.0 * b / ( 2.0 * a ) * sqrt( -3.0 / a );
-
-        // 2. SAFE CLAMPING: We must evaluate the primal part to clamp,
-        // but if we hardcode `aux = 1.0`, we kill the derivative.
-        // A common AD trick is to let the dual library handle the clamp,
-        // or re-assign with a zeroed dual part if exactly at the boundary.
-        double aux_real = Math::makeReal( aux );
-        if ( aux_real <= -1.0 ) {
-          aux = T( -1.0 ); // Kills gradient at exact boundary to prevent NaN in acos derivative
-        }
-        else if ( aux_real >= 1.0 ) {
-          aux = T( 1.0 ); // Kills gradient at exact boundary to prevent NaN in acos derivative
-        }
-
-        T theta = acos( aux );
-
-        for ( int k = 0; k < 3; ++k ) {
-          // T(2.0) and T(3.0) ensure we don't accidentally cast down to double
-          eigenvalues( k ) = T( 2.0 ) * r * cos( ( theta - T( 2.0 ) * T( M_PI ) * T( k ) ) / T( 3.0 ) ) - p1 / T( 3.0 );
+    // Sort descending (must swap eigenvectors to match)
+    for ( int i = 0; i < 2; ++i ) {
+      for ( int j = i + 1; j < 3; ++j ) {
+        if ( Math::makeReal( eigenvalues( i ) ) < Math::makeReal( eigenvalues( j ) ) ) {
+          std::swap( eigenvalues( i ), eigenvalues( j ) );
+          for ( int r = 0; r < 3; ++r ) {
+            std::swap( V( r, i ), V( r, j ) );
+          }
         }
       }
-
-      // Sort descending (using primal values for the logic operators)
-      if ( Math::makeReal( eigenvalues( 0 ) ) < Math::makeReal( eigenvalues( 1 ) ) )
-        std::swap( eigenvalues( 0 ), eigenvalues( 1 ) );
-      if ( Math::makeReal( eigenvalues( 1 ) ) < Math::makeReal( eigenvalues( 2 ) ) )
-        std::swap( eigenvalues( 1 ), eigenvalues( 2 ) );
-      if ( Math::makeReal( eigenvalues( 0 ) ) < Math::makeReal( eigenvalues( 1 ) ) )
-        std::swap( eigenvalues( 0 ), eigenvalues( 1 ) );
-
-      // ------------------------------------------------------------------
-      // EIGENVECTOR COMPUTATION
-      // ------------------------------------------------------------------
-      Tensor33t< T > eigenvectors;
-
-      auto get_eigenvector = [&]( T lambda, Tensor3t< T >& v ) {
-        T B[3][3] = { { A( 0, 0 ) - lambda, A( 0, 1 ), A( 0, 2 ) },
-                      { A( 1, 0 ), A( 1, 1 ) - lambda, A( 1, 2 ) },
-                      { A( 2, 0 ), A( 2, 1 ), A( 2, 2 ) - lambda } };
-
-        T v1[3] = { B[1][1] * B[2][2] - B[1][2] * B[2][1],
-                    B[1][2] * B[2][0] - B[1][0] * B[2][2],
-                    B[1][0] * B[2][1] - B[1][1] * B[2][0] };
-        T v2[3] = { B[2][1] * B[0][2] - B[2][2] * B[0][1],
-                    B[2][2] * B[0][0] - B[2][0] * B[0][2],
-                    B[2][0] * B[0][1] - B[2][1] * B[0][0] };
-        T v3[3] = { B[0][1] * B[1][2] - B[0][2] * B[1][1],
-                    B[0][2] * B[1][0] - B[0][0] * B[1][2],
-                    B[0][0] * B[1][1] - B[0][1] * B[1][0] };
-
-        // 3. USE PRIMAL FOR NORM COMPARISONS, BUT PRESERVE `T` FOR THE DIVISION
-        double n1_real = Math::makeReal( T( sqrt( v1[0] * v1[0] + v1[1] * v1[1] + v1[2] * v1[2] ) ) );
-        double n2_real = Math::makeReal( T( sqrt( v2[0] * v2[0] + v2[1] * v2[1] + v2[2] * v2[2] ) ) );
-        double n3_real = Math::makeReal( T( sqrt( v3[0] * v3[0] + v3[1] * v3[1] + v3[2] * v3[2] ) ) );
-
-        double max_norm_real = n1_real;
-        T*     best_v        = v1;
-
-        if ( n2_real > max_norm_real ) {
-          max_norm_real = n2_real;
-          best_v        = v2;
-        }
-        if ( n3_real > max_norm_real ) {
-          max_norm_real = n3_real;
-          best_v        = v3;
-        }
-
-        // Calculate the actual dual norm strictly for the winning vector
-        T max_norm_dual = sqrt( best_v[0] * best_v[0] + best_v[1] * best_v[1] + best_v[2] * best_v[2] );
-
-        if ( max_norm_real > 1e-10 ) {
-          v( 0 ) = best_v[0] / max_norm_dual; // Divide by Dual to keep gradient!
-          v( 1 ) = best_v[1] / max_norm_dual;
-          v( 2 ) = best_v[2] / max_norm_dual;
-        }
-        else {
-          v( 0 ) = T( 0.0 );
-          v( 1 ) = T( 0.0 );
-          v( 2 ) = T( 0.0 );
-        }
-      };
-
-      auto make_orthogonal = []( const Tensor3t< T >& v, Tensor3t< T >& n ) {
-        // Use real parts to find the smallest axis
-        double abs_x = std::abs( Math::makeReal( v( 0 ) ) );
-        double abs_y = std::abs( Math::makeReal( v( 1 ) ) );
-        double abs_z = std::abs( Math::makeReal( v( 2 ) ) );
-
-        Tensor3t< T > axis;
-        axis( 0 ) = T( 0 );
-        axis( 1 ) = T( 0 );
-        axis( 2 ) = T( 0 );
-        if ( abs_x <= abs_y && abs_x <= abs_z )
-          axis( 0 ) = T( 1.0 );
-        else if ( abs_y <= abs_x && abs_y <= abs_z )
-          axis( 1 ) = T( 1.0 );
-        else
-          axis( 2 ) = T( 1.0 );
-
-        n( 0 ) = v( 1 ) * axis( 2 ) - v( 2 ) * axis( 1 );
-        n( 1 ) = v( 2 ) * axis( 0 ) - v( 0 ) * axis( 2 );
-        n( 2 ) = v( 0 ) * axis( 1 ) - v( 1 ) * axis( 0 );
-
-        // Normalize using dual math
-        T len = sqrt( n( 0 ) * n( 0 ) + n( 1 ) * n( 1 ) + n( 2 ) * n( 2 ) );
-        n( 0 ) /= len;
-        n( 1 ) /= len;
-        n( 2 ) /= len;
-      };
-
-      Tensor3t< T > e1, e2, e3;
-
-      double max_eig = std::max( { std::abs( Math::makeReal( eigenvalues( 0 ) ) ),
-                                   std::abs( Math::makeReal( eigenvalues( 1 ) ) ),
-                                   std::abs( Math::makeReal( eigenvalues( 2 ) ) ) } );
-      double tol     = 1e-6 * std::max( max_eig, 1.0 );
-
-      bool root_01_repeated = std::abs( Math::makeReal( T( eigenvalues( 0 ) - eigenvalues( 1 ) ) ) ) < tol;
-      bool root_12_repeated = std::abs( Math::makeReal( T( eigenvalues( 1 ) - eigenvalues( 2 ) ) ) ) < tol;
-
-      if ( root_01_repeated && root_12_repeated ) {
-        e1( 0 ) = T( 1.0 );
-        e1( 1 ) = T( 0.0 );
-        e1( 2 ) = T( 0.0 );
-        e2( 0 ) = T( 0.0 );
-        e2( 1 ) = T( 1.0 );
-        e2( 2 ) = T( 0.0 );
-        e3( 0 ) = T( 0.0 );
-        e3( 1 ) = T( 0.0 );
-        e3( 2 ) = T( 1.0 );
-      }
-      else if ( root_01_repeated ) {
-        get_eigenvector( eigenvalues( 2 ), e3 );
-        make_orthogonal( e3, e1 );
-        e2( 0 ) = e3( 1 ) * e1( 2 ) - e3( 2 ) * e1( 1 );
-        e2( 1 ) = e3( 2 ) * e1( 0 ) - e3( 0 ) * e1( 2 );
-        e2( 2 ) = e3( 0 ) * e1( 1 ) - e3( 1 ) * e1( 0 );
-      }
-      else if ( root_12_repeated ) {
-        get_eigenvector( eigenvalues( 0 ), e1 );
-        make_orthogonal( e1, e2 );
-        e3( 0 ) = e1( 1 ) * e2( 2 ) - e1( 2 ) * e2( 1 );
-        e3( 1 ) = e1( 2 ) * e2( 0 ) - e1( 0 ) * e2( 2 );
-        e3( 2 ) = e1( 0 ) * e2( 1 ) - e1( 1 ) * e2( 0 );
-      }
-      else {
-        get_eigenvector( eigenvalues( 0 ), e1 );
-        get_eigenvector( eigenvalues( 1 ), e2 );
-        e3( 0 ) = e1( 1 ) * e2( 2 ) - e1( 2 ) * e2( 1 );
-        e3( 1 ) = e1( 2 ) * e2( 0 ) - e1( 0 ) * e2( 2 );
-        e3( 2 ) = e1( 0 ) * e2( 1 ) - e1( 1 ) * e2( 0 );
-      }
-
-      eigenvectors( 0, 0 ) = e1( 0 );
-      eigenvectors( 0, 1 ) = e2( 0 );
-      eigenvectors( 0, 2 ) = e3( 0 );
-      eigenvectors( 1, 0 ) = e1( 1 );
-      eigenvectors( 1, 1 ) = e2( 1 );
-      eigenvectors( 1, 2 ) = e3( 1 );
-      eigenvectors( 2, 0 ) = e1( 2 );
-      eigenvectors( 2, 1 ) = e2( 2 );
-      eigenvectors( 2, 2 ) = e3( 2 );
-
-      return std::make_pair( eigenvalues, eigenvectors );
     }
 
-  } // namespace Math
-} // namespace Marmot
+    return std::make_pair( eigenvalues, V );
+  }
+
+  template < typename T = double >
+  std::pair< FastorStandardTensors::Tensor3t< T >, FastorStandardTensors::Tensor33t< T > > computeEigenSystemWithCardano(
+    const FastorStandardTensors::Tensor33t< T >& A )
+  {
+    using namespace FastorStandardTensors;
+
+    const T trA = trace( A );
+
+    const T p1 = -trA;
+    const T p2 = 0.5 * ( trA * trA - trace( A % A ) );
+    const T p3 = -det( A );
+
+    const T a = p2 - ( p1 * p1 ) / 3.0;
+    const T b = ( 2.0 * p1 * p1 * p1 ) / 27.0 - ( p1 * p2 ) / 3.0 + p3;
+
+    Tensor3t< T > eigenvalues;
+
+    // 1. SAFE BRANCHING: Use the primal value to check for isotropic/repeated states
+    // This prevents the derivative of sqrt(-a) from exploding when 'a' approaches 0.
+    if ( std::abs( Math::makeReal( a ) ) < 1e-14 ) {
+      T root           = -p1 / 3.0;
+      eigenvalues( 0 ) = root;
+      eigenvalues( 1 ) = root;
+      eigenvalues( 2 ) = root;
+    }
+    else {
+      T r = sqrt( -a / 3.0 );
+
+      // Protect against division by zero in the dual part
+      T aux = 3.0 * b / ( 2.0 * a ) * sqrt( -3.0 / a );
+
+      // 2. SAFE CLAMPING: We must evaluate the primal part to clamp,
+      // but if we hardcode `aux = 1.0`, we kill the derivative.
+      // A common AD trick is to let the dual library handle the clamp,
+      // or re-assign with a zeroed dual part if exactly at the boundary.
+      double aux_real = Math::makeReal( aux );
+      if ( aux_real <= -1.0 ) {
+        aux = T( -1.0 ); // Kills gradient at exact boundary to prevent NaN in acos derivative
+      }
+      else if ( aux_real >= 1.0 ) {
+        aux = T( 1.0 ); // Kills gradient at exact boundary to prevent NaN in acos derivative
+      }
+
+      T theta = acos( aux );
+
+      for ( int k = 0; k < 3; ++k ) {
+        // T(2.0) and T(3.0) ensure we don't accidentally cast down to double
+        eigenvalues( k ) = T( 2.0 ) * r * cos( ( theta - T( 2.0 ) * T( M_PI ) * T( k ) ) / T( 3.0 ) ) - p1 / T( 3.0 );
+      }
+    }
+
+    // Sort descending (using primal values for the logic operators)
+    if ( Math::makeReal( eigenvalues( 0 ) ) < Math::makeReal( eigenvalues( 1 ) ) )
+      std::swap( eigenvalues( 0 ), eigenvalues( 1 ) );
+    if ( Math::makeReal( eigenvalues( 1 ) ) < Math::makeReal( eigenvalues( 2 ) ) )
+      std::swap( eigenvalues( 1 ), eigenvalues( 2 ) );
+    if ( Math::makeReal( eigenvalues( 0 ) ) < Math::makeReal( eigenvalues( 1 ) ) )
+      std::swap( eigenvalues( 0 ), eigenvalues( 1 ) );
+
+    // ------------------------------------------------------------------
+    // EIGENVECTOR COMPUTATION
+    // ------------------------------------------------------------------
+    Tensor33t< T > eigenvectors;
+
+    auto get_eigenvector = [&]( T lambda, Tensor3t< T >& v ) {
+      T B[3][3] = { { A( 0, 0 ) - lambda, A( 0, 1 ), A( 0, 2 ) },
+                    { A( 1, 0 ), A( 1, 1 ) - lambda, A( 1, 2 ) },
+                    { A( 2, 0 ), A( 2, 1 ), A( 2, 2 ) - lambda } };
+
+      T v1[3] = { B[1][1] * B[2][2] - B[1][2] * B[2][1],
+                  B[1][2] * B[2][0] - B[1][0] * B[2][2],
+                  B[1][0] * B[2][1] - B[1][1] * B[2][0] };
+      T v2[3] = { B[2][1] * B[0][2] - B[2][2] * B[0][1],
+                  B[2][2] * B[0][0] - B[2][0] * B[0][2],
+                  B[2][0] * B[0][1] - B[2][1] * B[0][0] };
+      T v3[3] = { B[0][1] * B[1][2] - B[0][2] * B[1][1],
+                  B[0][2] * B[1][0] - B[0][0] * B[1][2],
+                  B[0][0] * B[1][1] - B[0][1] * B[1][0] };
+
+      // 3. USE PRIMAL FOR NORM COMPARISONS, BUT PRESERVE `T` FOR THE DIVISION
+      double n1_real = Math::makeReal( T( sqrt( v1[0] * v1[0] + v1[1] * v1[1] + v1[2] * v1[2] ) ) );
+      double n2_real = Math::makeReal( T( sqrt( v2[0] * v2[0] + v2[1] * v2[1] + v2[2] * v2[2] ) ) );
+      double n3_real = Math::makeReal( T( sqrt( v3[0] * v3[0] + v3[1] * v3[1] + v3[2] * v3[2] ) ) );
+
+      double max_norm_real = n1_real;
+      T*     best_v        = v1;
+
+      if ( n2_real > max_norm_real ) {
+        max_norm_real = n2_real;
+        best_v        = v2;
+      }
+      if ( n3_real > max_norm_real ) {
+        max_norm_real = n3_real;
+        best_v        = v3;
+      }
+
+      // Calculate the actual dual norm strictly for the winning vector
+      T max_norm_dual = sqrt( best_v[0] * best_v[0] + best_v[1] * best_v[1] + best_v[2] * best_v[2] );
+
+      if ( max_norm_real > 1e-10 ) {
+        v( 0 ) = best_v[0] / max_norm_dual; // Divide by Dual to keep gradient!
+        v( 1 ) = best_v[1] / max_norm_dual;
+        v( 2 ) = best_v[2] / max_norm_dual;
+      }
+      else {
+        v( 0 ) = T( 0.0 );
+        v( 1 ) = T( 0.0 );
+        v( 2 ) = T( 0.0 );
+      }
+    };
+
+    auto make_orthogonal = []( const Tensor3t< T >& v, Tensor3t< T >& n ) {
+      // Use real parts to find the smallest axis
+      double abs_x = std::abs( Math::makeReal( v( 0 ) ) );
+      double abs_y = std::abs( Math::makeReal( v( 1 ) ) );
+      double abs_z = std::abs( Math::makeReal( v( 2 ) ) );
+
+      Tensor3t< T > axis;
+      axis( 0 ) = T( 0 );
+      axis( 1 ) = T( 0 );
+      axis( 2 ) = T( 0 );
+      if ( abs_x <= abs_y && abs_x <= abs_z )
+        axis( 0 ) = T( 1.0 );
+      else if ( abs_y <= abs_x && abs_y <= abs_z )
+        axis( 1 ) = T( 1.0 );
+      else
+        axis( 2 ) = T( 1.0 );
+
+      n( 0 ) = v( 1 ) * axis( 2 ) - v( 2 ) * axis( 1 );
+      n( 1 ) = v( 2 ) * axis( 0 ) - v( 0 ) * axis( 2 );
+      n( 2 ) = v( 0 ) * axis( 1 ) - v( 1 ) * axis( 0 );
+
+      // Normalize using dual math
+      T len = sqrt( n( 0 ) * n( 0 ) + n( 1 ) * n( 1 ) + n( 2 ) * n( 2 ) );
+      n( 0 ) /= len;
+      n( 1 ) /= len;
+      n( 2 ) /= len;
+    };
+
+    Tensor3t< T > e1, e2, e3;
+
+    double max_eig = std::max( { std::abs( Math::makeReal( eigenvalues( 0 ) ) ),
+                                 std::abs( Math::makeReal( eigenvalues( 1 ) ) ),
+                                 std::abs( Math::makeReal( eigenvalues( 2 ) ) ) } );
+    double tol     = 1e-6 * std::max( max_eig, 1.0 );
+
+    bool root_01_repeated = std::abs( Math::makeReal( T( eigenvalues( 0 ) - eigenvalues( 1 ) ) ) ) < tol;
+    bool root_12_repeated = std::abs( Math::makeReal( T( eigenvalues( 1 ) - eigenvalues( 2 ) ) ) ) < tol;
+
+    if ( root_01_repeated && root_12_repeated ) {
+      e1( 0 ) = T( 1.0 );
+      e1( 1 ) = T( 0.0 );
+      e1( 2 ) = T( 0.0 );
+      e2( 0 ) = T( 0.0 );
+      e2( 1 ) = T( 1.0 );
+      e2( 2 ) = T( 0.0 );
+      e3( 0 ) = T( 0.0 );
+      e3( 1 ) = T( 0.0 );
+      e3( 2 ) = T( 1.0 );
+    }
+    else if ( root_01_repeated ) {
+      get_eigenvector( eigenvalues( 2 ), e3 );
+      make_orthogonal( e3, e1 );
+      e2( 0 ) = e3( 1 ) * e1( 2 ) - e3( 2 ) * e1( 1 );
+      e2( 1 ) = e3( 2 ) * e1( 0 ) - e3( 0 ) * e1( 2 );
+      e2( 2 ) = e3( 0 ) * e1( 1 ) - e3( 1 ) * e1( 0 );
+    }
+    else if ( root_12_repeated ) {
+      get_eigenvector( eigenvalues( 0 ), e1 );
+      make_orthogonal( e1, e2 );
+      e3( 0 ) = e1( 1 ) * e2( 2 ) - e1( 2 ) * e2( 1 );
+      e3( 1 ) = e1( 2 ) * e2( 0 ) - e1( 0 ) * e2( 2 );
+      e3( 2 ) = e1( 0 ) * e2( 1 ) - e1( 1 ) * e2( 0 );
+    }
+    else {
+      get_eigenvector( eigenvalues( 0 ), e1 );
+      get_eigenvector( eigenvalues( 1 ), e2 );
+      e3( 0 ) = e1( 1 ) * e2( 2 ) - e1( 2 ) * e2( 1 );
+      e3( 1 ) = e1( 2 ) * e2( 0 ) - e1( 0 ) * e2( 2 );
+      e3( 2 ) = e1( 0 ) * e2( 1 ) - e1( 1 ) * e2( 0 );
+    }
+
+    eigenvectors( 0, 0 ) = e1( 0 );
+    eigenvectors( 0, 1 ) = e2( 0 );
+    eigenvectors( 0, 2 ) = e3( 0 );
+    eigenvectors( 1, 0 ) = e1( 1 );
+    eigenvectors( 1, 1 ) = e2( 1 );
+    eigenvectors( 1, 2 ) = e3( 1 );
+    eigenvectors( 2, 0 ) = e1( 2 );
+    eigenvectors( 2, 1 ) = e2( 2 );
+    eigenvectors( 2, 2 ) = e3( 2 );
+
+    return std::make_pair( eigenvalues, eigenvectors );
+  }
+
+} // namespace Marmot::Math

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotMath.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotMath.h
@@ -31,474 +31,472 @@
 #include <autodiff/forward/real/real.hpp>
 #include <complex>
 
-namespace Marmot {
-  namespace Math {
+namespace Marmot::Math {
 
-    /** @brief Checks if a scalar is NaN
-     *  @param x scalar to be checked
-     *  @return true if x is NaN, false otherwise
-     *
-     *  Checks if value x is NaN (not a number).
-     *  This is done by checking if x is unequal to itself, which is only true for NaN values.
-     */
-    template < typename T >
-    bool isNaN( T x )
-    {
-      return x != x;
-    }
+  /** @brief Checks if a scalar is NaN
+   *  @param x scalar to be checked
+   *  @return true if x is NaN, false otherwise
+   *
+   *  Checks if value x is NaN (not a number).
+   *  This is done by checking if x is unequal to itself, which is only true for NaN values.
+   */
+  template < typename T >
+  bool isNaN( T x )
+  {
+    return x != x;
+  }
 
-    /** @brief Performs linear interpolation
-     * @param x Point at which to interpolate
-     * @param x0 First known point
-     * @param x1 Second known point
-     * @param y0 Value at first known point
-     * @param y1 Value at second known point
-     * @return Interpolated value at point x
-     *
-     * Performs linear interpolation to find the value at point x given two known points (x0, y0) and (x1, y1).
-     * If x is outside the range [x0, x1], the function will perform linear extrapolation.
-     */
-    double linearInterpolation( double x, double x0, double x1, double y0, double y1 );
+  /** @brief Performs linear interpolation
+   * @param x Point at which to interpolate
+   * @param x0 First known point
+   * @param x1 Second known point
+   * @param y0 Value at first known point
+   * @param y1 Value at second known point
+   * @return Interpolated value at point x
+   *
+   * Performs linear interpolation to find the value at point x given two known points (x0, y0) and (x1, y1).
+   * If x is outside the range [x0, x1], the function will perform linear extrapolation.
+   */
+  double linearInterpolation( double x, double x0, double x1, double y0, double y1 );
 
-    /** @brief Computes the exponential of value @p x with numerical limits check
-     *  @param x Exponent to which e is raised
-     *  @return exponential of x
-     *
-     * If x is larger than the maximum limit of double precision floating point numbers,
-     * the maximum limit is returned. If @p x is smaller than the minimum limit, the minimum limit is returned.
-     */
-    double exp( double x );
+  /** @brief Computes the exponential of value @p x with numerical limits check
+   *  @param x Exponent to which e is raised
+   *  @return exponential of x
+   *
+   * If x is larger than the maximum limit of double precision floating point numbers,
+   * the maximum limit is returned. If @p x is smaller than the minimum limit, the minimum limit is returned.
+   */
+  double exp( double x );
 
-    /**
-     * @brief Runtime factorial
-     * @param n An unsigned integer
-     * @return The factorial of n
-     */
-    unsigned long factorial( unsigned int n );
+  /**
+   * @brief Runtime factorial
+   * @param n An unsigned integer
+   * @return The factorial of n
+   */
+  unsigned long factorial( unsigned int n );
 
-    /** @brief Extracts the exponent to the power of ten from a floating point number
-     *  @param x Input floating point number
-     *  @return Exponent to the power of ten
-     *
-     *  This function extracts the exponent to the power of ten from a given floating point number.
-     *  For example, for an input of 3e5, the function will return 5.
-     *  If the input number is very close to zero (between -1e-16 and 1e-16), the function returns 0.
-     */
-    int getExponentPowerTen( const double x );
+  /** @brief Extracts the exponent to the power of ten from a floating point number
+   *  @param x Input floating point number
+   *  @return Exponent to the power of ten
+   *
+   *  This function extracts the exponent to the power of ten from a given floating point number.
+   *  For example, for an input of 3e5, the function will return 5.
+   *  If the input number is very close to zero (between -1e-16 and 1e-16), the function returns 0.
+   */
+  int getExponentPowerTen( const double x );
 
-    /** @brief Convert angle from radiant to degree
-     *  @param alpha Angle in radiant
-     *  @return Angle in degree
-     *
-     *  Converts angle alpha given in radiant to degree.
-     */
-    constexpr double radToDeg( const double alpha )
-    {
-      return alpha * 180 / Marmot::Constants::Pi;
-    }
+  /** @brief Convert angle from radiant to degree
+   *  @param alpha Angle in radiant
+   *  @return Angle in degree
+   *
+   *  Converts angle alpha given in radiant to degree.
+   */
+  constexpr double radToDeg( const double alpha )
+  {
+    return alpha * 180 / Marmot::Constants::Pi;
+  }
 
-    /** @brief Convert angle from degree to radiant
-     *  @param alpha Angle in degree
-     *  @return Angle in radiant
-     *
-     *  Converts angle alpha given in degree to radiant.
-     */
-    constexpr double degToRad( const double alpha )
-    {
-      return alpha / 180 * Marmot::Constants::Pi;
-    }
+  /** @brief Convert angle from degree to radiant
+   *  @param alpha Angle in degree
+   *  @return Angle in radiant
+   *
+   *  Converts angle alpha given in degree to radiant.
+   */
+  constexpr double degToRad( const double alpha )
+  {
+    return alpha / 180 * Marmot::Constants::Pi;
+  }
 
-    /** @brief Macaulay function applied to a scalar
-     *  @param scalar Input value
-     *  @return Positive part of scalar
-     *
-     *  The Macaulay function, also as positive part operator, is defined as:
-     *  \f[
-     *  \langle x \rangle =
-     *  \begin{cases}
-     *  x, & x \geq 0 \\
-     *  0, & x < 0
-     *  \end{cases}
-     *  \f]
-     */
-    constexpr double macauly( double scalar )
-    {
-      return scalar >= 0 ? scalar : 0.0;
-    }
+  /** @brief Macaulay function applied to a scalar
+   *  @param scalar Input value
+   *  @return Positive part of scalar
+   *
+   *  The Macaulay function, also as positive part operator, is defined as:
+   *  \f[
+   *  \langle x \rangle =
+   *  \begin{cases}
+   *  x, & x \geq 0 \\
+   *  0, & x < 0
+   *  \end{cases}
+   *  \f]
+   */
+  constexpr double macauly( double scalar )
+  {
+    return scalar >= 0 ? scalar : 0.0;
+  }
 
-    /** @brief Heaviside step function applied to a scalar
-     *  @param scalar Input value
-     *  @return 1 if scalar >= 0, 0 otherwise
-     *
-     *  The Heaviside step function is defined as:
-     *  \f[
-     *  H(x) =
-     *  \begin{cases}
-     *  1, & x \geq 0 \\
-     *  0, & x < 0
-     *  \end{cases}
-     *  \f]
-     */
-    constexpr int heaviside( double scalar )
-    {
-      return scalar >= 0 ? 1 : 0;
-    }
+  /** @brief Heaviside step function applied to a scalar
+   *  @param scalar Input value
+   *  @return 1 if scalar >= 0, 0 otherwise
+   *
+   *  The Heaviside step function is defined as:
+   *  \f[
+   *  H(x) =
+   *  \begin{cases}
+   *  1, & x \geq 0 \\
+   *  0, & x < 0
+   *  \end{cases}
+   *  \f]
+   */
+  constexpr int heaviside( double scalar )
+  {
+    return scalar >= 0 ? 1 : 0;
+  }
 
-    /** @brief Heaviside step function excluding zero applied to a scalar
-     *  @param scalar Input value
-     *  @return 1 if scalar > 0, 0 otherwise
-     *
-     *  The Heaviside step function excluding zero is defined as:
-     *  \f[
-     *  H(x) =
-     *  \begin{cases}
-     *  1, & x > 0 \\
-     *  0, & x \leq 0
-     *  \end{cases}
-     *  \f]
-     */
-    constexpr int heavisideExclude0( double scalar )
-    {
-      return scalar > 0 ? 1 : 0;
-    }
+  /** @brief Heaviside step function excluding zero applied to a scalar
+   *  @param scalar Input value
+   *  @return 1 if scalar > 0, 0 otherwise
+   *
+   *  The Heaviside step function excluding zero is defined as:
+   *  \f[
+   *  H(x) =
+   *  \begin{cases}
+   *  1, & x > 0 \\
+   *  0, & x \leq 0
+   *  \end{cases}
+   *  \f]
+   */
+  constexpr int heavisideExclude0( double scalar )
+  {
+    return scalar > 0 ? 1 : 0;
+  }
 
-    /** @brief Sign function applied to a scalar
-     *  @param val Input value
-     *  @return 1 if val > 0, -1 if val < 0, 0 if val == 0
-     *
-     *  The sign function is defined as:
-     *  \f[
-     *  \text{sign}(x) =
-     *  \begin{cases}
-     *  1, & x > 0 \\
-     *  0, & x = 0 \\
-     * -1, & x < 0
-     *  \end{cases}
-     *  \f]
-     */
-    template < typename T >
-    constexpr int sgn( const T& val ) noexcept
-    {
-      return ( T( 0 ) < val ) - ( val < T( 0 ) );
-    }
+  /** @brief Sign function applied to a scalar
+   *  @param val Input value
+   *  @return 1 if val > 0, -1 if val < 0, 0 if val == 0
+   *
+   *  The sign function is defined as:
+   *  \f[
+   *  \text{sign}(x) =
+   *  \begin{cases}
+   *  1, & x > 0 \\
+   *  0, & x = 0 \\
+   * -1, & x < 0
+   *  \end{cases}
+   *  \f]
+   */
+  template < typename T >
+  constexpr int sgn( const T& val ) noexcept
+  {
+    return ( T( 0 ) < val ) - ( val < T( 0 ) );
+  }
 
-    /** @brief Converts various scalar types to double precision floating point numbers
-     *  @param value Input value of various numeric types
-     *  @return Converted value as double
-     *
-     *  This function converts input values of different numeric types, including:
-     *  - double
-     *  - std::complex<double>
-     *  - autodiff::real
-     *  - autodiff::dual
-     *  - Eigen::Matrix with elements of any type convertible to double
-     *
-     *  The function is overloaded and templated to handle these different types appropriately.
-     */
-    double makeReal( const double& value );
-    double makeReal( const std::complex< double >& value );
-    double makeReal( const autodiff::real& value );
+  /** @brief Converts various scalar types to double precision floating point numbers
+   *  @param value Input value of various numeric types
+   *  @return Converted value as double
+   *
+   *  This function converts input values of different numeric types, including:
+   *  - double
+   *  - std::complex<double>
+   *  - autodiff::real
+   *  - autodiff::dual
+   *  - Eigen::Matrix with elements of any type convertible to double
+   *
+   *  The function is overloaded and templated to handle these different types appropriately.
+   */
+  double makeReal( const double& value );
+  double makeReal( const std::complex< double >& value );
+  double makeReal( const autodiff::real& value );
 
-    /** @brief Converts autodiff::dual numbers to double precision floating point numbers
-     *  @tparam T Underlying type of the autodiff::dual number
-     *  @tparam G Gradient type of the autodiff::dual number
-     *  @param number Input autodiff::dual number
-     *  @return Converted value as double
-     *
-     *  This function converts an autodiff::dual number to a double precision floating point number.
-     *  It is templated to handle dual numbers with different underlying types.
-     */
-    template < typename T, typename G >
-    double makeReal( const autodiff::detail::Dual< T, G >& number )
-    {
-      return double( number );
-    }
+  /** @brief Converts autodiff::dual numbers to double precision floating point numbers
+   *  @tparam T Underlying type of the autodiff::dual number
+   *  @tparam G Gradient type of the autodiff::dual number
+   *  @param number Input autodiff::dual number
+   *  @return Converted value as double
+   *
+   *  This function converts an autodiff::dual number to a double precision floating point number.
+   *  It is templated to handle dual numbers with different underlying types.
+   */
+  template < typename T, typename G >
+  double makeReal( const autodiff::detail::Dual< T, G >& number )
+  {
+    return double( number );
+  }
 
-    /** @brief Extracts the real part of a arbitrary scalartype-valued Matrix
-     *  @tparam T scalar type
-     *  @tparam Rest... parameter pack for additional matrix information, e.g, dimensions
-     *  @param mat T-valued matrix
-     *  @return double-valued matrix
-     */
-    template < typename T, int... Rest >
-    Eigen::Matrix< double, Rest... > makeReal( const Eigen::Matrix< T, Rest... > mat )
-    {
-      Eigen::Matrix< double, Rest... > out;
-      const size_t                     m = static_cast< size_t >( mat.rows() );
-      const size_t                     n = static_cast< size_t >( mat.cols() );
+  /** @brief Extracts the real part of a arbitrary scalartype-valued Matrix
+   *  @tparam T scalar type
+   *  @tparam Rest... parameter pack for additional matrix information, e.g, dimensions
+   *  @param mat T-valued matrix
+   *  @return double-valued matrix
+   */
+  template < typename T, int... Rest >
+  Eigen::Matrix< double, Rest... > makeReal( const Eigen::Matrix< T, Rest... > mat )
+  {
+    Eigen::Matrix< double, Rest... > out;
+    const size_t                     m = static_cast< size_t >( mat.rows() );
+    const size_t                     n = static_cast< size_t >( mat.cols() );
 
-      for ( size_t i = 0; i < m; i++ ) {
-        for ( size_t j = 0; j < n; j++ ) {
-          out( i, j ) = makeReal( mat( i, j ) );
-        }
+    for ( size_t i = 0; i < m; i++ ) {
+      for ( size_t j = 0; j < n; j++ ) {
+        out( i, j ) = makeReal( mat( i, j ) );
       }
+    }
+    return out;
+  }
+
+  /** @brief Extracts the real part of a arbitrary scalartype-valued Vector
+   *  @tparam T scalar type
+   *  @param in T-valued vector
+   *  @return double-valued vector
+   */
+  template < typename T >
+  Eigen::VectorXd makeReal( Eigen::Vector< T, Eigen::Dynamic > in )
+  {
+
+    int             inSize = in.size();
+    Eigen::VectorXd out( inSize );
+    for ( int i = 0; i < inSize; i++ ) {
+      out( i ) = double( in( i ) );
+    }
+    return out;
+  }
+
+  /**
+   * @brief Apply Macaulay function to a matrix
+   * @tparam nRows Number of rows in the matrix
+   * @tparam nCols Number of columns in the matrix
+   * @param mat Input matrix
+   * @return Matrix with Macaulay function applied element-wise
+   *
+   * Applies the Macaulay function element-wise to the input matrix.
+   *
+   * @todo: Can be replaced easily with Eigen's array() functionality ???
+   */
+  template < int nRows, int nCols >
+  Eigen::Matrix< double, nRows, nCols > macaulyMatrix( const Eigen::Matrix< double, nRows, nCols >& mat )
+  {
+    Eigen::Matrix< double, nRows, nCols > positivePart = Eigen::Matrix< double, nRows, nCols >::Zero();
+    for ( int i = 0; i < nRows; i++ ) {
+      for ( int j = 0; j < nCols; j++ ) {
+        positivePart( i, j ) = macauly( mat( i, j ) );
+      }
+    }
+    return positivePart;
+  }
+
+  /** @brief Explicit Euler time integrator
+   * @param yN Current value
+   * @param dt Time step size
+   * @param fRate Function that computes the rate of change
+   * @param fRateArgs Additional arguments for the rate function
+   * @return Updated value after time step
+   *
+   * This function computes one single time step using the explicit Euler method:
+   * \f[ \boldsymbol{y}_{n+1} = \boldsymbol{y}_n + f(\boldsymbol{y}_n) * \Delta t \f]
+   * where \f$ \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is the time step size,
+   * and \f$ f(\boldsymbol{y}_n) \f$ is the rate of change.
+   *
+   */
+  template < typename functionType, typename yType, typename... Args >
+  yType explicitEuler( yType yN, const double dt, functionType fRate, Args&&... fRateArgs )
+  {
+    return yN + fRate( yN, fRateArgs... ) * dt;
+  }
+
+  /**
+   * @brief Implicit Euler time integrator for a linear vector-valued rate equation
+   * @param yN Current value
+   * @param dt Time step size
+   * @param fRate Function that computes the rate of change
+   * @param fRateArgs Additional arguments for the rate function
+   * @return Updated value after time step
+   *
+   * This function computes one single time step using the implicit Euler method for a linear vector-valued rate
+   * equation: \f[ \boldsymbol{y}_{n+1} = \boldsymbol{y}_n + f(\boldsymbol{y}_{n+1}) \Delta t \f] where \f$
+   * \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is the time step size, and \f$ f(\boldsymbol{y}) \f$
+   * is the linear rate of change evaluated at the next time step.
+   *
+   *
+   * @todo: Is this really semi-implicit? It looks like a fully implicit Euler step for linear systems.
+   * @todo: Use external central difference function?
+   *
+   * */
+  template < int ySize, typename functionType, typename... Args >
+  Eigen::Matrix< double, ySize, 1 > semiImplicitEuler( Eigen::Matrix< double, ySize, 1 > yN,
+                                                       const double                      dt,
+                                                       functionType                      fRate,
+                                                       Args&&... fRateArgs )
+  {
+    Eigen::Matrix< double, ySize, ySize > fS = Eigen::Matrix< double, ySize, ySize >::Zero();
+    Eigen::Matrix< double, ySize, ySize > Iy = Eigen::Matrix< double, ySize, ySize >::Identity();
+
+    Eigen::VectorXd leftX( ySize );
+    Eigen::VectorXd rightX( ySize );
+
+    for ( size_t i = 0; i < ySize; i++ ) {
+      double volatile h = std::max( 1.0, std::abs( yN( i ) ) ) * Constants::cubicRootEps();
+      leftX             = yN;
+      leftX( i ) -= h;
+      rightX = yN;
+      rightX( i ) += h;
+      fS.col( i ) = 1. / ( 2. * h ) * ( fRate( rightX, fRateArgs... ) - fRate( leftX, fRateArgs... ) );
+    }
+
+    const auto A = Iy - dt * fS;
+    const auto r = fRate( yN, fRateArgs... );
+
+    if constexpr ( ySize == 1 ) {
+      Eigen::Matrix< double, 1, 1 > out;
+      out( 0 ) = yN( 0 ) + dt * r( 0 ) / A( 0, 0 );
       return out;
     }
 
-    /** @brief Extracts the real part of a arbitrary scalartype-valued Vector
-     *  @tparam T scalar type
-     *  @param in T-valued vector
-     *  @return double-valued vector
-     */
-    template < typename T >
-    Eigen::VectorXd makeReal( Eigen::Vector< T, Eigen::Dynamic > in )
-    {
+    return yN + A.colPivHouseholderQr().solve( dt * r );
+  }
 
-      int             inSize = in.size();
-      Eigen::VectorXd out( inSize );
-      for ( int i = 0; i < inSize; i++ ) {
-        out( i ) = double( in( i ) );
-      }
-      return out;
+  /**
+   * @brief Explicit Euler integration with error estimation based on Richardson extrapolation
+   * @tparam functionType Type of the rate function
+   * @tparam yType Type of the current value
+   * @tparam Args Additional argument types for the rate function
+   * @param yN Current value
+   * @param dt Time step size
+   * @param fRate Function that computes the rate of change
+   * @param fRateArgs Additional arguments for the rate function
+   * @return Updated value after time step
+   *
+   * This function computes one single time step using the explicit Euler method with Richardson extrapolation for
+   * error estimation: \f[ \boldsymbol{y}_{n+1} = 2 \left( \boldsymbol{y}_n + f\left(\boldsymbol{y}_n
+   * + \frac{f(\boldsymbol{y}_n) \Delta t}{2}\right) \frac{\Delta t}{2} \right) - \left( \boldsymbol{y}_n +
+   * f(\boldsymbol{y}_n) \Delta t \right) \f] where \f$ \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is
+   * the time step size, and \f$ f(\boldsymbol{y}) \f$ is the rate of change.
+   *
+   */
+  template < typename functionType, typename yType, typename... Args >
+  yType explicitEulerRichardson( yType yN, const double dt, functionType fRate, Args&&... fRateArgs )
+  {
+    yType fN = fRate( yN, fRateArgs... );
+    yType u  = yN + fN * dt;
+    yType v  = yN + fN * dt / 2.;
+    yType w  = v + fRate( v, fRateArgs... ) * dt / 2.;
+
+    return 2. * w - u;
+  }
+
+  /**
+   * @brief Explicit Euler integration based on Richardson extrapolation with error estimation and time step
+   * estimation
+   * @tparam ySize Size of the state vector
+   * @tparam functionType Type of the rate function
+   * @tparam Args Additional argument types for the rate function
+   * @param yN Current value
+   * @param dt Current time step size
+   * @param TOL Desired tolerance for the error estimation
+   * @param fRate Function that computes the rate of change
+   * @param fRateArgs Additional arguments for the rate function
+   * @return Tuple containing the updated value after time step and the new time step size
+   *
+   * This function computes one single time step using the explicit Euler method with Richardson extrapolation for
+   * error estimation and adaptive time stepping: \f[ \boldsymbol{y}_{n+1} = 2 \left( \boldsymbol{y}_n +
+   * f\left(\boldsymbol{y}_n
+   * + \frac{f(\boldsymbol{y}_n) \Delta t}{2}\right) \frac{\Delta t}{2} \right) - \left( \boldsymbol{y}_n +
+   * f(\boldsymbol{y}_n) \Delta t \right) \f] where \f$ \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is
+   * the current time step size, and \f$ f(\boldsymbol{y}) \f$ is the rate of change.
+   *
+   * The function also estimates the error of the time step and adjusts the time step size for the next iteration
+   * based on the desired tolerance @p TOL. The new time step size is computed as: \f[ \Delta t_{\text{new}} =
+   * \Delta t \cdot \min\left(2, \max\left(0.2, 0.9 \sqrt{\frac{TOL}{EST}}\right)\right) \f] where \f$ EST \f$ is the
+   * estimated error.
+   *
+   * @todo: reuse explicitEulerRichardson function?
+   */
+  template < int ySize, typename functionType, typename... Args >
+  std::tuple< Eigen::Matrix< double, ySize, 1 >, double > explicitEulerRichardsonWithErrorEstimator(
+    Eigen::Matrix< double, ySize, 1 > yN,
+    const double                      dt,
+    const double                      TOL,
+    functionType                      fRate,
+    Args&&... fRateArgs )
+  {
+
+    typedef Eigen::Matrix< double, ySize, 1 > ySized;
+    ySized                                    fN   = fRate( yN, fRateArgs... );
+    ySized                                    u    = yN + fN * dt;
+    ySized                                    v    = yN + fN * dt / 2.;
+    ySized                                    w    = v + fRate( v, fRateArgs... ) * dt / 2.;
+    ySized                                    yNew = 2. * w - u;
+
+    // error estimator
+    const double AERR    = 1.0;
+    const double aI      = AERR / TOL;
+    const double rI      = 1.0;
+    double       scaling = 0;
+    ySized       ESTVec  = ySized::Zero();
+
+    for ( int i = 0; i < ySize; i++ ) {
+      scaling     = aI + rI * std::max( abs( yNew( i ) ), abs( yN( i ) ) );
+      ESTVec( i ) = abs( w( i ) - u( i ) ) / abs( scaling );
     }
 
-    /**
-     * @brief Apply Macaulay function to a matrix
-     * @tparam nRows Number of rows in the matrix
-     * @tparam nCols Number of columns in the matrix
-     * @param mat Input matrix
-     * @return Matrix with Macaulay function applied element-wise
-     *
-     * Applies the Macaulay function element-wise to the input matrix.
-     *
-     * @todo: Can be replaced easily with Eigen's array() functionality ???
-     */
-    template < int nRows, int nCols >
-    Eigen::Matrix< double, nRows, nCols > macaulyMatrix( const Eigen::Matrix< double, nRows, nCols >& mat )
-    {
-      Eigen::Matrix< double, nRows, nCols > positivePart = Eigen::Matrix< double, nRows, nCols >::Zero();
-      for ( int i = 0; i < nRows; i++ ) {
-        for ( int j = 0; j < nCols; j++ ) {
-          positivePart( i, j ) = macauly( mat( i, j ) );
-        }
-      }
-      return positivePart;
-    }
+    const double EST    = ESTVec.maxCoeff();
+    const double tauNew = dt * std::min( 2., std::max( 0.2, 0.9 * std::sqrt( TOL / EST ) ) );
 
-    /** @brief Explicit Euler time integrator
-     * @param yN Current value
-     * @param dt Time step size
-     * @param fRate Function that computes the rate of change
-     * @param fRateArgs Additional arguments for the rate function
-     * @return Updated value after time step
-     *
-     * This function computes one single time step using the explicit Euler method:
-     * \f[ \boldsymbol{y}_{n+1} = \boldsymbol{y}_n + f(\boldsymbol{y}_n) * \Delta t \f]
-     * where \f$ \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is the time step size,
-     * and \f$ f(\boldsymbol{y}_n) \f$ is the rate of change.
-     *
-     */
-    template < typename functionType, typename yType, typename... Args >
-    yType explicitEuler( yType yN, const double dt, functionType fRate, Args&&... fRateArgs )
-    {
-      return yN + fRate( yN, fRateArgs... ) * dt;
-    }
+    return std::make_tuple( yNew, tauNew );
+  }
 
-    /**
-     * @brief Implicit Euler time integrator for a linear vector-valued rate equation
-     * @param yN Current value
-     * @param dt Time step size
-     * @param fRate Function that computes the rate of change
-     * @param fRateArgs Additional arguments for the rate function
-     * @return Updated value after time step
-     *
-     * This function computes one single time step using the implicit Euler method for a linear vector-valued rate
-     * equation: \f[ \boldsymbol{y}_{n+1} = \boldsymbol{y}_n + f(\boldsymbol{y}_{n+1}) \Delta t \f] where \f$
-     * \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is the time step size, and \f$ f(\boldsymbol{y}) \f$
-     * is the linear rate of change evaluated at the next time step.
-     *
-     *
-     * @todo: Is this really semi-implicit? It looks like a fully implicit Euler step for linear systems.
-     * @todo: Use external central difference function?
-     *
-     * */
-    template < int ySize, typename functionType, typename... Args >
-    Eigen::Matrix< double, ySize, 1 > semiImplicitEuler( Eigen::Matrix< double, ySize, 1 > yN,
-                                                         const double                      dt,
-                                                         functionType                      fRate,
-                                                         Args&&... fRateArgs )
-    {
-      Eigen::Matrix< double, ySize, ySize > fS = Eigen::Matrix< double, ySize, ySize >::Zero();
-      Eigen::Matrix< double, ySize, ySize > Iy = Eigen::Matrix< double, ySize, ySize >::Identity();
+  /**
+   * @brief Computes the direction cosines between a given coordinate system and the global coordinate system
+   * @param transformedCoordinateSystem 3x3 matrix representing the transformed coordinate system
+   * @return 3x3 matrix of direction cosines
+   *
+   * The direction cosines are computed as the dot products between the basis vectors of the transformed coordinate
+   * system and the global coordinate system.
+   */
+  Matrix3d directionCosines( const Matrix3d& transformedCoordinateSystem );
 
-      Eigen::VectorXd leftX( ySize );
-      Eigen::VectorXd rightX( ySize );
+  /**
+   * @brief Constructs a orthonormal coordinate system with a given normal vector as \f$x_1\f$-axis.
+   * @param normalVector Input normal vector, which will be normalized and used as \f$x_1\f$-axis.
+   * @return Orthonormal coordinate system as a 3x3 matrix.
+   *
+   * The orthonormal coordinate system is constructed such that:
+   * - The first column corresponds to the normalized input normal vector (\f$x_1\f$-axis).
+   * - The second column is a unit vector orthogonal to the first (\f$x_2\f$-axis).
+   * - The third column is the cross product of the first two columns (\f$x_3\f$-axis).
+   *
+   * @note Do not use this function if you want to control the direction of the axes in the plane orthogonal to the
+   * normal vector.
+   * @todo: Maybe remove this function completely to avoid mistakes?
+   */
+  Matrix3d orthonormalCoordinateSystem( Vector3d& normalVector );
 
-      for ( size_t i = 0; i < ySize; i++ ) {
-        double volatile h = std::max( 1.0, std::abs( yN( i ) ) ) * Constants::cubicRootEps();
-        leftX             = yN;
-        leftX( i ) -= h;
-        rightX = yN;
-        rightX( i ) += h;
-        fS.col( i ) = 1. / ( 2. * h ) * ( fRate( rightX, fRateArgs... ) - fRate( leftX, fRateArgs... ) );
-      }
+  /**
+   * @brief Constructs an orthonormal coordinate system with two given normal vectors.
+   * @param n1 First input vector.
+   * @param n2 Second input vector.
+   * @return Orthonormal coordinate system as a 3x3 matrix.
+   *
+   * @throws std::invalid_argument if the input normal vectors are not orthogonal.
+   *
+   * The orthonormal coordinate system is constructed such that:
+   * - The first column corresponds to the normalized first input normal vector (\f$x_1\f$-axis).
+   * - The second colum corresponds to the normalized second input normal vector (\f$x_2\f$-axis).
+   * - The third column is the normalized cross product of the first two columns (\f$x_3\f$-axis).
+   */
+  Matrix3d orthonormalCoordinateSystem( const Vector3d& n1, const Vector3d& n2 );
 
-      const auto A = Iy - dt * fS;
-      const auto r = fRate( yN, fRateArgs... );
+  /**
+   * @brief Transforms a second-order tensor from the global coordinate system to a local coordinate system.
+   * @param T The tensor to be transformed, represented as a 3x3 matrix in the global coordinate system.
+   * @param transformedCoordinateSystem The 3x3 transformation matrix representing the local coordinate system axes in
+   * global coordinates.
+   * @return The tensor represented in the local coordinate system as a 3x3 matrix.
+   *
+   * The transformation is performed as: \f$ T_{local} = Q^T \, T_{global} \, Q \f$, where \f$ Q \f$ is the
+   * transformation matrix.
+   */
+  Matrix3d transformToLocalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem );
 
-      if constexpr ( ySize == 1 ) {
-        Eigen::Matrix< double, 1, 1 > out;
-        out( 0 ) = yN( 0 ) + dt * r( 0 ) / A( 0, 0 );
-        return out;
-      }
+  /**
+   * @brief Transforms a second-order tensor from a local coordinate system to the global coordinate system.
+   * @param T The tensor to be transformed, represented as a 3x3 matrix in the local coordinate system.
+   * @param transformedCoordinateSystem The 3x3 transformation matrix representing the local coordinate system axes in
+   * global coordinates.
+   * @return The tensor represented in the global coordinate system as a 3x3 matrix.
+   *
+   * The transformation is performed as: \f$ T_{global} = Q \, T_{local} \, Q^T \f$, where \f$ Q \f$ is the
+   * transformation matrix.
+   */
+  Matrix3d transformToGlobalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem );
 
-      return yN + A.colPivHouseholderQr().solve( dt * r );
-    }
-
-    /**
-     * @brief Explicit Euler integration with error estimation based on Richardson extrapolation
-     * @tparam functionType Type of the rate function
-     * @tparam yType Type of the current value
-     * @tparam Args Additional argument types for the rate function
-     * @param yN Current value
-     * @param dt Time step size
-     * @param fRate Function that computes the rate of change
-     * @param fRateArgs Additional arguments for the rate function
-     * @return Updated value after time step
-     *
-     * This function computes one single time step using the explicit Euler method with Richardson extrapolation for
-     * error estimation: \f[ \boldsymbol{y}_{n+1} = 2 \left( \boldsymbol{y}_n + f\left(\boldsymbol{y}_n
-     * + \frac{f(\boldsymbol{y}_n) \Delta t}{2}\right) \frac{\Delta t}{2} \right) - \left( \boldsymbol{y}_n +
-     * f(\boldsymbol{y}_n) \Delta t \right) \f] where \f$ \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is
-     * the time step size, and \f$ f(\boldsymbol{y}) \f$ is the rate of change.
-     *
-     */
-    template < typename functionType, typename yType, typename... Args >
-    yType explicitEulerRichardson( yType yN, const double dt, functionType fRate, Args&&... fRateArgs )
-    {
-      yType fN = fRate( yN, fRateArgs... );
-      yType u  = yN + fN * dt;
-      yType v  = yN + fN * dt / 2.;
-      yType w  = v + fRate( v, fRateArgs... ) * dt / 2.;
-
-      return 2. * w - u;
-    }
-
-    /**
-     * @brief Explicit Euler integration based on Richardson extrapolation with error estimation and time step
-     * estimation
-     * @tparam ySize Size of the state vector
-     * @tparam functionType Type of the rate function
-     * @tparam Args Additional argument types for the rate function
-     * @param yN Current value
-     * @param dt Current time step size
-     * @param TOL Desired tolerance for the error estimation
-     * @param fRate Function that computes the rate of change
-     * @param fRateArgs Additional arguments for the rate function
-     * @return Tuple containing the updated value after time step and the new time step size
-     *
-     * This function computes one single time step using the explicit Euler method with Richardson extrapolation for
-     * error estimation and adaptive time stepping: \f[ \boldsymbol{y}_{n+1} = 2 \left( \boldsymbol{y}_n +
-     * f\left(\boldsymbol{y}_n
-     * + \frac{f(\boldsymbol{y}_n) \Delta t}{2}\right) \frac{\Delta t}{2} \right) - \left( \boldsymbol{y}_n +
-     * f(\boldsymbol{y}_n) \Delta t \right) \f] where \f$ \boldsymbol{y}_n \f$ is the current value, \f$ \Delta t \f$ is
-     * the current time step size, and \f$ f(\boldsymbol{y}) \f$ is the rate of change.
-     *
-     * The function also estimates the error of the time step and adjusts the time step size for the next iteration
-     * based on the desired tolerance @p TOL. The new time step size is computed as: \f[ \Delta t_{\text{new}} =
-     * \Delta t \cdot \min\left(2, \max\left(0.2, 0.9 \sqrt{\frac{TOL}{EST}}\right)\right) \f] where \f$ EST \f$ is the
-     * estimated error.
-     *
-     * @todo: reuse explicitEulerRichardson function?
-     */
-    template < int ySize, typename functionType, typename... Args >
-    std::tuple< Eigen::Matrix< double, ySize, 1 >, double > explicitEulerRichardsonWithErrorEstimator(
-      Eigen::Matrix< double, ySize, 1 > yN,
-      const double                      dt,
-      const double                      TOL,
-      functionType                      fRate,
-      Args&&... fRateArgs )
-    {
-
-      typedef Eigen::Matrix< double, ySize, 1 > ySized;
-      ySized                                    fN   = fRate( yN, fRateArgs... );
-      ySized                                    u    = yN + fN * dt;
-      ySized                                    v    = yN + fN * dt / 2.;
-      ySized                                    w    = v + fRate( v, fRateArgs... ) * dt / 2.;
-      ySized                                    yNew = 2. * w - u;
-
-      // error estimator
-      const double AERR    = 1.0;
-      const double aI      = AERR / TOL;
-      const double rI      = 1.0;
-      double       scaling = 0;
-      ySized       ESTVec  = ySized::Zero();
-
-      for ( int i = 0; i < ySize; i++ ) {
-        scaling     = aI + rI * std::max( abs( yNew( i ) ), abs( yN( i ) ) );
-        ESTVec( i ) = abs( w( i ) - u( i ) ) / abs( scaling );
-      }
-
-      const double EST    = ESTVec.maxCoeff();
-      const double tauNew = dt * std::min( 2., std::max( 0.2, 0.9 * std::sqrt( TOL / EST ) ) );
-
-      return std::make_tuple( yNew, tauNew );
-    }
-
-    /**
-     * @brief Computes the direction cosines between a given coordinate system and the global coordinate system
-     * @param transformedCoordinateSystem 3x3 matrix representing the transformed coordinate system
-     * @return 3x3 matrix of direction cosines
-     *
-     * The direction cosines are computed as the dot products between the basis vectors of the transformed coordinate
-     * system and the global coordinate system.
-     */
-    Matrix3d directionCosines( const Matrix3d& transformedCoordinateSystem );
-
-    /**
-     * @brief Constructs a orthonormal coordinate system with a given normal vector as \f$x_1\f$-axis.
-     * @param normalVector Input normal vector, which will be normalized and used as \f$x_1\f$-axis.
-     * @return Orthonormal coordinate system as a 3x3 matrix.
-     *
-     * The orthonormal coordinate system is constructed such that:
-     * - The first column corresponds to the normalized input normal vector (\f$x_1\f$-axis).
-     * - The second column is a unit vector orthogonal to the first (\f$x_2\f$-axis).
-     * - The third column is the cross product of the first two columns (\f$x_3\f$-axis).
-     *
-     * @note Do not use this function if you want to control the direction of the axes in the plane orthogonal to the
-     * normal vector.
-     * @todo: Maybe remove this function completely to avoid mistakes?
-     */
-    Matrix3d orthonormalCoordinateSystem( Vector3d& normalVector );
-
-    /**
-     * @brief Constructs an orthonormal coordinate system with two given normal vectors.
-     * @param n1 First input vector.
-     * @param n2 Second input vector.
-     * @return Orthonormal coordinate system as a 3x3 matrix.
-     *
-     * @throws std::invalid_argument if the input normal vectors are not orthogonal.
-     *
-     * The orthonormal coordinate system is constructed such that:
-     * - The first column corresponds to the normalized first input normal vector (\f$x_1\f$-axis).
-     * - The second colum corresponds to the normalized second input normal vector (\f$x_2\f$-axis).
-     * - The third column is the normalized cross product of the first two columns (\f$x_3\f$-axis).
-     */
-    Matrix3d orthonormalCoordinateSystem( const Vector3d& n1, const Vector3d& n2 );
-
-    /**
-     * @brief Transforms a second-order tensor from the global coordinate system to a local coordinate system.
-     * @param T The tensor to be transformed, represented as a 3x3 matrix in the global coordinate system.
-     * @param transformedCoordinateSystem The 3x3 transformation matrix representing the local coordinate system axes in
-     * global coordinates.
-     * @return The tensor represented in the local coordinate system as a 3x3 matrix.
-     *
-     * The transformation is performed as: \f$ T_{local} = Q^T \, T_{global} \, Q \f$, where \f$ Q \f$ is the
-     * transformation matrix.
-     */
-    Matrix3d transformToLocalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem );
-
-    /**
-     * @brief Transforms a second-order tensor from a local coordinate system to the global coordinate system.
-     * @param T The tensor to be transformed, represented as a 3x3 matrix in the local coordinate system.
-     * @param transformedCoordinateSystem The 3x3 transformation matrix representing the local coordinate system axes in
-     * global coordinates.
-     * @return The tensor represented in the global coordinate system as a 3x3 matrix.
-     *
-     * The transformation is performed as: \f$ T_{global} = Q \, T_{local} \, Q^T \f$, where \f$ Q \f$ is the
-     * transformation matrix.
-     */
-    Matrix3d transformToGlobalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem );
-
-  } // namespace Math
-} // namespace Marmot
+} // namespace Marmot::Math

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotNumericalDifferentiation.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotNumericalDifferentiation.h
@@ -28,168 +28,165 @@
 #include "Marmot/MarmotTypedefs.h"
 #include <functional>
 
-namespace Marmot {
-  namespace NumericalAlgorithms::Differentiation {
+namespace Marmot::NumericalAlgorithms::Differentiation {
+
+  /** @typedef scalar_to_scalar_function_type
+   *  @brief Type definition for a function that maps a double to another double.
+   */
+  using scalar_to_scalar_function_type = std::function< double( const double x ) >;
+
+  /** @typedef vector_to_vector_function_type
+   *  @brief Type definition for a function that maps an Eigen vector to another Eigen vector.
+   */
+  using vector_to_vector_function_type = std::function< Eigen::VectorXd( const Eigen::VectorXd& X ) >;
+
+  /** @brief Approximates the first derivative of a scalar function f at point x using the forward difference method.
+   *  @param f The scalar function for which the derivative is to be approximated.
+   *  @param x The point at which the derivative is to be approximated.
+   *  @return The approximated first derivative of f at point x.
+   *
+   *  It actually computes
+   *  \f[
+   *   f'(x) \approx \frac{f(x + h) - f(x)}{h}
+   *   \f]
+   *   with \f$ h = \sqrt{\epsilon}\, \max(1,|x|) \f$ and \f$ \epsilon \f$ being the machine precision.
+   */
+  double forwardDifference( const scalar_to_scalar_function_type& f, const double x );
+
+  /** @brief Approximates the first derivative of a scalar function f at point x using the central difference method.
+   *  @param f The scalar function for which the derivative is to be approximated.
+   *  @param x The point at which the derivative is to be approximated.
+   *  @return The approximated first derivative of f at point x.
+   *
+   *  It actually approximates the first derivative by
+   *  \f[
+   *   f'(x) \approx \frac{f(x + h) - f(x - h)}{2h}
+   *   \f]
+   *   with \f$ h = \sqrt[3]{\epsilon}\,\max( 1, |x|)\f$ and \f$ \epsilon \f$ being the machine precision.
+   */
+  double centralDifference( const scalar_to_scalar_function_type& f, const double x );
+
+  /** @brief Approximates the Jacobian matrix of a vector function F at point X using the forward difference method.
+   *  @param F The vector function for which the Jacobian matrix is to be approximated.
+   *  @param X The point at which the Jacobian matrix is to be approximated.
+   *  @return The approximated Jacobian matrix of F at point X.
+   *
+   *  It actually computes
+   *  \f[
+   *   J_{ij} \approx \frac{F_i(X + h e_j) - F_i(X)}{h}
+   *   \f]
+   *   with \f$ h = \sqrt{\epsilon} (1 + |X_j|) \f$, \f$ e_j \f$ being the unit vector in the j-th direction, and \f$
+   * \epsilon \f$ being the machine precision.
+   */
+  Eigen::MatrixXd forwardDifference( const vector_to_vector_function_type& F, const Eigen::VectorXd& X );
+
+  /** @brief Approximates the Jacobian matrix of a vector function F at point X using the central difference method.
+   *  @param F The vector function for which the Jacobian matrix is to be approximated.
+   *  @param X The point at which the Jacobian matrix is to be approximated.
+   *  @return The approximated Jacobian matrix of F at point X.
+   *
+   *  It actually approximates the Jacobian matrix by
+   *  \f[
+   *   J_{ij} \approx \frac{F_i(\boldsymbol{X} + h e_j) - F_i(\boldsymbol{X} - h e_j)}{2h}
+   *   \f]
+   *   with \f$ h = \sqrt[3]{\epsilon} \max(1, ||\boldsymbol{X}||) \f$, \f$ e_j \f$ being the unit vector in the j-th
+   * direction, and \f$ \epsilon \f$ being the machine precision.
+   */
+  Eigen::MatrixXd centralDifference( const vector_to_vector_function_type& F, const Eigen::VectorXd& X );
+
+  namespace Complex {
+
+    /// A variable representing \f$ 0 + 1i \f$
+    const static std::complex< double > imaginaryUnit = { 0, 1 };
+    /// A variable representing \f$ 1 + 1i \f$
+    const static std::complex< double > complexUnit = { 1, 1 };
+    /// A variable representing \f$ \frac{\sqrt{2}}{2} (1+1i) \f$
+    const static std::complex< double > i_ = Marmot::Constants::sqrt2 / 2. * complexUnit;
 
     /** @typedef scalar_to_scalar_function_type
-     *  @brief Type definition for a function that maps a double to another double.
+     *  @brief Type definition for a function that maps a complex double to another complex double.
      */
-    using scalar_to_scalar_function_type = std::function< double( const double x ) >;
+    using scalar_to_scalar_function_type = std::function< complexDouble( const complexDouble x ) >;
 
     /** @typedef vector_to_vector_function_type
-     *  @brief Type definition for a function that maps an Eigen vector to another Eigen vector.
+     *  @brief Type definition for a function that maps an Eigen complex vector to another Eigen complex vector.
      */
-    using vector_to_vector_function_type = std::function< Eigen::VectorXd( const Eigen::VectorXd& X ) >;
+    using vector_to_vector_function_type = std::function< Eigen::VectorXcd( const Eigen::VectorXcd& X ) >;
 
-    /** @brief Approximates the first derivative of a scalar function f at point x using the forward difference method.
+    /** @brief Approximates the first derivative of a scalar function f at point x using the complex step method.
      *  @param f The scalar function for which the derivative is to be approximated.
      *  @param x The point at which the derivative is to be approximated.
      *  @return The approximated first derivative of f at point x.
      *
      *  It actually computes
      *  \f[
-     *   f'(x) \approx \frac{f(x + h) - f(x)}{h}
+     *   f'(x) \approx \frac{\text{Im}(f(x + ih))}{h}
      *   \f]
-     *   with \f$ h = \sqrt{\epsilon}\, \max(1,|x|) \f$ and \f$ \epsilon \f$ being the machine precision.
+     *   with \f$ h = 10^{-20} \f$.
+     *
+     *   @note This method is highly accurate and does not suffer from subtractive cancellation errors,
+     *   making it suitable for functions where high precision is required.
+     *
      */
     double forwardDifference( const scalar_to_scalar_function_type& f, const double x );
 
-    /** @brief Approximates the first derivative of a scalar function f at point x using the central difference method.
-     *  @param f The scalar function for which the derivative is to be approximated.
-     *  @param x The point at which the derivative is to be approximated.
-     *  @return The approximated first derivative of f at point x.
-     *
-     *  It actually approximates the first derivative by
-     *  \f[
-     *   f'(x) \approx \frac{f(x + h) - f(x - h)}{2h}
-     *   \f]
-     *   with \f$ h = \sqrt[3]{\epsilon}\,\max( 1, |x|)\f$ and \f$ \epsilon \f$ being the machine precision.
-     */
-    double centralDifference( const scalar_to_scalar_function_type& f, const double x );
-
-    /** @brief Approximates the Jacobian matrix of a vector function F at point X using the forward difference method.
+    /** @brief Approximates the Jacobian matrix of a vector function F at point X using the complex step method.
      *  @param F The vector function for which the Jacobian matrix is to be approximated.
      *  @param X The point at which the Jacobian matrix is to be approximated.
-     *  @return The approximated Jacobian matrix of F at point X.
+     *  @return A tuple containing the function value at X and the approximated Jacobian matrix of F at point X.
      *
      *  It actually computes
      *  \f[
-     *   J_{ij} \approx \frac{F_i(X + h e_j) - F_i(X)}{h}
+     *   J_{ij} \approx \frac{\text{Im}(F_i(X + ih e_j))}{h}
      *   \f]
-     *   with \f$ h = \sqrt{\epsilon} (1 + |X_j|) \f$, \f$ e_j \f$ being the unit vector in the j-th direction, and \f$
-     * \epsilon \f$ being the machine precision.
+     *   with \f$ h = 10^{-20} \f$, and \f$ e_j \f$ being the unit vector in the j-th direction.
+     *
+     *   @note This method is highly accurate and does not suffer from subtractive cancellation errors,
+     *   making it suitable for functions where high precision is required.
+     *
      */
-    Eigen::MatrixXd forwardDifference( const vector_to_vector_function_type& F, const Eigen::VectorXd& X );
+    std::tuple< Eigen::VectorXd, Eigen::MatrixXd > forwardDifference( const vector_to_vector_function_type& F,
+                                                                      const Eigen::VectorXd&                X );
 
-    /** @brief Approximates the Jacobian matrix of a vector function F at point X using the central difference method.
+    /** @brief Approximates the Jacobian matrix of a vector function F at point X using the complex step method with
+     * central differences.
      *  @param F The vector function for which the Jacobian matrix is to be approximated.
      *  @param X The point at which the Jacobian matrix is to be approximated.
      *  @return The approximated Jacobian matrix of F at point X.
      *
      *  It actually approximates the Jacobian matrix by
      *  \f[
-     *   J_{ij} \approx \frac{F_i(\boldsymbol{X} + h e_j) - F_i(\boldsymbol{X} - h e_j)}{2h}
-     *   \f]
-     *   with \f$ h = \sqrt[3]{\epsilon} \max(1, ||\boldsymbol{X}||) \f$, \f$ e_j \f$ being the unit vector in the j-th
-     * direction, and \f$ \epsilon \f$ being the machine precision.
+     *  J_{ij} \approx \frac{\text{Im}(F_i(\boldsymbol{X} + Ih e_j) - F_i(\boldsymbol{X} - Ih e_j))}{2h}
+     *  \f]
+     *  with  \f$ I = \sqrt{2}/2( 1+1i )\f$,
+     *  \f$ h = \sqrt[3]{\epsilon} \max(1, ||\boldsymbol{X}||) \f$,
+     *  and \f$ e_j \f$ being the unit vector in the j-th direction.
+     *
+     *  @note The formula can be found in Lai et al. (2005) Equ. 19.
      */
     Eigen::MatrixXd centralDifference( const vector_to_vector_function_type& F, const Eigen::VectorXd& X );
 
-    namespace Complex {
+    /** @brief Approximates the Jacobian matrix of a vector function F at point X using a fourth-order accurate
+     * complex step method.
+     * @param F The vector function for which the Jacobian matrix is to be approximated.
+     * @param X The point at which the Jacobian matrix is to be approximated.
+     * @return The approximated Jacobian matrix of F at point X.
+     *
+     * It actually approximates the Jacobian matrix by
+     * \f[
+     * J_{ij} \approx \frac{\text{Im}(8 [
+     * F_i(\boldsymbol{X} + I/2h e_j) -
+     * F_i(\boldsymbol{X} - I/2h e_j)] -
+     * [F_i(\boldsymbol{X} + Ih e_j) +
+     * F_i(\boldsymbol{X} - Ih e_j)])}{3\sqrt{2}h}
+     * \f]
+     * with  \f$ I = \sqrt{2}/2( 1+1i )\f$,
+     * \f$ h = \sqrt{\epsilon} \max(1, ||\boldsymbol{X}||) \f$,
+     * and \f$ e_j \f$ being the unit vector in the j-th direction.
+     *
+     * @note The formula can be found in Lai et al. (2005) Equ. 24.
+     */
+    Eigen::MatrixXd fourthOrderAccurateDerivative( const vector_to_vector_function_type& F, const Eigen::VectorXd& X );
 
-      /// A variable representing \f$ 0 + 1i \f$
-      const static std::complex< double > imaginaryUnit = { 0, 1 };
-      /// A variable representing \f$ 1 + 1i \f$
-      const static std::complex< double > complexUnit = { 1, 1 };
-      /// A variable representing \f$ \frac{\sqrt{2}}{2} (1+1i) \f$
-      const static std::complex< double > i_ = Marmot::Constants::sqrt2 / 2. * complexUnit;
-
-      /** @typedef scalar_to_scalar_function_type
-       *  @brief Type definition for a function that maps a complex double to another complex double.
-       */
-      using scalar_to_scalar_function_type = std::function< complexDouble( const complexDouble x ) >;
-
-      /** @typedef vector_to_vector_function_type
-       *  @brief Type definition for a function that maps an Eigen complex vector to another Eigen complex vector.
-       */
-      using vector_to_vector_function_type = std::function< Eigen::VectorXcd( const Eigen::VectorXcd& X ) >;
-
-      /** @brief Approximates the first derivative of a scalar function f at point x using the complex step method.
-       *  @param f The scalar function for which the derivative is to be approximated.
-       *  @param x The point at which the derivative is to be approximated.
-       *  @return The approximated first derivative of f at point x.
-       *
-       *  It actually computes
-       *  \f[
-       *   f'(x) \approx \frac{\text{Im}(f(x + ih))}{h}
-       *   \f]
-       *   with \f$ h = 10^{-20} \f$.
-       *
-       *   @note This method is highly accurate and does not suffer from subtractive cancellation errors,
-       *   making it suitable for functions where high precision is required.
-       *
-       */
-      double forwardDifference( const scalar_to_scalar_function_type& f, const double x );
-
-      /** @brief Approximates the Jacobian matrix of a vector function F at point X using the complex step method.
-       *  @param F The vector function for which the Jacobian matrix is to be approximated.
-       *  @param X The point at which the Jacobian matrix is to be approximated.
-       *  @return A tuple containing the function value at X and the approximated Jacobian matrix of F at point X.
-       *
-       *  It actually computes
-       *  \f[
-       *   J_{ij} \approx \frac{\text{Im}(F_i(X + ih e_j))}{h}
-       *   \f]
-       *   with \f$ h = 10^{-20} \f$, and \f$ e_j \f$ being the unit vector in the j-th direction.
-       *
-       *   @note This method is highly accurate and does not suffer from subtractive cancellation errors,
-       *   making it suitable for functions where high precision is required.
-       *
-       */
-      std::tuple< Eigen::VectorXd, Eigen::MatrixXd > forwardDifference( const vector_to_vector_function_type& F,
-                                                                        const Eigen::VectorXd&                X );
-
-      /** @brief Approximates the Jacobian matrix of a vector function F at point X using the complex step method with
-       * central differences.
-       *  @param F The vector function for which the Jacobian matrix is to be approximated.
-       *  @param X The point at which the Jacobian matrix is to be approximated.
-       *  @return The approximated Jacobian matrix of F at point X.
-       *
-       *  It actually approximates the Jacobian matrix by
-       *  \f[
-       *  J_{ij} \approx \frac{\text{Im}(F_i(\boldsymbol{X} + Ih e_j) - F_i(\boldsymbol{X} - Ih e_j))}{2h}
-       *  \f]
-       *  with  \f$ I = \sqrt{2}/2( 1+1i )\f$,
-       *  \f$ h = \sqrt[3]{\epsilon} \max(1, ||\boldsymbol{X}||) \f$,
-       *  and \f$ e_j \f$ being the unit vector in the j-th direction.
-       *
-       *  @note The formula can be found in Lai et al. (2005) Equ. 19.
-       */
-      Eigen::MatrixXd centralDifference( const vector_to_vector_function_type& F, const Eigen::VectorXd& X );
-
-      /** @brief Approximates the Jacobian matrix of a vector function F at point X using a fourth-order accurate
-       * complex step method.
-       * @param F The vector function for which the Jacobian matrix is to be approximated.
-       * @param X The point at which the Jacobian matrix is to be approximated.
-       * @return The approximated Jacobian matrix of F at point X.
-       *
-       * It actually approximates the Jacobian matrix by
-       * \f[
-       * J_{ij} \approx \frac{\text{Im}(8 [
-       * F_i(\boldsymbol{X} + I/2h e_j) -
-       * F_i(\boldsymbol{X} - I/2h e_j)] -
-       * [F_i(\boldsymbol{X} + Ih e_j) +
-       * F_i(\boldsymbol{X} - Ih e_j)])}{3\sqrt{2}h}
-       * \f]
-       * with  \f$ I = \sqrt{2}/2( 1+1i )\f$,
-       * \f$ h = \sqrt{\epsilon} \max(1, ||\boldsymbol{X}||) \f$,
-       * and \f$ e_j \f$ being the unit vector in the j-th direction.
-       *
-       * @note The formula can be found in Lai et al. (2005) Equ. 24.
-       */
-      Eigen::MatrixXd fourthOrderAccurateDerivative( const vector_to_vector_function_type& F,
-                                                     const Eigen::VectorXd&                X );
-
-    } // namespace Complex
-  }   // namespace NumericalAlgorithms::Differentiation
-} // namespace Marmot
+  } // namespace Complex
+} // namespace Marmot::NumericalAlgorithms::Differentiation

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotNumericalIntegration.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotNumericalIntegration.h
@@ -26,47 +26,45 @@
 #pragma once
 #include <functional>
 
-namespace Marmot {
-  namespace NumericalAlgorithms::Integration {
+namespace Marmot::NumericalAlgorithms::Integration {
 
-    /** @brief Type alias for a function that takes a double and returns a double.*/
-    using scalar_to_scalar_function_type = std::function< double( const double x ) >;
+  /** @brief Type alias for a function that takes a double and returns a double.*/
+  using scalar_to_scalar_function_type = std::function< double( const double x ) >;
 
-    /** @brief Enumeration of available numerical integration rules.
-     *
-     *  This enum defines the different numerical integration methods that can be used
-     *  in the integrateScalarFunction function.
-     */
-    enum integrationRule {
-      /// Midpoint rule for numerical integration
-      midpoint,
-      /// Trapezoidal rule for numerical integration
-      trapezodial,
-      /// Simpson's rule for numerical integration
-      simpson
-    };
+  /** @brief Enumeration of available numerical integration rules.
+   *
+   *  This enum defines the different numerical integration methods that can be used
+   *  in the integrateScalarFunction function.
+   */
+  enum integrationRule {
+    /// Midpoint rule for numerical integration
+    midpoint,
+    /// Trapezoidal rule for numerical integration
+    trapezodial,
+    /// Simpson's rule for numerical integration
+    simpson
+  };
 
-    /** @brief Numerically integrates a scalar function over a specified interval using a chosen integration rule.
-     *  @param f The scalar function to be integrated.
-     *  @param integrationLimits A tuple containing the lower and upper limits of integration.
-     *  @param n The number of subintervals to use for the integration (must be positive).
-     *  @param intRule The numerical integration rule to use (midpoint, trapezoidal, or Simpson's rule).
-     *  @return The approximate value of the integral of f over the specified interval.
-     *
-     *  This function approximates the integral of the given scalar function @p f over the interval
-     *  defined by integrationLimits using the specified numerical integration rule. The number
-     *  of subintervals n determines the accuracy of the approximation; a larger @p n generally
-     *  leads to a more accurate result.
-     *
-     *  Example usage:
-     *  ```cpp
-     *  auto f = [](double x) { return x * x; }; // Function to integrate
-     *  double result = integrateScalarFunction(f, std::make_tuple(0.0, 1.0), 100, integrationRule::simpson);
-     *  ```
-     */
-    double integrateScalarFunction( scalar_to_scalar_function_type     f,
-                                    const std::tuple< double, double > integrationLimits,
-                                    const int                          n,
-                                    const integrationRule              intRule );
-  } // namespace NumericalAlgorithms::Integration
-} // namespace Marmot
+  /** @brief Numerically integrates a scalar function over a specified interval using a chosen integration rule.
+   *  @param f The scalar function to be integrated.
+   *  @param integrationLimits A tuple containing the lower and upper limits of integration.
+   *  @param n The number of subintervals to use for the integration (must be positive).
+   *  @param intRule The numerical integration rule to use (midpoint, trapezoidal, or Simpson's rule).
+   *  @return The approximate value of the integral of f over the specified interval.
+   *
+   *  This function approximates the integral of the given scalar function @p f over the interval
+   *  defined by integrationLimits using the specified numerical integration rule. The number
+   *  of subintervals n determines the accuracy of the approximation; a larger @p n generally
+   *  leads to a more accurate result.
+   *
+   *  Example usage:
+   *  ```cpp
+   *  auto f = [](double x) { return x * x; }; // Function to integrate
+   *  double result = integrateScalarFunction(f, std::make_tuple(0.0, 1.0), 100, integrationRule::simpson);
+   *  ```
+   */
+  double integrateScalarFunction( scalar_to_scalar_function_type     f,
+                                  const std::tuple< double, double > integrationLimits,
+                                  const int                          n,
+                                  const integrationRule              intRule );
+} // namespace Marmot::NumericalAlgorithms::Integration

--- a/modules/core/MarmotMathCore/include/Marmot/MarmotTensorExponential.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotTensorExponential.h
@@ -27,147 +27,143 @@
 #include "Marmot/MarmotMath.h"
 #include <iostream>
 
-namespace Marmot {
-  namespace ContinuumMechanics::TensorUtility {
-    namespace TensorExponential {
-      struct ExponentialMapFailed : std::exception {};
+namespace Marmot::ContinuumMechanics::TensorUtility::TensorExponential {
+  struct ExponentialMapFailed : std::exception {};
 
-      /**
-       * @brief Computes the exponential of a square second rank tensor
-       *
-       * @details Evaluates exp(@p theTensor) using a series expansion up to
-       * @p maxIterations or until the terms converge below @p tolerance.
-       *
-       * @tparam T Element type of the tensor.
-       * @tparam tensorSize Dimension of the square tensor.
-       * @param theTensor Input tensor.
-       * @param maxIterations Maximum number of series terms to compute.
-       * @param tolerance Convergence threshold for the series terms.
-       * @param alternativeTolerance Secondary threshold to detect failure.
-       * @return Tensor representing the exponential of @p theTensor.
-       * @throws ExponentialMapFailed If convergence is not achieved.
-       */
-      template < typename T, size_t tensorSize >
-      Fastor::Tensor< T, tensorSize, tensorSize > computeTensorExponential(
-        const Fastor::Tensor< T, tensorSize, tensorSize >& theTensor,
-        int                                                maxIterations,
-        double                                             tolerance,
-        double                                             alternativeTolerance )
-      {
-        using TensorNN = Fastor::Tensor< T, tensorSize, tensorSize >;
+  /**
+   * @brief Computes the exponential of a square second rank tensor
+   *
+   * @details Evaluates exp(@p theTensor) using a series expansion up to
+   * @p maxIterations or until the terms converge below @p tolerance.
+   *
+   * @tparam T Element type of the tensor.
+   * @tparam tensorSize Dimension of the square tensor.
+   * @param theTensor Input tensor.
+   * @param maxIterations Maximum number of series terms to compute.
+   * @param tolerance Convergence threshold for the series terms.
+   * @param alternativeTolerance Secondary threshold to detect failure.
+   * @return Tensor representing the exponential of @p theTensor.
+   * @throws ExponentialMapFailed If convergence is not achieved.
+   */
+  template < typename T, size_t tensorSize >
+  Fastor::Tensor< T, tensorSize, tensorSize > computeTensorExponential(
+    const Fastor::Tensor< T, tensorSize, tensorSize >& theTensor,
+    int                                                maxIterations,
+    double                                             tolerance,
+    double                                             alternativeTolerance )
+  {
+    using TensorNN = Fastor::Tensor< T, tensorSize, tensorSize >;
 
-        TensorNN theExponential;
+    TensorNN theExponential;
 
-        int n;
-        int facN = 1;
+    int n;
+    int facN = 1;
 
-        // term 1 ( n = 0 )
-        theExponential.eye();
+    // term 1 ( n = 0 )
+    theExponential.eye();
 
-        // series 2 ( n = 1 )
-        theExponential += theTensor;
+    // series 2 ( n = 1 )
+    theExponential += theTensor;
 
-        TensorNN tensorPower = theTensor;
-        // loop starts at n = 2
-        //
-        double norm = 0.0;
-        for ( n = 2; n < maxIterations; ++n ) {
-          facN *= n;
-          tensorPower           = tensorPower % theTensor;
-          const TensorNN series = 1. / facN * tensorPower;
-          theExponential += series;
+    TensorNN tensorPower = theTensor;
+    // loop starts at n = 2
+    //
+    double norm = 0.0;
+    for ( n = 2; n < maxIterations; ++n ) {
+      facN *= n;
+      tensorPower           = tensorPower % theTensor;
+      const TensorNN series = 1. / facN * tensorPower;
+      theExponential += series;
 
-          // workaround for autodiff::dual
-          Fastor::Tensor< double, tensorSize, tensorSize > series_real;
-          for ( size_t i = 0; i < tensorSize; i++ ) {
-            for ( size_t j = 0; j < tensorSize; j++ ) {
-              series_real( i, j ) = Math::makeReal( series( i, j ) );
-            }
-          }
-          norm = Fastor::norm( series_real );
-
-          if ( norm <= tolerance )
-            break;
+      // workaround for autodiff::dual
+      Fastor::Tensor< double, tensorSize, tensorSize > series_real;
+      for ( size_t i = 0; i < tensorSize; i++ ) {
+        for ( size_t j = 0; j < tensorSize; j++ ) {
+          series_real( i, j ) = Math::makeReal( series( i, j ) );
         }
+      }
+      norm = Fastor::norm( series_real );
 
-        if ( n == maxIterations && norm > alternativeTolerance ) {
-          throw ExponentialMapFailed();
-        }
+      if ( norm <= tolerance )
+        break;
+    }
 
-        return theExponential;
+    if ( n == maxIterations && norm > alternativeTolerance ) {
+      throw ExponentialMapFailed();
+    }
+
+    return theExponential;
+  }
+
+  /// @brief Result aggregate returned by the first-order-derived tensor exponential.
+  template < typename T, std::size_t tensorSize >
+  struct TensorExponentialResult {
+    Fastor::Tensor< T, tensorSize, tensorSize > theExponential; ///< The matrix exponential \f$\exp(\mathbf{A})\f$
+    Fastor::Tensor< T, tensorSize, tensorSize, tensorSize, tensorSize >
+      theExponentialDerivative; ///< First-order derivative of the matrix exponential with respect to the input
+                                ///< tensor
+  };
+
+  namespace FirstOrderDerived {
+    /** @brief Computes the exponential of a square second rank tensor and its first-order derivative.
+     * @details See the documentation of `computeTensorExponential` without derivative
+     *          for additional details.
+     */
+    template < typename T, size_t tensorSize >
+    TensorExponentialResult< T, tensorSize > computeTensorExponential(
+      const Fastor::Tensor< T, tensorSize, tensorSize >& theTensor,
+      int                                                maxIterations,
+      double                                             tolerance )
+    {
+      // tensor exponential;
+      using Tensor = Fastor::Tensor< T, tensorSize, tensorSize >;
+      TensorExponentialResult< T, tensorSize > theResult;
+
+      std::vector< Tensor > tensorPowers;
+
+      int n;
+      int facN = 1;
+
+      // term 1 ( n = 0 )
+      theResult.theExponential.eye();
+      tensorPowers.push_back( theResult.theExponential ); // I
+
+      // series 2 ( n = 1 )
+      theResult.theExponential += theTensor;
+      tensorPowers.push_back( theTensor ); // T
+
+      // loop starts at n = 2
+      for ( n = 2; n < maxIterations; ++n ) {
+        facN *= n;
+        const Tensor tensorPower = tensorPowers.back() % theTensor;
+        const Tensor series      = 1. / facN * tensorPower;
+        theResult.theExponential += series;
+
+        tensorPowers.push_back( tensorPower );
+
+        if ( Fastor::norm( series ) <= tolerance )
+          break;
       }
 
-      /// @brief Result aggregate returned by the first-order-derived tensor exponential.
-      template < typename T, std::size_t tensorSize >
-      struct TensorExponentialResult {
-        Fastor::Tensor< T, tensorSize, tensorSize > theExponential; ///< The matrix exponential \f$\exp(\mathbf{A})\f$
-        Fastor::Tensor< T, tensorSize, tensorSize, tensorSize, tensorSize >
-          theExponentialDerivative; ///< First-order derivative of the matrix exponential with respect to the input
-                                    ///< tensor
-      };
+      // derivative
+      const int N = n;
 
-      namespace FirstOrderDerived {
-        /** @brief Computes the exponential of a square second rank tensor and its first-order derivative.
-         * @details See the documentation of `computeTensorExponential` without derivative
-         *          for additional details.
-         */
-        template < typename T, size_t tensorSize >
-        TensorExponentialResult< T, tensorSize > computeTensorExponential(
-          const Fastor::Tensor< T, tensorSize, tensorSize >& theTensor,
-          int                                                maxIterations,
-          double                                             tolerance )
-        {
-          // tensor exponential;
-          using Tensor = Fastor::Tensor< T, tensorSize, tensorSize >;
-          TensorExponentialResult< T, tensorSize > theResult;
-
-          std::vector< Tensor > tensorPowers;
-
-          int n;
-          int facN = 1;
-
-          // term 1 ( n = 0 )
-          theResult.theExponential.eye();
-          tensorPowers.push_back( theResult.theExponential ); // I
-
-          // series 2 ( n = 1 )
-          theResult.theExponential += theTensor;
-          tensorPowers.push_back( theTensor ); // T
-
-          // loop starts at n = 2
-          for ( n = 2; n < maxIterations; ++n ) {
-            facN *= n;
-            const Tensor tensorPower = tensorPowers.back() % theTensor;
-            const Tensor series      = 1. / facN * tensorPower;
-            theResult.theExponential += series;
-
-            tensorPowers.push_back( tensorPower );
-
-            if ( Fastor::norm( series ) <= tolerance )
-              break;
-          }
-
-          // derivative
-          const int N = n;
-
-          facN = 1;
-          Fastor::Tensor< T, tensorSize, tensorSize, tensorSize, tensorSize > innerSeries;
-          Fastor::Tensor< T, tensorSize, tensorSize, tensorSize, tensorSize > outerSeries;
-          outerSeries.zeros();
-          for ( n = 1; n <= N; ++n ) {
-            innerSeries.zeros();
-            for ( int m = 1; m <= n; ++m ) {
-              innerSeries += Fastor::outer( tensorPowers[m - 1], tensorPowers[n - m] ); // ik_lj
-            }
-            facN *= n;
-            outerSeries += 1. / facN * innerSeries;
-          }
-          theResult.theExponentialDerivative = Fastor::permute< Fastor::Index< 0, 3, 1, 2 > >(
-            outerSeries ); // ik_lj -> ij_kl
-
-          return theResult;
+      facN = 1;
+      Fastor::Tensor< T, tensorSize, tensorSize, tensorSize, tensorSize > innerSeries;
+      Fastor::Tensor< T, tensorSize, tensorSize, tensorSize, tensorSize > outerSeries;
+      outerSeries.zeros();
+      for ( n = 1; n <= N; ++n ) {
+        innerSeries.zeros();
+        for ( int m = 1; m <= n; ++m ) {
+          innerSeries += Fastor::outer( tensorPowers[m - 1], tensorPowers[n - m] ); // ik_lj
         }
-      } // namespace FirstOrderDerived
-    }   // namespace TensorExponential
-  }     // namespace ContinuumMechanics::TensorUtility
-} // namespace Marmot
+        facN *= n;
+        outerSeries += 1. / facN * innerSeries;
+      }
+      theResult.theExponentialDerivative = Fastor::permute< Fastor::Index< 0, 3, 1, 2 > >(
+        outerSeries ); // ik_lj -> ij_kl
+
+      return theResult;
+    }
+  } // namespace FirstOrderDerived
+} // namespace Marmot::ContinuumMechanics::TensorUtility::TensorExponential

--- a/modules/core/MarmotMathCore/src/MarmotAutomaticDifferentiation.cpp
+++ b/modules/core/MarmotMathCore/src/MarmotAutomaticDifferentiation.cpp
@@ -5,105 +5,102 @@
 using namespace autodiff;
 using namespace Eigen;
 
-namespace Marmot {
+namespace Marmot::AutomaticDifferentiation {
 
-  namespace AutomaticDifferentiation {
+  dual2nd shiftTo2ndOrderDual( const dual& x )
+  {
+    dual2nd x2nd( 0.0 );
+    x2nd.val = x;
 
-    dual2nd shiftTo2ndOrderDual( const dual& x )
-    {
-      dual2nd x2nd( 0.0 );
-      x2nd.val = x;
+    return x2nd;
+  }
 
-      return x2nd;
+  VectorXdual2nd shiftTo2ndOrderDual( const VectorXdual& X )
+  {
+    VectorXdual2nd X_;
+    const size_t   sizeX = X.size();
+
+    for ( size_t j = 0; j < sizeX; j++ ) {
+      X_( j ) = shiftTo2ndOrderDual( X( j ) );
     }
 
-    VectorXdual2nd shiftTo2ndOrderDual( const VectorXdual& X )
-    {
-      VectorXdual2nd X_;
-      const size_t   sizeX = X.size();
+    return X_;
+  }
 
-      for ( size_t j = 0; j < sizeX; j++ ) {
-        X_( j ) = shiftTo2ndOrderDual( X( j ) );
+  double df_dx( const scalar_to_scalar_function_type& f, const double& x )
+  {
+    dual x_right;
+    x_right.val = x;
+    seed< 1 >( x_right, 1.0 );
+
+    const double df_dx = f( x_right ).grad;
+
+    return df_dx;
+  }
+
+  dual df_dx( const scalar_to_scalar_function_type_2nd& f, const dual& x )
+  {
+
+    dual2nd x_right = shiftTo2ndOrderDual( x );
+    seed< 1 >( x_right, 1.0 );
+
+    dual          df_dx;
+    const dual2nd f_right = f( x_right );
+    df_dx.val             = derivative< 1 >( f_right );
+    df_dx.grad            = derivative< 2 >( f_right );
+
+    return df_dx;
+  }
+
+  std::pair< VectorXd, MatrixXd > dF_dX( const vector_to_vector_function_type_dual& F, const VectorXd& X )
+  {
+    VectorXdual  X_( X );
+    VectorXdual  F_right;
+    const size_t sizeX = X_.rows();
+    MatrixXd     J( sizeX, sizeX );
+    VectorXd     F_( sizeX );
+
+    // J_ij = d F_i / d x_j
+    for ( size_t j = 0; j < sizeX; j++ ) {
+
+      seed< 1 >( X_( j ), 1.0 );
+      F_right = F( X_ );
+
+      for ( size_t i = 0; i < sizeX; i++ ) {
+        J( i, j ) = derivative< 1 >( F_right( i ) );
+      }
+      seed< 1 >( X_( j ), 0.0 );
+      F_( j ) = F_right( j ).val;
+    }
+
+    return { F_, J };
+  }
+
+  std::pair< VectorXdual, MatrixXdual > dF_dX_2nd( const vector_to_vector_function_type_dual2nd& F,
+                                                   const VectorXdual&                            X )
+  {
+    VectorXdual2nd X_ = increaseDualOrderWithShift< 1 >( X );
+    VectorXdual2nd F_right;
+    const size_t   sizeX = X_.rows();
+    MatrixXdual    J( sizeX, sizeX );
+    VectorXdual    F_( sizeX );
+
+    // J_ij = d F_i / d x_j
+    for ( size_t j = 0; j < sizeX; j++ ) {
+
+      seed< 1 >( X_( j ), 1.0 );
+      F_right = F( X_ );
+
+      for ( size_t i = 0; i < sizeX; i++ ) {
+        J( i, j ).val  = derivative< 1 >( F_right( i ) );
+        J( i, j ).grad = derivative< 2 >( F_right( i ) );
       }
 
-      return X_;
+      seed< 1 >( X_( j ), 0.0 );
+      F_( j ).val  = F_right( j ).val.val;
+      F_( j ).grad = derivative< 1 >( F_right( j ) );
     }
 
-    double df_dx( const scalar_to_scalar_function_type& f, const double& x )
-    {
-      dual x_right;
-      x_right.val = x;
-      seed< 1 >( x_right, 1.0 );
-
-      const double df_dx = f( x_right ).grad;
-
-      return df_dx;
-    }
-
-    dual df_dx( const scalar_to_scalar_function_type_2nd& f, const dual& x )
-    {
-
-      dual2nd x_right = shiftTo2ndOrderDual( x );
-      seed< 1 >( x_right, 1.0 );
-
-      dual          df_dx;
-      const dual2nd f_right = f( x_right );
-      df_dx.val             = derivative< 1 >( f_right );
-      df_dx.grad            = derivative< 2 >( f_right );
-
-      return df_dx;
-    }
-
-    std::pair< VectorXd, MatrixXd > dF_dX( const vector_to_vector_function_type_dual& F, const VectorXd& X )
-    {
-      VectorXdual  X_( X );
-      VectorXdual  F_right;
-      const size_t sizeX = X_.rows();
-      MatrixXd     J( sizeX, sizeX );
-      VectorXd     F_( sizeX );
-
-      // J_ij = d F_i / d x_j
-      for ( size_t j = 0; j < sizeX; j++ ) {
-
-        seed< 1 >( X_( j ), 1.0 );
-        F_right = F( X_ );
-
-        for ( size_t i = 0; i < sizeX; i++ ) {
-          J( i, j ) = derivative< 1 >( F_right( i ) );
-        }
-        seed< 1 >( X_( j ), 0.0 );
-        F_( j ) = F_right( j ).val;
-      }
-
-      return { F_, J };
-    }
-
-    std::pair< VectorXdual, MatrixXdual > dF_dX_2nd( const vector_to_vector_function_type_dual2nd& F,
-                                                     const VectorXdual&                            X )
-    {
-      VectorXdual2nd X_ = increaseDualOrderWithShift< 1 >( X );
-      VectorXdual2nd F_right;
-      const size_t   sizeX = X_.rows();
-      MatrixXdual    J( sizeX, sizeX );
-      VectorXdual    F_( sizeX );
-
-      // J_ij = d F_i / d x_j
-      for ( size_t j = 0; j < sizeX; j++ ) {
-
-        seed< 1 >( X_( j ), 1.0 );
-        F_right = F( X_ );
-
-        for ( size_t i = 0; i < sizeX; i++ ) {
-          J( i, j ).val  = derivative< 1 >( F_right( i ) );
-          J( i, j ).grad = derivative< 2 >( F_right( i ) );
-        }
-
-        seed< 1 >( X_( j ), 0.0 );
-        F_( j ).val  = F_right( j ).val.val;
-        F_( j ).grad = derivative< 1 >( F_right( j ) );
-      }
-
-      return { F_, J };
-    }
-  } // namespace AutomaticDifferentiation
-} // namespace Marmot
+    return { F_, J };
+  }
+} // namespace Marmot::AutomaticDifferentiation

--- a/modules/core/MarmotMathCore/src/MarmotMath.cpp
+++ b/modules/core/MarmotMathCore/src/MarmotMath.cpp
@@ -1,121 +1,119 @@
 #include "Marmot/MarmotMath.h"
 
-namespace Marmot {
-  namespace Math {
-    // return linear interpolation of polynom y at given coordinates (x0, y0) and (x1, y1) at
-    // point x
-    double linearInterpolation( double x, double x0, double x1, double y0, double y1 )
-    {
-      return y0 + ( x - x0 ) * ( y1 - y0 ) / ( x1 - x0 );
+namespace Marmot::Math {
+  // return linear interpolation of polynom y at given coordinates (x0, y0) and (x1, y1) at
+  // point x
+  double linearInterpolation( double x, double x0, double x1, double y0, double y1 )
+  {
+    return y0 + ( x - x0 ) * ( y1 - y0 ) / ( x1 - x0 );
+  }
+
+  // bounded version of std::exp
+  double exp( double x )
+  {
+    if ( x <= -64 ) // underflow if arg < -708.4 (type double)
+      return 0.0;
+    if ( x >= 64 )  // overflow if arg > 709.8 (type double), leave ample margin (e.g. for
+                    // squaring)
+      return std::exp( 64 );
+    return std::exp( x );
+  }
+
+  unsigned long factorial( unsigned int n )
+  {
+    if ( n == 0 || n == 1 )
+      return 1;
+    return n * factorial( n - 1 );
+  }
+
+  double makeReal( const complexDouble& value )
+  {
+    return value.real();
+  }
+
+  double makeReal( const autodiff::real& value )
+  {
+    return double( value );
+  }
+  double makeReal( const autodiff::dual& value )
+  {
+    return double( value );
+  }
+
+  double makeReal( const double& value )
+  {
+    return value;
+  }
+
+  // return the exponent to the power of ten of an expression like 5*10^5 --> return 5
+  int getExponentPowerTen( const double x )
+  {
+    if ( x >= 1e-16 )      // positive number
+      return floor( log10( x ) );
+    else if ( x <= 1e-16 ) // negative number
+      return floor( log10( abs( x ) ) );
+    else                   // number close to 0
+      return 0;
+  }
+
+  Matrix3d orthonormalCoordinateSystem( Vector3d& normalVector )
+  {
+    normalVector.normalize();
+    Matrix3d coordinateSystem = Eigen::MatrixXd::Zero( 3, 3 );
+    coordinateSystem.col( 0 ) = normalVector;
+
+    if ( coordinateSystem( 0, 0 ) == 0 && coordinateSystem( 1, 0 ) == 0 ) {
+      coordinateSystem( 1, 1 ) = 1.0;
     }
-
-    // bounded version of std::exp
-    double exp( double x )
-    {
-      if ( x <= -64 ) // underflow if arg < -708.4 (type double)
-        return 0.0;
-      if ( x >= 64 )  // overflow if arg > 709.8 (type double), leave ample margin (e.g. for
-                      // squaring)
-        return std::exp( 64 );
-      return std::exp( x );
+    else {
+      coordinateSystem( 0, 1 ) = -coordinateSystem( 1, 0 );
+      coordinateSystem( 1, 1 ) = coordinateSystem( 0, 0 );
     }
+    coordinateSystem.col( 1 ).normalize();
 
-    unsigned long factorial( unsigned int n )
-    {
-      if ( n == 0 || n == 1 )
-        return 1;
-      return n * factorial( n - 1 );
-    }
+    coordinateSystem.col( 2 ) = coordinateSystem.col( 0 ).cross( coordinateSystem.col( 1 ) );
+    coordinateSystem.col( 2 ).normalize();
 
-    double makeReal( const complexDouble& value )
-    {
-      return value.real();
-    }
+    return coordinateSystem;
+  }
 
-    double makeReal( const autodiff::real& value )
-    {
-      return double( value );
-    }
-    double makeReal( const autodiff::dual& value )
-    {
-      return double( value );
-    }
+  Matrix3d orthonormalCoordinateSystem( const Vector3d& n1, const Vector3d& n2 )
+  {
 
-    double makeReal( const double& value )
-    {
-      return value;
-    }
+    // check if n1 and n2 are orthogonal
 
-    // return the exponent to the power of ten of an expression like 5*10^5 --> return 5
-    int getExponentPowerTen( const double x )
-    {
-      if ( x >= 1e-16 )      // positive number
-        return floor( log10( x ) );
-      else if ( x <= 1e-16 ) // negative number
-        return floor( log10( abs( x ) ) );
-      else                   // number close to 0
-        return 0;
-    }
+    if ( std::abs( n1.dot( n2 ) ) > 1e-15 )
+      throw std::invalid_argument( "n1 and n2 not orthogonal" );
 
-    Matrix3d orthonormalCoordinateSystem( Vector3d& normalVector )
-    {
-      normalVector.normalize();
-      Matrix3d coordinateSystem = Eigen::MatrixXd::Zero( 3, 3 );
-      coordinateSystem.col( 0 ) = normalVector;
+    Matrix3d coordinateSystem = Eigen::MatrixXd::Zero( 3, 3 );
+    coordinateSystem.col( 0 ) = n1;
+    coordinateSystem.col( 1 ) = n2;
 
-      if ( coordinateSystem( 0, 0 ) == 0 && coordinateSystem( 1, 0 ) == 0 ) {
-        coordinateSystem( 1, 1 ) = 1.0;
-      }
-      else {
-        coordinateSystem( 0, 1 ) = -coordinateSystem( 1, 0 );
-        coordinateSystem( 1, 1 ) = coordinateSystem( 0, 0 );
-      }
-      coordinateSystem.col( 1 ).normalize();
+    // make sure n1 and n2 are normalized
+    coordinateSystem.col( 0 ).normalize();
+    coordinateSystem.col( 1 ).normalize();
 
-      coordinateSystem.col( 2 ) = coordinateSystem.col( 0 ).cross( coordinateSystem.col( 1 ) );
-      coordinateSystem.col( 2 ).normalize();
+    coordinateSystem.col( 2 ) = coordinateSystem.col( 0 ).cross( coordinateSystem.col( 1 ) );
+    coordinateSystem.col( 2 ).normalize();
 
-      return coordinateSystem;
-    }
+    return coordinateSystem;
+  }
 
-    Matrix3d orthonormalCoordinateSystem( const Vector3d& n1, const Vector3d& n2 )
-    {
+  Matrix3d directionCosines( const Matrix3d& transformedCoordinateSystem )
+  {
+    return transformedCoordinateSystem.transpose();
+  }
 
-      // check if n1 and n2 are orthogonal
+  Matrix3d transformToLocalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem )
+  {
+    const Matrix3d N = transformedCoordinateSystem;
+    return N * T * N.transpose();
+  }
 
-      if ( std::abs( n1.dot( n2 ) ) > 1e-15 )
-        throw std::invalid_argument( "n1 and n2 not orthogonal" );
+  Matrix3d transformToGlobalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem )
+  {
+    const Matrix3d N = transformedCoordinateSystem;
+    return N.transpose() * T * N;
+  }
 
-      Matrix3d coordinateSystem = Eigen::MatrixXd::Zero( 3, 3 );
-      coordinateSystem.col( 0 ) = n1;
-      coordinateSystem.col( 1 ) = n2;
-
-      // make sure n1 and n2 are normalized
-      coordinateSystem.col( 0 ).normalize();
-      coordinateSystem.col( 1 ).normalize();
-
-      coordinateSystem.col( 2 ) = coordinateSystem.col( 0 ).cross( coordinateSystem.col( 1 ) );
-      coordinateSystem.col( 2 ).normalize();
-
-      return coordinateSystem;
-    }
-
-    Matrix3d directionCosines( const Matrix3d& transformedCoordinateSystem )
-    {
-      return transformedCoordinateSystem.transpose();
-    }
-
-    Matrix3d transformToLocalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem )
-    {
-      const Matrix3d N = transformedCoordinateSystem;
-      return N * T * N.transpose();
-    }
-
-    Matrix3d transformToGlobalSystem( const Matrix3d& T, const Matrix3d& transformedCoordinateSystem )
-    {
-      const Matrix3d N = transformedCoordinateSystem;
-      return N.transpose() * T * N;
-    }
-
-  } // namespace Math
-} // namespace Marmot
+} // namespace Marmot::Math

--- a/modules/core/MarmotMathCore/src/MarmotNumericalDifferentiation.cpp
+++ b/modules/core/MarmotMathCore/src/MarmotNumericalDifferentiation.cpp
@@ -4,189 +4,187 @@
 
 using namespace Eigen;
 
-namespace Marmot {
-  namespace NumericalAlgorithms::Differentiation {
+namespace Marmot::NumericalAlgorithms::Differentiation {
 
-    double forwardDifference( const scalar_to_scalar_function_type& f, const double x )
-    {
-      double volatile h = std::max( 1.0, std::abs( x ) ) * Marmot::Constants::SquareRootEps;
-      const double out  = ( f( x + h ) - f( x ) ) / h;
-      return out;
-    }
+  double forwardDifference( const scalar_to_scalar_function_type& f, const double x )
+  {
+    double volatile h = std::max( 1.0, std::abs( x ) ) * Marmot::Constants::SquareRootEps;
+    const double out  = ( f( x + h ) - f( x ) ) / h;
+    return out;
+  }
 
-    double centralDifference( const scalar_to_scalar_function_type& f, const double x )
-    {
-      double volatile h = std::max( 1.0, std::abs( x ) ) * Marmot::Constants::CubicRootEps;
-      const double out  = ( f( x + h ) - f( x - h ) ) / ( 2. * h );
-      return out;
-    }
+  double centralDifference( const scalar_to_scalar_function_type& f, const double x )
+  {
+    double volatile h = std::max( 1.0, std::abs( x ) ) * Marmot::Constants::CubicRootEps;
+    const double out  = ( f( x + h ) - f( x - h ) ) / ( 2. * h );
+    return out;
+  }
 
-    MatrixXd forwardDifference( const vector_to_vector_function_type& F, const VectorXd& X )
-    {
-      VectorXd fx = F( X );
+  MatrixXd forwardDifference( const vector_to_vector_function_type& F, const VectorXd& X )
+  {
+    VectorXd fx = F( X );
 
-      const auto xSize  = X.rows();
-      const auto fxSize = fx.rows();
-      MatrixXd   J( fxSize, xSize );
+    const auto xSize  = X.rows();
+    const auto fxSize = fx.rows();
+    MatrixXd   J( fxSize, xSize );
 
-      VectorXd rightX( xSize );
+    VectorXd rightX( xSize );
 
-      for ( auto i = 0; i < xSize; i++ ) {
-        double volatile h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::SquareRootEps;
-        // clang-format off
+    for ( auto i = 0; i < xSize; i++ ) {
+      double volatile h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::SquareRootEps;
+      // clang-format off
         rightX = X;
         rightX( i ) += h;
 
         J.col( i ) = (  F( rightX )  - fx )
             / //------------------------------------
                             ( 1. * h );
-        // clang-format on
+      // clang-format on
+    }
+
+    return J;
+  }
+
+  MatrixXd centralDifference( const vector_to_vector_function_type& F, const VectorXd& X )
+  {
+    const auto xSize = X.rows();
+
+    MatrixXd J;
+
+    VectorXd leftX( xSize );
+    VectorXd rightX( xSize );
+
+    for ( auto i = 0; i < xSize; i++ ) {
+      double volatile h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::CubicRootEps;
+
+      leftX  = X;
+      rightX = X;
+      leftX( i ) -= h;
+      rightX( i ) += h;
+
+      VectorXd yRight = F( rightX );
+      VectorXd yLeft  = F( leftX );
+
+      if ( i == 0 ) {
+        J.resize( yRight.size(), xSize );
       }
 
-      return J;
+      // clang-format off
+        J.col( i ) = ( yRight - yLeft )
+            / //-----------------------
+                     ( 2. * h );
+      // clang-format on
+    }
+
+    return J;
+  }
+  namespace Complex {
+    /*
+     * Implementation of Numerical Differentiation using Complex Step Approximations
+     *
+     * further Information can be found in
+     *   - Martins et al. (2003) The Complex-Step Derivative Approximation
+     *   - Lai et al. (2005) New Complex-Step Derivative Approximations ...
+     *
+     */
+    double forwardDifference( const scalar_to_scalar_function_type& f, const double x )
+    {
+      complexDouble x_  = complexDouble( x ) + 1e-20 * imaginaryUnit;
+      const double  out = f( x_ ).imag() / 1e-20;
+      return out;
+    }
+
+    std::tuple< VectorXd, MatrixXd > forwardDifference( const vector_to_vector_function_type& F, const VectorXd& X )
+    {
+      /*
+       * according to Martins et al. (2003) Equ. 6
+       * according to Lai et al. (2005) Equ. 7
+       */
+      const auto xSize = X.rows();
+      MatrixXd   J( xSize, xSize );
+      VectorXcd  rightX( xSize );
+      VectorXcd  F_( xSize );
+
+      for ( auto i = 0; i < xSize; i++ ) {
+        // double h = std::max( 1.0, std::abs( X( i ) ) ) * 1e-16;
+        rightX = X;
+        rightX( i ) += 1e-20 * imaginaryUnit;
+        F_         = F( rightX );
+        J.col( i ) = F_.imag() / 1e-20;
+      }
+
+      return { F_.real(), J };
     }
 
     MatrixXd centralDifference( const vector_to_vector_function_type& F, const VectorXd& X )
     {
+      /*
+       * according to Lai et al. (2005) Equ. 19
+       */
       const auto xSize = X.rows();
+      MatrixXd   J( xSize, xSize );
+      VectorXcd  e( xSize );
+      VectorXcd  rightX( xSize );
+      VectorXcd  leftX( xSize );
 
-      MatrixXd J;
-
-      VectorXd leftX( xSize );
-      VectorXd rightX( xSize );
+      complexDouble i_ = Marmot::Constants::sqrt2 / 2. * complexUnit;
 
       for ( auto i = 0; i < xSize; i++ ) {
-        double volatile h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::CubicRootEps;
+        double h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::SquareRootEps;
 
-        leftX  = X;
+        e.setZero();
+        e( i ) = 1.;
+
+        leftX = X;
+        leftX -= e * i_ * h;
+
         rightX = X;
-        leftX( i ) -= h;
-        rightX( i ) += h;
-
-        VectorXd yRight = F( rightX );
-        VectorXd yLeft  = F( leftX );
-
-        if ( i == 0 ) {
-          J.resize( yRight.size(), xSize );
-        }
+        rightX += e * i_ * h;
 
         // clang-format off
-        J.col( i ) = ( yRight - yLeft )
-            / //-----------------------
-                     ( 2. * h );
+          J.col( i ) =      ( F( rightX ) - F( leftX )  ).imag()
+                       / //--------------------------------------
+                              ( Marmot::Constants::sqrt2 * h );
+
+        // clang-format on
+      }
+      return J;
+    }
+
+    MatrixXd fourthOrderAccurateDerivative( const vector_to_vector_function_type& F, const VectorXd& X )
+    {
+      /*
+       * according to Lai et al. (2005) Equ. 24
+       */
+      const auto xSize = X.rows();
+      MatrixXd   J( xSize, xSize );
+      VectorXcd  complex_X( X );
+      VectorXcd  e( xSize );
+      VectorXcd  x1_( xSize );
+      VectorXcd  x2_( xSize );
+      VectorXcd  x3_( xSize );
+      VectorXcd  x4_( xSize );
+
+      for ( auto i = 0; i < xSize; i++ ) {
+        double h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::SquareRootEps;
+        e.setZero();
+        e( i ) = 1.;
+
+        x1_ = complex_X + e / 2. * i_ * h;
+        x2_ = complex_X - e / 2. * i_ * h;
+        x3_ = complex_X + e * i_ * h;
+        x4_ = complex_X - e * i_ * h;
+
+        // clang-format off
+          J.col( i ) = ( 8.* ( F( x1_ ) - F( x2_ ) )
+                           - ( F( x3_ ) - F( x4_ ) ) ).imag()
+                           / ( Marmot::Constants::sqrt2 * 3. * h );
+
         // clang-format on
       }
 
       return J;
     }
-    namespace Complex {
-      /*
-       * Implementation of Numerical Differentiation using Complex Step Approximations
-       *
-       * further Information can be found in
-       *   - Martins et al. (2003) The Complex-Step Derivative Approximation
-       *   - Lai et al. (2005) New Complex-Step Derivative Approximations ...
-       *
-       */
-      double forwardDifference( const scalar_to_scalar_function_type& f, const double x )
-      {
-        complexDouble x_  = complexDouble( x ) + 1e-20 * imaginaryUnit;
-        const double  out = f( x_ ).imag() / 1e-20;
-        return out;
-      }
+  } // namespace Complex
 
-      std::tuple< VectorXd, MatrixXd > forwardDifference( const vector_to_vector_function_type& F, const VectorXd& X )
-      {
-        /*
-         * according to Martins et al. (2003) Equ. 6
-         * according to Lai et al. (2005) Equ. 7
-         */
-        const auto xSize = X.rows();
-        MatrixXd   J( xSize, xSize );
-        VectorXcd  rightX( xSize );
-        VectorXcd  F_( xSize );
-
-        for ( auto i = 0; i < xSize; i++ ) {
-          // double h = std::max( 1.0, std::abs( X( i ) ) ) * 1e-16;
-          rightX = X;
-          rightX( i ) += 1e-20 * imaginaryUnit;
-          F_         = F( rightX );
-          J.col( i ) = F_.imag() / 1e-20;
-        }
-
-        return { F_.real(), J };
-      }
-
-      MatrixXd centralDifference( const vector_to_vector_function_type& F, const VectorXd& X )
-      {
-        /*
-         * according to Lai et al. (2005) Equ. 19
-         */
-        const auto xSize = X.rows();
-        MatrixXd   J( xSize, xSize );
-        VectorXcd  e( xSize );
-        VectorXcd  rightX( xSize );
-        VectorXcd  leftX( xSize );
-
-        complexDouble i_ = Marmot::Constants::sqrt2 / 2. * complexUnit;
-
-        for ( auto i = 0; i < xSize; i++ ) {
-          double h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::SquareRootEps;
-
-          e.setZero();
-          e( i ) = 1.;
-
-          leftX = X;
-          leftX -= e * i_ * h;
-
-          rightX = X;
-          rightX += e * i_ * h;
-
-          // clang-format off
-          J.col( i ) =      ( F( rightX ) - F( leftX )  ).imag()
-                       / //--------------------------------------
-                              ( Marmot::Constants::sqrt2 * h );
-
-          // clang-format on
-        }
-        return J;
-      }
-
-      MatrixXd fourthOrderAccurateDerivative( const vector_to_vector_function_type& F, const VectorXd& X )
-      {
-        /*
-         * according to Lai et al. (2005) Equ. 24
-         */
-        const auto xSize = X.rows();
-        MatrixXd   J( xSize, xSize );
-        VectorXcd  complex_X( X );
-        VectorXcd  e( xSize );
-        VectorXcd  x1_( xSize );
-        VectorXcd  x2_( xSize );
-        VectorXcd  x3_( xSize );
-        VectorXcd  x4_( xSize );
-
-        for ( auto i = 0; i < xSize; i++ ) {
-          double h = std::max( 1.0, std::abs( X( i ) ) ) * Marmot::Constants::SquareRootEps;
-          e.setZero();
-          e( i ) = 1.;
-
-          x1_ = complex_X + e / 2. * i_ * h;
-          x2_ = complex_X - e / 2. * i_ * h;
-          x3_ = complex_X + e * i_ * h;
-          x4_ = complex_X - e * i_ * h;
-
-          // clang-format off
-          J.col( i ) = ( 8.* ( F( x1_ ) - F( x2_ ) )
-                           - ( F( x3_ ) - F( x4_ ) ) ).imag()
-                           / ( Marmot::Constants::sqrt2 * 3. * h );
-
-          // clang-format on
-        }
-
-        return J;
-      }
-    } // namespace Complex
-
-  }   // namespace NumericalAlgorithms::Differentiation
-} // namespace Marmot
+} // namespace Marmot::NumericalAlgorithms::Differentiation

--- a/modules/core/MarmotMathCore/src/MarmotNumericalIntegration.cpp
+++ b/modules/core/MarmotMathCore/src/MarmotNumericalIntegration.cpp
@@ -2,42 +2,39 @@
 #include <algorithm>
 #include <stdexcept>
 
-namespace Marmot {
-  namespace NumericalAlgorithms::Integration {
+namespace Marmot::NumericalAlgorithms::Integration {
 
-    double integrateScalarFunction( scalar_to_scalar_function_type     f,
-                                    const std::tuple< double, double > integrationLimits,
-                                    const int                          n,
-                                    const integrationRule              intRule )
-    {
+  double integrateScalarFunction( scalar_to_scalar_function_type     f,
+                                  const std::tuple< double, double > integrationLimits,
+                                  const int                          n,
+                                  const integrationRule              intRule )
+  {
 
-      // create linear spacing
-      double deltaX = ( std::get< 1 >( integrationLimits ) - std::get< 0 >( integrationLimits ) ) / ( n );
-      std::vector< double > xValues( n + 1 );
+    // create linear spacing
+    double                deltaX = ( std::get< 1 >( integrationLimits ) - std::get< 0 >( integrationLimits ) ) / ( n );
+    std::vector< double > xValues( n + 1 );
 
-      std::generate( xValues.begin(), xValues.end(), [n = 0, &deltaX]() mutable { return n++ * deltaX; } );
-      double val = 0.;
+    std::generate( xValues.begin(), xValues.end(), [n = 0, &deltaX]() mutable { return n++ * deltaX; } );
+    double val = 0.;
 
-      switch ( intRule ) {
-      case integrationRule::midpoint:
-        for ( int i = 0; i < n; i++ ) {
-          val += f( ( xValues[i + 1] + xValues[i] ) / 2. ) * deltaX;
-        }
-        break;
-      case integrationRule::trapezodial:
-        for ( int i = 0; i < n; i++ ) {
-          val += ( f( xValues[i + 1] ) + f( xValues[i] ) ) / 2. * deltaX;
-        }
-        break;
-      case integrationRule::simpson:
-        for ( int i = 0; i < n; i++ ) {
-          val += deltaX / 6. *
-                 ( f( xValues[i] ) + 4 * f( ( xValues[i + 1] + xValues[i] ) / 2. ) + f( xValues[i + 1] ) );
-        }
-        break;
-      default: throw std::invalid_argument( "Invalid integration rule!" );
+    switch ( intRule ) {
+    case integrationRule::midpoint:
+      for ( int i = 0; i < n; i++ ) {
+        val += f( ( xValues[i + 1] + xValues[i] ) / 2. ) * deltaX;
       }
-      return val;
+      break;
+    case integrationRule::trapezodial:
+      for ( int i = 0; i < n; i++ ) {
+        val += ( f( xValues[i + 1] ) + f( xValues[i] ) ) / 2. * deltaX;
+      }
+      break;
+    case integrationRule::simpson:
+      for ( int i = 0; i < n; i++ ) {
+        val += deltaX / 6. * ( f( xValues[i] ) + 4 * f( ( xValues[i + 1] + xValues[i] ) / 2. ) + f( xValues[i + 1] ) );
+      }
+      break;
+    default: throw std::invalid_argument( "Invalid integration rule!" );
     }
-  } // namespace NumericalAlgorithms::Integration
-} // namespace Marmot
+    return val;
+  }
+} // namespace Marmot::NumericalAlgorithms::Integration

--- a/modules/core/MarmotMathCore/test/TestMarmotAutomaticDifferentiationForFastor.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotAutomaticDifferentiationForFastor.cpp
@@ -6,6 +6,7 @@
 #include "Marmot/MarmotTesting.h"
 
 using namespace Fastor;
+using Marmot::MakeString;
 using namespace Marmot::AutomaticDifferentiation;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;

--- a/modules/core/MarmotMathCore/test/TestMarmotEigenSystems.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotEigenSystems.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::FastorStandardTensors;
 using namespace Marmot::Math;

--- a/modules/core/MarmotMathCore/test/TestMarmotMath.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotMath.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Math;
 using namespace Marmot::Testing;
 

--- a/modules/core/MarmotMathCore/test/TestMarmotNumericalDifferentiation.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotNumericalDifferentiation.cpp
@@ -4,6 +4,7 @@
 
 #include "Marmot/MarmotConstants.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::NumericalAlgorithms::Differentiation;
 

--- a/modules/core/MarmotMathCore/test/TestMarmotTensor.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotTensor.cpp
@@ -1,6 +1,7 @@
 #include "Marmot/MarmotTensor.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::ContinuumMechanics::CommonTensors;
 using namespace Marmot::ContinuumMechanics::TensorUtility;
 using namespace Marmot::Testing;

--- a/modules/core/MarmotMechanicsCore/include/Marmot/DuvautLionsViscosity.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/DuvautLionsViscosity.h
@@ -26,74 +26,70 @@
 #pragma once
 #include "Marmot/MarmotTypedefs.h"
 
-namespace Marmot {
-  namespace ContinuumMechanics::CommonConstitutiveModels {
+namespace Marmot::ContinuumMechanics::CommonConstitutiveModels {
+  /**
+   * \brief Implementation of Duvaut-Lions viscosity for a material with `nMatTangentSize` internal degrees of
+   * freedom
+   * @todo: Update member names to more descriptive ones
+   */
+  template < int nMatTangentSize >
+  class DuvautLionsViscosity {
+  private:
+    /*
+     * Viscosity parameter for Duvault-Lions viscosity*/
+    const double viscosity;
+
+  public:
+    typedef Eigen::Matrix< double, nMatTangentSize, nMatTangentSize >
+      TangentSizedMatrix; ///< Square matrix type sized to the material tangent dimension
+
+    /// @brief Constructs the viscosity model with the given viscosity parameter.
+    /// @param viscosity Viscosity parameter \f$\eta\f$ for the Duvaut-Lions regularisation.
+    DuvautLionsViscosity( double viscosity );
+
     /**
-     * \brief Implementation of Duvaut-Lions viscosity for a material with `nMatTangentSize` internal degrees of
-     * freedom
-     * @todo: Update member names to more descriptive ones
-     */
-    template < int nMatTangentSize >
-    class DuvautLionsViscosity {
-    private:
-      /*
-       * Viscosity parameter for Duvault-Lions viscosity*/
-      const double viscosity;
+     * Apply viscosity on a scalar internal variable depending on the extremal solutions for t=0 (trialState) and
+     * t=\f$\infty\f$, and timestep dt */
+    double applyViscosityOnStateVar( double stateVarTrial, double StateVarInf, double dT );
+    /**
+     * Apply viscosity on voigt sized rank two tensor depending on the extremal solutions for t=0 (trialState) and
+     * t=\f$\infty\f$, and timestep dt */
+    Marmot::Vector6d applyViscosityOnStress( const Marmot::Vector6d& trialStress,
+                                             const Marmot::Vector6d& stressInf,
+                                             double                  dT );
+    /**
+     * Apply viscosity on the inverse (algorithmic) material tangent depending on the extremal solutions for t=0
+     * (trialState) and t=\f$\infty\f$, and timestep dt
+     * @todo: Check if application to inverse can be replaced by application to non-inverse in general*/
+    TangentSizedMatrix applyViscosityOnMatTangent( const TangentSizedMatrix& matTangentInv, double dT );
+  };
+} // namespace Marmot::ContinuumMechanics::CommonConstitutiveModels
 
-    public:
-      typedef Eigen::Matrix< double, nMatTangentSize, nMatTangentSize >
-        TangentSizedMatrix; ///< Square matrix type sized to the material tangent dimension
+namespace Marmot::ContinuumMechanics::CommonConstitutiveModels {
+  template < int s >
+  DuvautLionsViscosity< s >::DuvautLionsViscosity( double viscosity ) : viscosity( viscosity )
+  {
+  }
 
-      /// @brief Constructs the viscosity model with the given viscosity parameter.
-      /// @param viscosity Viscosity parameter \f$\eta\f$ for the Duvaut-Lions regularisation.
-      DuvautLionsViscosity( double viscosity );
+  template < int s >
+  double DuvautLionsViscosity< s >::applyViscosityOnStateVar( double stateVarTrial, double StateVarInf, double dT )
+  {
+    return ( stateVarTrial + ( dT / viscosity ) * StateVarInf ) / ( dT / viscosity + 1 );
+  }
 
-      /**
-       * Apply viscosity on a scalar internal variable depending on the extremal solutions for t=0 (trialState) and
-       * t=\f$\infty\f$, and timestep dt */
-      double applyViscosityOnStateVar( double stateVarTrial, double StateVarInf, double dT );
-      /**
-       * Apply viscosity on voigt sized rank two tensor depending on the extremal solutions for t=0 (trialState) and
-       * t=\f$\infty\f$, and timestep dt */
-      Marmot::Vector6d applyViscosityOnStress( const Marmot::Vector6d& trialStress,
-                                               const Marmot::Vector6d& stressInf,
-                                               double                  dT );
-      /**
-       * Apply viscosity on the inverse (algorithmic) material tangent depending on the extremal solutions for t=0
-       * (trialState) and t=\f$\infty\f$, and timestep dt
-       * @todo: Check if application to inverse can be replaced by application to non-inverse in general*/
-      TangentSizedMatrix applyViscosityOnMatTangent( const TangentSizedMatrix& matTangentInv, double dT );
-    };
-  } // namespace ContinuumMechanics::CommonConstitutiveModels
-} // namespace Marmot
+  template < int s >
+  Marmot::Vector6d DuvautLionsViscosity< s >::applyViscosityOnStress( const Marmot::Vector6d& trialStress,
+                                                                      const Marmot::Vector6d& stressInf,
+                                                                      double                  dT )
+  {
+    return ( trialStress + ( dT / viscosity ) * stressInf ) / ( dT / viscosity + 1 );
+  }
 
-namespace Marmot {
-  namespace ContinuumMechanics::CommonConstitutiveModels {
-    template < int s >
-    DuvautLionsViscosity< s >::DuvautLionsViscosity( double viscosity ) : viscosity( viscosity )
-    {
-    }
-
-    template < int s >
-    double DuvautLionsViscosity< s >::applyViscosityOnStateVar( double stateVarTrial, double StateVarInf, double dT )
-    {
-      return ( stateVarTrial + ( dT / viscosity ) * StateVarInf ) / ( dT / viscosity + 1 );
-    }
-
-    template < int s >
-    Marmot::Vector6d DuvautLionsViscosity< s >::applyViscosityOnStress( const Marmot::Vector6d& trialStress,
-                                                                        const Marmot::Vector6d& stressInf,
-                                                                        double                  dT )
-    {
-      return ( trialStress + ( dT / viscosity ) * stressInf ) / ( dT / viscosity + 1 );
-    }
-
-    template < int s >
-    typename DuvautLionsViscosity< s >::TangentSizedMatrix DuvautLionsViscosity< s >::applyViscosityOnMatTangent(
-      const TangentSizedMatrix& matTangentInv,
-      double                    dT )
-    {
-      return ( 1 / ( 1 + dT / viscosity ) ) * ( TangentSizedMatrix::Identity() + dT / viscosity * matTangentInv );
-    }
-  } // namespace ContinuumMechanics::CommonConstitutiveModels
-} // namespace Marmot
+  template < int s >
+  typename DuvautLionsViscosity< s >::TangentSizedMatrix DuvautLionsViscosity< s >::applyViscosityOnMatTangent(
+    const TangentSizedMatrix& matTangentInv,
+    double                    dT )
+  {
+    return ( 1 / ( 1 + dT / viscosity ) ) * ( TangentSizedMatrix::Identity() + dT / viscosity * matTangentInv );
+  }
+} // namespace Marmot::ContinuumMechanics::CommonConstitutiveModels

--- a/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/HaighWestergaard.h
@@ -37,80 +37,78 @@
  * and Lode angle \f$\theta\f$ from stress or strain tensors in Voigt notation.
  */
 
-namespace Marmot {
-  namespace ContinuumMechanics::HaighWestergaard {
+namespace Marmot::ContinuumMechanics::HaighWestergaard {
 
-    /**
-     * Aggregate of the Haigh-Westergaard coordinates (invariants) \f$\xi\f$,
-     * \f$\rho\f$, \f$\theta\f$.
-     */
-    template < typename T = double >
-    struct HaighWestergaardCoordinates {
+  /**
+   * Aggregate of the Haigh-Westergaard coordinates (invariants) \f$\xi\f$,
+   * \f$\rho\f$, \f$\theta\f$.
+   */
+  template < typename T = double >
+  struct HaighWestergaardCoordinates {
 
-      /// Hydrostatic component \f$\xi\f$
-      T xi;
-      ///  Deviatoric radius \f$\rho\f$
-      T rho;
-      /// Lode angle \f$\theta\f$ specified in radian
-      T theta;
-    };
+    /// Hydrostatic component \f$\xi\f$
+    T xi;
+    ///  Deviatoric radius \f$\rho\f$
+    T rho;
+    /// Lode angle \f$\theta\f$ specified in radian
+    T theta;
+  };
 
-    /**
-     * Computes the stress coordinates in the Haigh-Westergaard space.
-     *
-     * \note The stress coordinates are computed from the invariants \f$I_1,\,J_2,\,J_3\f$ of the stress tensor as
-     * follows:
-     *
-     * \f[\xi=I_1/\sqrt{3}\f]
-     * \f[\rho=\sqrt{2\,J_2}\f]
-     * \f[\theta=\frac{1}{3}\,\arccos{\left(\frac{3\,\sqrt{3}}{2}\,\frac{J_3}{\sqrt{J_2^3}}\right)}\f]
-     *
-     * @param stress Stress tensor \f$\sig\f$ given in Voigt notation.
-     */
-    template < typename T = double >
-    HaighWestergaardCoordinates< T > haighWestergaard( const Eigen::Matrix< T, 6, 1 >& stress )
-    {
-      using namespace Constants;
-      using namespace Marmot::ContinuumMechanics::VoigtNotation::Invariants;
-      HaighWestergaardCoordinates< T > hw;
-      const auto                       J2_ = J2( stress );
-      hw.xi                                = I1( stress ) / sqrt3;
-      // sqrt()'s derivative is singular at J2=0 (the hydrostatic axis, e.g. a virgin stress
-      // state of exactly zero): autodiff/complex-step differentiation propagates that as a NaN
-      // *derivative* even though rho's *value* (0) is perfectly well defined there. Below a tiny
-      // threshold, skip sqrt() entirely and construct an exact zero of the correct type instead
-      // -- mirroring dRho_dStress()'s existing "rho <= 1e-16" near-origin convention exactly
-      // (rho = sqrt(2*J2) <= 1e-16  <=>  J2 <= 5e-33) -- rather than letting sqrt() propagate a
-      // NaN derivative. This also absorbs J2 rounding to a tiny negative value for
-      // near-hydrostatic states.
-      hw.rho = Marmot::Math::makeReal( J2_ ) <= 5e-33 ? T( 0. ) : sqrt( 2. * J2_ );
+  /**
+   * Computes the stress coordinates in the Haigh-Westergaard space.
+   *
+   * \note The stress coordinates are computed from the invariants \f$I_1,\,J_2,\,J_3\f$ of the stress tensor as
+   * follows:
+   *
+   * \f[\xi=I_1/\sqrt{3}\f]
+   * \f[\rho=\sqrt{2\,J_2}\f]
+   * \f[\theta=\frac{1}{3}\,\arccos{\left(\frac{3\,\sqrt{3}}{2}\,\frac{J_3}{\sqrt{J_2^3}}\right)}\f]
+   *
+   * @param stress Stress tensor \f$\sig\f$ given in Voigt notation.
+   */
+  template < typename T = double >
+  HaighWestergaardCoordinates< T > haighWestergaard( const Eigen::Matrix< T, 6, 1 >& stress )
+  {
+    using namespace Constants;
+    using namespace Marmot::ContinuumMechanics::VoigtNotation::Invariants;
+    HaighWestergaardCoordinates< T > hw;
+    const auto                       J2_ = J2( stress );
+    hw.xi                                = I1( stress ) / sqrt3;
+    // sqrt()'s derivative is singular at J2=0 (the hydrostatic axis, e.g. a virgin stress
+    // state of exactly zero): autodiff/complex-step differentiation propagates that as a NaN
+    // *derivative* even though rho's *value* (0) is perfectly well defined there. Below a tiny
+    // threshold, skip sqrt() entirely and construct an exact zero of the correct type instead
+    // -- mirroring dRho_dStress()'s existing "rho <= 1e-16" near-origin convention exactly
+    // (rho = sqrt(2*J2) <= 1e-16  <=>  J2 <= 5e-33) -- rather than letting sqrt() propagate a
+    // NaN derivative. This also absorbs J2 rounding to a tiny negative value for
+    // near-hydrostatic states.
+    hw.rho = Marmot::Math::makeReal( J2_ ) <= 5e-33 ? T( 0. ) : sqrt( 2. * J2_ );
 
-      if ( Marmot::Math::makeReal( hw.rho ) != 0 ) {
-        const T J3_ = J3( stress );
-        const T x   = 3. * ( sqrt3 / 2. ) * J3_ / ( pow( J2_, 3. / 2 ) );
-        if ( Marmot::Math::makeReal( x ) <= -1 )
-          hw.theta = 1. / 3 * Pi;
-        else if ( Marmot::Math::makeReal( x ) >= 1 )
-          hw.theta = 0.;
-        else if ( x != x )
-          hw.theta = 1. / 3 * Marmot::Constants::Pi;
-        else
-          hw.theta = 1. / 3 * acos( x );
-      }
-      else
+    if ( Marmot::Math::makeReal( hw.rho ) != 0 ) {
+      const T J3_ = J3( stress );
+      const T x   = 3. * ( sqrt3 / 2. ) * J3_ / ( pow( J2_, 3. / 2 ) );
+      if ( Marmot::Math::makeReal( x ) <= -1 )
+        hw.theta = 1. / 3 * Pi;
+      else if ( Marmot::Math::makeReal( x ) >= 1 )
         hw.theta = 0.;
-
-      return hw;
+      else if ( x != x )
+        hw.theta = 1. / 3 * Marmot::Constants::Pi;
+      else
+        hw.theta = 1. / 3 * acos( x );
     }
-    /**
-     * Computes the strain coordinates in the Haigh-Westergaard space.
-     *
-     * \note The computation is equal to haighWestergaard() by replacing the stress invariants with the strain
-     * invariants.
-     *
-     * @param strain Strain tensor \f$\eps\f$ given in Voigt notation.
-     */
-    HaighWestergaardCoordinates< double > haighWestergaardFromStrain( const Marmot::Vector6d& strain );
+    else
+      hw.theta = 0.;
 
-  } // namespace ContinuumMechanics::HaighWestergaard
-} // namespace Marmot
+    return hw;
+  }
+  /**
+   * Computes the strain coordinates in the Haigh-Westergaard space.
+   *
+   * \note The computation is equal to haighWestergaard() by replacing the stress invariants with the strain
+   * invariants.
+   *
+   * @param strain Strain tensor \f$\eps\f$ given in Voigt notation.
+   */
+  HaighWestergaardCoordinates< double > haighWestergaardFromStrain( const Marmot::Vector6d& strain );
+
+} // namespace Marmot::ContinuumMechanics::HaighWestergaard

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotElasticity.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotElasticity.h
@@ -26,290 +26,287 @@
 #pragma once
 #include "Marmot/MarmotVoigt.h"
 
-namespace Marmot {
+namespace Marmot::ContinuumMechanics {
 
-  namespace ContinuumMechanics {
-
-    /**
-     * @brief Functions for the description of isotropic elastic behavior
-     */
-    namespace Elasticity::Isotropic {
-
-      /**
-       * @brief Computes the isotropic Young's modulus \f$ E \f$ from the compression modulus \f$ K \f$
-       * and shear modulus \f$ G \f$.
-       *
-       *\f[
-          \displaystyle E = \frac{9\,K\,G}{3\,K + G}
-        \f]
-       *
-       * @param K Compression modulus \f$ K \f$.
-       * @param G Shear modulus \f$ G \f$.
-       * @return Young's modulus \f$ E \f$.
-       */
-      double constexpr E( const double K, const double G )
-      {
-        return 9. * K * G / ( 3. * K + G );
-      }
-
-      /**
-       * @brief Computes the isotropic Poisson's ratio \f$ \nu \f$ from the compression modulus \f$ K \f$
-       * and shear modulus \f$ G \f$.
-       *
-       *\f[
-          \displaystyle \nu = \frac{3\,K - 2\,G}{6\,K + 2\,G}
-         \f]
-       *
-       * @param K Compression modulus \f$ K \f$.
-       * @param G Shear modulus \f$ G \f$.
-       * @return Poisson's ratio \f$ \nu \f$.
-       */
-      double constexpr nu( const double K, const double G )
-      {
-        return ( 3 * K - 2 * G ) / ( 6 * K + 2 * G );
-      }
-
-      /**
-       * @brief Computes the isotropic shear modulus \f$ G \f$ from the Young's modulus \f$ E \f$
-       * and Poisson's ratio \f$ \nu \f$.
-       *
-       *\f[
-         \displaystyle G = \frac{E}{2\,(1 + \nu)}
-        \f]
-       * @param E Young's modulus \f$ E \f$.
-       * @param nu Poisson's ratio \f$ \nu \f$.
-       * @return Shear modulus \f$ G \f$.
-      */
-      double constexpr shearModulus( const double E, const double nu )
-      {
-        return E / ( 2 * ( 1 + nu ) );
-      }
-
-      /**
-       * @brief Computes the isotropic Lamé parameter \f$ \lambda \f$ from the Young's modulus \f$ E \f$ and Poisson's
-       * ratio \f$ \nu \f$.
-       *
-       *\f[
-         \displaystyle \lambda = \frac{E\,\nu}{(1 + \nu)(1 - 2\,\nu)}
-        \f]
-       *
-       * @param E Young's modulus \f$ E \f$.
-       * @param nu Poisson's ratio \f$ \nu \f$.
-       * @return Lamé parameter \f$ \lambda \f$.
-       */
-      double constexpr lameParameter( const double E, const double nu )
-      {
-        return E * nu / ( ( 1 + nu ) * ( 1 - 2 * nu ) );
-      }
-
-      /**
-       * @brief Computes the isotropic compliance tensor \f$\mathbb{C}^{-1}\f$.
-       *\f[
-         \displaystyle \mathbb{ C }^{-1} = \begin{bmatrix}
-                        \frac{1}{E} & \frac{-\nu}{E} & \frac{-\nu}{E} & 0 & 0 & 0 \\
-                        \frac{-\nu}{E} & \frac{1}{E} & \frac{-\nu}{E} & 0 & 0 & 0 \\
-                        \frac{-\nu}{E} & \frac{-\nu}{E} & \frac{1}{E} & 0 & 0 & 0 \\
-                  0 & 0 & 0 & \frac{1}{G} & 0 & 0 \\
-                  0 & 0 & 0 & 0 & \frac{1}{G} & 0 \\
-                  0 & 0 & 0 & 0 & 0 & \frac{1}{G}
-                   \end{bmatrix}
-        \f]
-       *
-       * with
-       *
-       * \f[
-       *   G = \frac{E}{2\,(1 + \nu)}.
-       * \f]
-       *
-       * @param E Young's modulus \f$E\f$.
-       * @param nu Poisson's ratio \f$\nu\f$.
-       * @return Compliance tensor \f$\mathbb{C}^{-1}\f$ as a 6x6 matrix.
-       */
-      Matrix6d complianceTensor( const double E, const double nu );
-
-      /**
-       * @brief Computes the isotropic stiffness tensor \f$\mathbb{C}\f$ from
-       * Young's modulus \f$E\f$ and Poisson's ratio \f$\nu\f$.
-       *
-       *\f[
-       \displaystyle \mathbb{ C } = \frac{E\,(1-\nu)}{(1+\nu)(1-2\,\nu)} \begin{bmatrix}
-                                       1 & \frac{\nu}{1-\nu} & \frac{\nu}{1-\nu} & 0 & 0 & 0 \\
-                                                   \frac{\nu}{1-\nu} & 1 & \frac{\nu}{1-\nu} & 0 & 0 & 0 \\
-                                             \frac{\nu}{1-\nu} & \frac{\nu}{1-\nu} & 1 & 0 & 0 & 0 \\
-                                         0 & 0 & 0 & \frac{1-2\,\nu}{2\,(1-\nu)} & 0 & 0 \\
-                                             0 & 0 & 0 & 0 & \frac{1-2\,\nu}{2\,(1-\nu)} & 0 \\
-                                             0 & 0 & 0 & 0 & 0 & \frac{1-2\,\nu}{2\,(1-\nu)}
-                                        \end{bmatrix}
-        \f]
-
-       * @param E Young's modulus \f$E\f$.
-       * @param nu Poisson's ratio \f$\nu\f$.
-       * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
-       */
-      Matrix6d stiffnessTensor( const double E, const double nu );
-
-      /**
-       * @brief Computes the isotropic stiffness tensor \f$\mathbb{C}\f$ from
-       * the bulk modulus \f$K\f$ and shear modulus \f$G\f$.
-       *
-       * @param K Bulk modulus \f$K\f$.
-       * @param G Shear modulus \f$G\f$.
-       * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
-       */
-      Matrix6d stiffnessTensorKG( const double K, const double G );
-
-    } // namespace Elasticity::Isotropic
+  /**
+   * @brief Functions for the description of isotropic elastic behavior
+   */
+  namespace Elasticity::Isotropic {
 
     /**
-     * @brief Functions for the description of transversely isotropic elastic behavior
+     * @brief Computes the isotropic Young's modulus \f$ E \f$ from the compression modulus \f$ K \f$
+     * and shear modulus \f$ G \f$.
      *
-     * Poisson's ratio \f$\nu_{ij}\f$ is defined as the negative ratio of the lateral strain in
-     * direction \f$x_j\f$ to the axial strain in direction \f$x_i\f$ for uniaxial stress applied
-     * in direction \f$x_i\f$,
+     *\f[
+        \displaystyle E = \frac{9\,K\,G}{3\,K + G}
+      \f]
      *
-     \f[
-       \displaystyle \nu_{ij} = -\frac{\varepsilon_j}{\varepsilon_i}
-       \quad\text{for}\quad \sigma_i \neq 0,\ \sigma_k = 0\ (k \neq i),
-     \f]
-     *
-     * so the corresponding compliance entry reads \f$ \mathbb{C}^{-1}_{ji} = -\nu_{ij}/E_i \f$.
-     * Symmetry of the compliance tensor implies \f$ \nu_{ij}/E_i = \nu_{ji}/E_j \f$, hence only
-     * \f$\nu_{12}\f$ and \f$\nu_{23}\f$ are independent.
+     * @param K Compression modulus \f$ K \f$.
+     * @param G Shear modulus \f$ G \f$.
+     * @return Young's modulus \f$ E \f$.
      */
-    namespace Elasticity::TransverseIsotropic {
+    double constexpr E( const double K, const double G )
+    {
+      return 9. * K * G / ( 3. * K + G );
+    }
 
-      /**
-       * @brief Computes the transversely isotropic compliance tensor \f$\mathbb{C}^{-1}\f$.
-       *\f[
-          \displaystyle \mathbb{ C }^{-1} = \begin{bmatrix}
-                       \frac{1}{E_1} & \frac{-\nu_{12}}{E_1} & \frac{-\nu_{12}}{E_1} & 0 & 0 & 0 \\
-                             \frac{-\nu_{12}}{E_1} & \frac{1}{E_2} & \frac{-\nu_{23}}{E_2} & 0 & 0 & 0 \\
-                             \frac{-\nu_{12}}{E_1} & \frac{-\nu_{23}}{E_2} & \frac{1}{E_2} & 0 & 0 & 0 \\
-                         0 & 0 & 0 & \frac{1}{G_{12}} & 0 & 0 \\
-                         0 & 0 & 0 & 0 & \frac{1}{G_{12}} & 0 \\
-                         0 & 0 & 0 & 0 & 0 & \frac{1}{G_{23}}
-                                          \end{bmatrix}
+    /**
+     * @brief Computes the isotropic Poisson's ratio \f$ \nu \f$ from the compression modulus \f$ K \f$
+     * and shear modulus \f$ G \f$.
+     *
+     *\f[
+        \displaystyle \nu = \frac{3\,K - 2\,G}{6\,K + 2\,G}
        \f]
-       *
-       * The isotropic plane is defined with respect to the \f$x_2\f$–\f$x_3\f$ axes of a local coordinate system.
-       * The tensor is expressed in terms of the out-of-plane Young's modulus \f$E_1\f$, shear modulus \f$G_{12}\f$,
-       * and Poisson's ratio \f$\nu_{12}\f$, together with the in-plane Young's modulus \f$E_2\f$ and
-       * Poisson's ratio \f$\nu_{23}\f$.
-       *
-       *The in-plane shear modulus \f$ G_{23} \f$ is given by
-       *
-       \f[
-         \displaystyle G_{23} = \frac{E_2}{2\,(1 + \nu_{23})}
-       \f]
-       *
-       * @param E1 Out-of-plane Young's modulus \f$E_1\f$.
-       * @param E2 In-plane Young's modulus \f$E_2\f$.
-       * @param nu12 Poisson's ratio \f$\nu_{12}\f$.
-       * @param nu23 Poisson's ratio \f$\nu_{23}\f$.
-       * @param G12 shear modulus \f$G_{12}\f$.
-       * @return Compliance tensor \f$\mathbb{C}^{-1}\f$ as a 6x6 matrix.
-       */
-      Matrix6d complianceTensor( const double E1,
-                                 const double E2,
-                                 const double nu12,
-                                 const double nu23,
-                                 const double G12 );
-      /**
-       * @brief Computes the transversely isotropic stiffness tensor \f$ \mathbb{C} \f$ as inverse of the transversely
-       * isotropic compliance tensor \f$ \mathbb{C}^{-1} \f$.
-       *
-       * @param E1 Out-of-plane Young's modulus \f$E_1\f$.
-       * @param E2 In-plane Young's modulus \f$E_2\f$.
-       * @param nu12 Poisson's ratio \f$\nu_{12}\f$.
-       * @param nu23 Poisson's ratio \f$\nu_{23}\f$.
-       * @param G12 shear modulus \f$G_{12}\f$.
-       * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
-       */
-      Matrix6d stiffnessTensor( const double E1,
-                                const double E2,
-                                const double nu12,
-                                const double nu23,
-                                const double G12 );
-    } // namespace Elasticity::TransverseIsotropic
+     *
+     * @param K Compression modulus \f$ K \f$.
+     * @param G Shear modulus \f$ G \f$.
+     * @return Poisson's ratio \f$ \nu \f$.
+     */
+    double constexpr nu( const double K, const double G )
+    {
+      return ( 3 * K - 2 * G ) / ( 6 * K + 2 * G );
+    }
 
     /**
-     * @brief Functions for the description of orthotropic elastic behavior
+     * @brief Computes the isotropic shear modulus \f$ G \f$ from the Young's modulus \f$ E \f$
+     * and Poisson's ratio \f$ \nu \f$.
      *
-     * Poisson's ratio \f$\nu_{ij}\f$ is defined as the negative ratio of the lateral strain in
-     * direction \f$x_j\f$ to the axial strain in direction \f$x_i\f$ for uniaxial stress applied
-     * in direction \f$x_i\f$,
+     *\f[
+       \displaystyle G = \frac{E}{2\,(1 + \nu)}
+      \f]
+     * @param E Young's modulus \f$ E \f$.
+     * @param nu Poisson's ratio \f$ \nu \f$.
+     * @return Shear modulus \f$ G \f$.
+    */
+    double constexpr shearModulus( const double E, const double nu )
+    {
+      return E / ( 2 * ( 1 + nu ) );
+    }
+
+    /**
+     * @brief Computes the isotropic Lamé parameter \f$ \lambda \f$ from the Young's modulus \f$ E \f$ and Poisson's
+     * ratio \f$ \nu \f$.
      *
-     \f[
-       \displaystyle \nu_{ij} = -\frac{\varepsilon_j}{\varepsilon_i}
-       \quad\text{for}\quad \sigma_i \neq 0,\ \sigma_k = 0\ (k \neq i),
-     \f]
+     *\f[
+       \displaystyle \lambda = \frac{E\,\nu}{(1 + \nu)(1 - 2\,\nu)}
+      \f]
      *
-     * so the corresponding compliance entry reads \f$ \mathbb{C}^{-1}_{ji} = -\nu_{ij}/E_i \f$.
-     * Symmetry of the compliance tensor implies \f$ \nu_{ij}/E_i = \nu_{ji}/E_j \f$, hence only
-     * \f$\nu_{12}\f$, \f$\nu_{13}\f$ and \f$\nu_{23}\f$ are independent.
+     * @param E Young's modulus \f$ E \f$.
+     * @param nu Poisson's ratio \f$ \nu \f$.
+     * @return Lamé parameter \f$ \lambda \f$.
      */
-    namespace Elasticity::Orthotropic {
-      /**
-       * @brief Computes the orthotropic compliance tensor \f$\mathbb{C}^{-1}\f$,
-       * defined in the principal material directions \f$x_1\f$, \f$x_2\f$, and \f$x_3\f$.
-       *
-       *\f[
-          \displaystyle \mathbb{ C }^{-1} = \begin{bmatrix}
-                         \frac{1}{E_1} & \frac{-\nu_{12}}{E_1} & \frac{-\nu_{13}}{E_1} & 0 & 0 & 0 \\
-                         \frac{-\nu_{12}}{E_1} & \frac{1}{E_2} & \frac{-\nu_{23}}{E_2} & 0 & 0 & 0 \\
-                         \frac{-\nu_{13}}{E_1} & \frac{-\nu_{23}}{E_2} & \frac{1}{E_3} & 0 & 0 & 0 \\
+    double constexpr lameParameter( const double E, const double nu )
+    {
+      return E * nu / ( ( 1 + nu ) * ( 1 - 2 * nu ) );
+    }
+
+    /**
+     * @brief Computes the isotropic compliance tensor \f$\mathbb{C}^{-1}\f$.
+     *\f[
+       \displaystyle \mathbb{ C }^{-1} = \begin{bmatrix}
+                      \frac{1}{E} & \frac{-\nu}{E} & \frac{-\nu}{E} & 0 & 0 & 0 \\
+                      \frac{-\nu}{E} & \frac{1}{E} & \frac{-\nu}{E} & 0 & 0 & 0 \\
+                      \frac{-\nu}{E} & \frac{-\nu}{E} & \frac{1}{E} & 0 & 0 & 0 \\
+                0 & 0 & 0 & \frac{1}{G} & 0 & 0 \\
+                0 & 0 & 0 & 0 & \frac{1}{G} & 0 \\
+                0 & 0 & 0 & 0 & 0 & \frac{1}{G}
+                 \end{bmatrix}
+      \f]
+     *
+     * with
+     *
+     * \f[
+     *   G = \frac{E}{2\,(1 + \nu)}.
+     * \f]
+     *
+     * @param E Young's modulus \f$E\f$.
+     * @param nu Poisson's ratio \f$\nu\f$.
+     * @return Compliance tensor \f$\mathbb{C}^{-1}\f$ as a 6x6 matrix.
+     */
+    Matrix6d complianceTensor( const double E, const double nu );
+
+    /**
+     * @brief Computes the isotropic stiffness tensor \f$\mathbb{C}\f$ from
+     * Young's modulus \f$E\f$ and Poisson's ratio \f$\nu\f$.
+     *
+     *\f[
+     \displaystyle \mathbb{ C } = \frac{E\,(1-\nu)}{(1+\nu)(1-2\,\nu)} \begin{bmatrix}
+                                     1 & \frac{\nu}{1-\nu} & \frac{\nu}{1-\nu} & 0 & 0 & 0 \\
+                                                 \frac{\nu}{1-\nu} & 1 & \frac{\nu}{1-\nu} & 0 & 0 & 0 \\
+                                           \frac{\nu}{1-\nu} & \frac{\nu}{1-\nu} & 1 & 0 & 0 & 0 \\
+                                       0 & 0 & 0 & \frac{1-2\,\nu}{2\,(1-\nu)} & 0 & 0 \\
+                                           0 & 0 & 0 & 0 & \frac{1-2\,\nu}{2\,(1-\nu)} & 0 \\
+                                           0 & 0 & 0 & 0 & 0 & \frac{1-2\,\nu}{2\,(1-\nu)}
+                                      \end{bmatrix}
+      \f]
+
+     * @param E Young's modulus \f$E\f$.
+     * @param nu Poisson's ratio \f$\nu\f$.
+     * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
+     */
+    Matrix6d stiffnessTensor( const double E, const double nu );
+
+    /**
+     * @brief Computes the isotropic stiffness tensor \f$\mathbb{C}\f$ from
+     * the bulk modulus \f$K\f$ and shear modulus \f$G\f$.
+     *
+     * @param K Bulk modulus \f$K\f$.
+     * @param G Shear modulus \f$G\f$.
+     * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
+     */
+    Matrix6d stiffnessTensorKG( const double K, const double G );
+
+  } // namespace Elasticity::Isotropic
+
+  /**
+   * @brief Functions for the description of transversely isotropic elastic behavior
+   *
+   * Poisson's ratio \f$\nu_{ij}\f$ is defined as the negative ratio of the lateral strain in
+   * direction \f$x_j\f$ to the axial strain in direction \f$x_i\f$ for uniaxial stress applied
+   * in direction \f$x_i\f$,
+   *
+   \f[
+     \displaystyle \nu_{ij} = -\frac{\varepsilon_j}{\varepsilon_i}
+     \quad\text{for}\quad \sigma_i \neq 0,\ \sigma_k = 0\ (k \neq i),
+   \f]
+   *
+   * so the corresponding compliance entry reads \f$ \mathbb{C}^{-1}_{ji} = -\nu_{ij}/E_i \f$.
+   * Symmetry of the compliance tensor implies \f$ \nu_{ij}/E_i = \nu_{ji}/E_j \f$, hence only
+   * \f$\nu_{12}\f$ and \f$\nu_{23}\f$ are independent.
+   */
+  namespace Elasticity::TransverseIsotropic {
+
+    /**
+     * @brief Computes the transversely isotropic compliance tensor \f$\mathbb{C}^{-1}\f$.
+     *\f[
+        \displaystyle \mathbb{ C }^{-1} = \begin{bmatrix}
+                     \frac{1}{E_1} & \frac{-\nu_{12}}{E_1} & \frac{-\nu_{12}}{E_1} & 0 & 0 & 0 \\
+                           \frac{-\nu_{12}}{E_1} & \frac{1}{E_2} & \frac{-\nu_{23}}{E_2} & 0 & 0 & 0 \\
+                           \frac{-\nu_{12}}{E_1} & \frac{-\nu_{23}}{E_2} & \frac{1}{E_2} & 0 & 0 & 0 \\
                        0 & 0 & 0 & \frac{1}{G_{12}} & 0 & 0 \\
-                       0 & 0 & 0 & 0 & \frac{1}{G_{13}} & 0 \\
+                       0 & 0 & 0 & 0 & \frac{1}{G_{12}} & 0 \\
                        0 & 0 & 0 & 0 & 0 & \frac{1}{G_{23}}
-                         \end{bmatrix}
-        \f]
-       *
-       * @param E1 Young's modulus \f$E_1\f$ in \f$ x_1 \f$ - direction.
-       * @param E2 Young's modulus \f$E_2\f$ in \f$ x_2 \f$ - direction.
-       * @param E3 Young's modulus \f$E_3\f$ in \f$ x_3 \f$ - direction.
-       * @param nu12 Poisson's ratio \f$\nu_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
-       * @param nu23 Poisson's ratio \f$\nu_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
-       * @param nu13 Poisson's ratio \f$\nu_{13}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
-       * @param G12 Shear modulus \f$G_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
-       * @param G23 Shear modulus \f$G_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
-       * @param G31 Shear modulus \f$G_{31}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
-       * @return Compliance tensor \f$\mathbb{C}^{-1}\f$ as a 6x6 matrix.
-       */
-      Matrix6d complianceTensor( const double E1,
-                                 const double E2,
-                                 const double E3,
-                                 const double nu12,
-                                 const double nu23,
-                                 const double nu13,
-                                 const double G12,
-                                 const double G23,
-                                 const double G31 );
-      /**
-       * @brief Computes the orthotropic stiffness tensor \f$ \mathbb{C} \f$ as inverse of the orthotropic compliance
-       * tensor
-       * \f$ \mathbb{C}^{-1} \f$.
-       *
-       * @param E1 Young's modulus \f$E_1\f$ in \f$ x_1 \f$ - direction.
-       * @param E2 Young's modulus \f$E_2\f$ in \f$ x_2 \f$ - direction.
-       * @param E3 Young's modulus \f$E_3\f$ in \f$ x_3 \f$ - direction.
-       * @param nu12 Poisson's ratio \f$\nu_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
-       * @param nu23 Poisson's ratio \f$\nu_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
-       * @param nu13 Poisson's ratio \f$\nu_{13}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
-       * @param G12 Shear modulus \f$G_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
-       * @param G23 Shear modulus \f$G_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
-       * @param G31 Shear modulus \f$G_{31}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
-       * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
-       */
-      Matrix6d stiffnessTensor( const double E1,
-                                const double E2,
-                                const double E3,
-                                const double nu12,
-                                const double nu23,
-                                const double nu13,
-                                const double G12,
-                                const double G23,
-                                const double G31 );
+                                        \end{bmatrix}
+     \f]
+     *
+     * The isotropic plane is defined with respect to the \f$x_2\f$–\f$x_3\f$ axes of a local coordinate system.
+     * The tensor is expressed in terms of the out-of-plane Young's modulus \f$E_1\f$, shear modulus \f$G_{12}\f$,
+     * and Poisson's ratio \f$\nu_{12}\f$, together with the in-plane Young's modulus \f$E_2\f$ and
+     * Poisson's ratio \f$\nu_{23}\f$.
+     *
+     *The in-plane shear modulus \f$ G_{23} \f$ is given by
+     *
+     \f[
+       \displaystyle G_{23} = \frac{E_2}{2\,(1 + \nu_{23})}
+     \f]
+     *
+     * @param E1 Out-of-plane Young's modulus \f$E_1\f$.
+     * @param E2 In-plane Young's modulus \f$E_2\f$.
+     * @param nu12 Poisson's ratio \f$\nu_{12}\f$.
+     * @param nu23 Poisson's ratio \f$\nu_{23}\f$.
+     * @param G12 shear modulus \f$G_{12}\f$.
+     * @return Compliance tensor \f$\mathbb{C}^{-1}\f$ as a 6x6 matrix.
+     */
+    Matrix6d complianceTensor( const double E1,
+                               const double E2,
+                               const double nu12,
+                               const double nu23,
+                               const double G12 );
+    /**
+     * @brief Computes the transversely isotropic stiffness tensor \f$ \mathbb{C} \f$ as inverse of the transversely
+     * isotropic compliance tensor \f$ \mathbb{C}^{-1} \f$.
+     *
+     * @param E1 Out-of-plane Young's modulus \f$E_1\f$.
+     * @param E2 In-plane Young's modulus \f$E_2\f$.
+     * @param nu12 Poisson's ratio \f$\nu_{12}\f$.
+     * @param nu23 Poisson's ratio \f$\nu_{23}\f$.
+     * @param G12 shear modulus \f$G_{12}\f$.
+     * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
+     */
+    Matrix6d stiffnessTensor( const double E1,
+                              const double E2,
+                              const double nu12,
+                              const double nu23,
+                              const double G12 );
+  } // namespace Elasticity::TransverseIsotropic
 
-    } // namespace Elasticity::Orthotropic
-  }   // namespace ContinuumMechanics
-} // namespace Marmot
+  /**
+   * @brief Functions for the description of orthotropic elastic behavior
+   *
+   * Poisson's ratio \f$\nu_{ij}\f$ is defined as the negative ratio of the lateral strain in
+   * direction \f$x_j\f$ to the axial strain in direction \f$x_i\f$ for uniaxial stress applied
+   * in direction \f$x_i\f$,
+   *
+   \f[
+     \displaystyle \nu_{ij} = -\frac{\varepsilon_j}{\varepsilon_i}
+     \quad\text{for}\quad \sigma_i \neq 0,\ \sigma_k = 0\ (k \neq i),
+   \f]
+   *
+   * so the corresponding compliance entry reads \f$ \mathbb{C}^{-1}_{ji} = -\nu_{ij}/E_i \f$.
+   * Symmetry of the compliance tensor implies \f$ \nu_{ij}/E_i = \nu_{ji}/E_j \f$, hence only
+   * \f$\nu_{12}\f$, \f$\nu_{13}\f$ and \f$\nu_{23}\f$ are independent.
+   */
+  namespace Elasticity::Orthotropic {
+    /**
+     * @brief Computes the orthotropic compliance tensor \f$\mathbb{C}^{-1}\f$,
+     * defined in the principal material directions \f$x_1\f$, \f$x_2\f$, and \f$x_3\f$.
+     *
+     *\f[
+        \displaystyle \mathbb{ C }^{-1} = \begin{bmatrix}
+                       \frac{1}{E_1} & \frac{-\nu_{12}}{E_1} & \frac{-\nu_{13}}{E_1} & 0 & 0 & 0 \\
+                       \frac{-\nu_{12}}{E_1} & \frac{1}{E_2} & \frac{-\nu_{23}}{E_2} & 0 & 0 & 0 \\
+                       \frac{-\nu_{13}}{E_1} & \frac{-\nu_{23}}{E_2} & \frac{1}{E_3} & 0 & 0 & 0 \\
+                     0 & 0 & 0 & \frac{1}{G_{12}} & 0 & 0 \\
+                     0 & 0 & 0 & 0 & \frac{1}{G_{13}} & 0 \\
+                     0 & 0 & 0 & 0 & 0 & \frac{1}{G_{23}}
+                       \end{bmatrix}
+      \f]
+     *
+     * @param E1 Young's modulus \f$E_1\f$ in \f$ x_1 \f$ - direction.
+     * @param E2 Young's modulus \f$E_2\f$ in \f$ x_2 \f$ - direction.
+     * @param E3 Young's modulus \f$E_3\f$ in \f$ x_3 \f$ - direction.
+     * @param nu12 Poisson's ratio \f$\nu_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
+     * @param nu23 Poisson's ratio \f$\nu_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
+     * @param nu13 Poisson's ratio \f$\nu_{13}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
+     * @param G12 Shear modulus \f$G_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
+     * @param G23 Shear modulus \f$G_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
+     * @param G31 Shear modulus \f$G_{31}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
+     * @return Compliance tensor \f$\mathbb{C}^{-1}\f$ as a 6x6 matrix.
+     */
+    Matrix6d complianceTensor( const double E1,
+                               const double E2,
+                               const double E3,
+                               const double nu12,
+                               const double nu23,
+                               const double nu13,
+                               const double G12,
+                               const double G23,
+                               const double G31 );
+    /**
+     * @brief Computes the orthotropic stiffness tensor \f$ \mathbb{C} \f$ as inverse of the orthotropic compliance
+     * tensor
+     * \f$ \mathbb{C}^{-1} \f$.
+     *
+     * @param E1 Young's modulus \f$E_1\f$ in \f$ x_1 \f$ - direction.
+     * @param E2 Young's modulus \f$E_2\f$ in \f$ x_2 \f$ - direction.
+     * @param E3 Young's modulus \f$E_3\f$ in \f$ x_3 \f$ - direction.
+     * @param nu12 Poisson's ratio \f$\nu_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
+     * @param nu23 Poisson's ratio \f$\nu_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
+     * @param nu13 Poisson's ratio \f$\nu_{13}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
+     * @param G12 Shear modulus \f$G_{12}\f$ effective between \f$ x_1 \f$ and \f$ x_2 \f$ - direction.
+     * @param G23 Shear modulus \f$G_{23}\f$ effective between \f$ x_2 \f$ and \f$ x_3 \f$ - direction.
+     * @param G31 Shear modulus \f$G_{31}\f$ effective between \f$ x_1 \f$ and \f$ x_3 \f$ - direction.
+     * @return Stiffness tensor \f$\mathbb{C}\f$ as a 6x6 matrix.
+     */
+    Matrix6d stiffnessTensor( const double E1,
+                              const double E2,
+                              const double E3,
+                              const double nu12,
+                              const double nu23,
+                              const double nu13,
+                              const double G12,
+                              const double G23,
+                              const double G31 );
+
+  } // namespace Elasticity::Orthotropic
+} // namespace Marmot::ContinuumMechanics

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotKelvinChain.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotKelvinChain.h
@@ -29,251 +29,246 @@
 #include "autodiff/forward/real.hpp"
 #include <functional>
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::KelvinChain {
+  /** This namespace contains the functions that derive the equivalent
+   * Kelvin chain for a given compliance function
+   * @typedef Properties
+   * @brief Vector of material properties.
+   *
+   * Convenience typedef for an Eigen dynamic-size vector (`Eigen::VectorXd`)
+   * that holds the material or model parameters of the Kelvin chain.
+   */
+  typedef Eigen::VectorXd Properties;
 
-  namespace KelvinChain {
-    /** This namespace contains the functions that derive the equivalent
-     * Kelvin chain for a given compliance function
-     * @typedef Properties
-     * @brief Vector of material properties.
-     *
-     * Convenience typedef for an Eigen dynamic-size vector (`Eigen::VectorXd`)
-     * that holds the material or model parameters of the Kelvin chain.
-     */
-    typedef Eigen::VectorXd Properties;
+  /**
+   * @typedef mapProperties
+   * @brief Mapped view of material properties.
+   *
+   * Alias for `Eigen::Map<Properties>`, which allows mapping an existing
+   * contiguous memory block as a `Properties` vector without copying.
+   */
+  typedef Eigen::Map< Properties > mapProperties;
+  /**
+   * @typedef StateVarMatrix
+   * @brief Matrix of state variables.
+   *
+   * Alias for an Eigen matrix of shape 6 × N (`Eigen::Matrix<double, 6, Eigen::Dynamic>`),
+   * storing viscoelastic strain variables for each Kelvin unit.
+   */
+  typedef Eigen::Matrix< double, 6, Eigen::Dynamic > StateVarMatrix;
 
-    /**
-     * @typedef mapProperties
-     * @brief Mapped view of material properties.
-     *
-     * Alias for `Eigen::Map<Properties>`, which allows mapping an existing
-     * contiguous memory block as a `Properties` vector without copying.
-     */
-    typedef Eigen::Map< Properties > mapProperties;
-    /**
-     * @typedef StateVarMatrix
-     * @brief Matrix of state variables.
-     *
-     * Alias for an Eigen matrix of shape 6 × N (`Eigen::Matrix<double, 6, Eigen::Dynamic>`),
-     * storing viscoelastic strain variables for each Kelvin unit.
-     */
-    typedef Eigen::Matrix< double, 6, Eigen::Dynamic > StateVarMatrix;
+  /**
+   * @typedef mapStateVarMatrix
+   * @brief Mapped view of the state variable matrix.
+   *
+   * Alias for `Eigen::Map<StateVarMatrix>`, allowing access to an existing
+   * state variable array as an Eigen matrix without copying.
+   */
+  typedef Eigen::Map< StateVarMatrix > mapStateVarMatrix;
+  /**
+   * @brief Compile-time factorial.
+   *
+   * Recursive template structure computing the factorial of N at compile time.
+   *
+   * Example:
+   * @code
+   *   int f = Factorial<5>::value; // f = 120
+   * @endcode
+   *
+   * @tparam N Non-negative integer whose factorial is to be computed.
+   */
+  template < int N >
+  struct Factorial {
+    enum factorial { value = N * Factorial< N - 1 >::value };
+  };
+  /// \cond DOXYGEN_SKIP
+  // Specialisation Factorial<0> is hidden from Doxygen: both the primary
+  // template and this specialisation would get the same documentation ID,
+  // causing a CRITICAL "Duplicate ID" error during the Sphinx build.
+  /**
+   * @brief Template specialization of Factorial for 0.
+   *
+   * Defines the base case of the factorial recursion, setting 0! = 1.
+   */
+  template <>
+  struct Factorial< 0 > {
+    enum factorial { value = 1 };
+  };
+  /// \endcond
+  /**
+   * @brief Evaluates the Post–Widder inversion formula to approximate the discrete retardance function
+   * \f$L_k(\tau)\f$.
+   *
+   * Evaluates the Post-Widder formula for deriving the equivalent retardance \f$L_\kappa(\tau)\f$ of the discrete
+   * Kelvin Chain model, given the continuous description of the compliance \f[\Phi(t) = \int_{\tau=0}^\infty
+   * L(\tau)\left(1-e^{-\frac{t}{\tau}}\right)d(\ln\tau)\f] according to the formula
+   * \f[L_k(\tau)=(-1)^{k-1}\frac{(-tk)^k\Phi^{(k)(t)}}{(k-1)!}\f]
+   *
+   * in the sense that \f$L_k(\tau)=\lim_{\kappa\to\infty}L_\kappa(\tau)\f$ in the frequency domain.
+   * @tparam k \f$k\f$ integer defining the order of differentiation that corresponds to the \f$L_k\f$ term in the
+   * sequence of the retardance approximation
+   * @param[in] phi compliance function whose discrete approximation is sought
+   * @param[in] tau the continuous variable in the frequency domain
+   * @return val the value of the \f$L_k(\tau)\f$ approximation.
+   */
+  template < int k >
+  double evaluatePostWidderFormula( std::function< autodiff::Real< k, double >( autodiff::Real< k, double > ) > phi,
+                                    double                                                                      tau )
+  {
+    autodiff::Real< k, double > tau_( tau * k );
 
-    /**
-     * @typedef mapStateVarMatrix
-     * @brief Mapped view of the state variable matrix.
-     *
-     * Alias for `Eigen::Map<StateVarMatrix>`, allowing access to an existing
-     * state variable array as an Eigen matrix without copying.
-     */
-    typedef Eigen::Map< StateVarMatrix > mapStateVarMatrix;
-    /**
-     * @brief Compile-time factorial.
-     *
-     * Recursive template structure computing the factorial of N at compile time.
-     *
-     * Example:
-     * @code
-     *   int f = Factorial<5>::value; // f = 120
-     * @endcode
-     *
-     * @tparam N Non-negative integer whose factorial is to be computed.
-     */
-    template < int N >
-    struct Factorial {
-      enum factorial { value = N * Factorial< N - 1 >::value };
-    };
-    /// \cond DOXYGEN_SKIP
-    // Specialisation Factorial<0> is hidden from Doxygen: both the primary
-    // template and this specialisation would get the same documentation ID,
-    // causing a CRITICAL "Duplicate ID" error during the Sphinx build.
-    /**
-     * @brief Template specialization of Factorial for 0.
-     *
-     * Defines the base case of the factorial recursion, setting 0! = 1.
-     */
-    template <>
-    struct Factorial< 0 > {
-      enum factorial { value = 1 };
-    };
-    /// \endcond
-    /**
-     * @brief Evaluates the Post–Widder inversion formula to approximate the discrete retardance function
-     * \f$L_k(\tau)\f$.
-     *
-     * Evaluates the Post-Widder formula for deriving the equivalent retardance \f$L_\kappa(\tau)\f$ of the discrete
-     * Kelvin Chain model, given the continuous description of the compliance \f[\Phi(t) = \int_{\tau=0}^\infty
-     * L(\tau)\left(1-e^{-\frac{t}{\tau}}\right)d(\ln\tau)\f] according to the formula
-     * \f[L_k(\tau)=(-1)^{k-1}\frac{(-tk)^k\Phi^{(k)(t)}}{(k-1)!}\f]
-     *
-     * in the sense that \f$L_k(\tau)=\lim_{\kappa\to\infty}L_\kappa(\tau)\f$ in the frequency domain.
-     * @tparam k \f$k\f$ integer defining the order of differentiation that corresponds to the \f$L_k\f$ term in the
-     * sequence of the retardance approximation
-     * @param[in] phi compliance function whose discrete approximation is sought
-     * @param[in] tau the continuous variable in the frequency domain
-     * @return val the value of the \f$L_k(\tau)\f$ approximation.
-     */
-    template < int k >
-    double evaluatePostWidderFormula( std::function< autodiff::Real< k, double >( autodiff::Real< k, double > ) > phi,
-                                      double                                                                      tau )
-    {
+    double val = -pow( -tau * k, k ) / double( Factorial< k - 1 >::value );
+    val *= autodiff::derivatives( phi, autodiff::along( 1. ), autodiff::at( tau_ ) )[k];
+    return val;
+  }
+  /**
+   * @brief Computes the zeroth-order (instantaneous) elastic compliance by numerically integrating the retardance
+   * function.
+   *
+   * Approximates the instantaneous elastic compliance \f$\Phi_0=\frac{1}{E_0}\f$,
+   * \f[\frac{1}{E_0}=\int_{\tau=0}^{\tau}L(\tau)d\ln(\tau)\f]
+   * It is used in order to avoid integrating over the origin of the frequency domain where
+   * \f$\int_0^{\tau_0}d\ln(\tau)\f$ is singular.
+   *
+   * @tparam k \f$k\f$ integer defining the order of differentiation for the \f$k-th\f$ approximation of the
+   * retardance.
+   * @param[in] phi compliance function whose discrete approximation is sought.
+   * @param[in] tauMin the minimum retardation time that is required to be of the same order or smaller than the total
+   * time of the analysis.
+   * @param[in] spacing the increment between two sunsequent retardation times
+   * @return val the value of the zeroth compliance term.
+   *
+   * @note The integral is evaluated numerically using Simpson’s rule via
+   * `NumericalAlgorithms::Integration::integrateScalarFunction`. The integration range
+   * \f$[\tau_{\min}/\sqrt{\text{spacing}},\,1\times10^{-14}]\f$ is chosen to avoid the logarithmic singularity
+   * at \f$\tau=0\f$. As Simpson's rule is sensitive to changes in the sign of the summands, integration should be
+   * handled with care. A Gauss quadrature approach involving Chebyshev polynomials could be implemented in the
+   * future.
+   */
+  template < int k >
+  double approximateZerothCompliance( std::function< autodiff::Real< k, double >( autodiff::Real< k, double > ) > phi,
+                                      double tauMin,
+                                      double spacing = 10. )
+  {
+    NumericalAlgorithms::Integration::scalar_to_scalar_function_type f = [&]( double tau ) {
+      double                      val_ = -pow( -k, k ) * pow( tau, k - 1 ) / double( Factorial< k - 1 >::value );
       autodiff::Real< k, double > tau_( tau * k );
+      val_ *= autodiff::derivatives( phi, autodiff::along( 1. ), autodiff::at( tau_ ) )[k];
+      return val_;
+    };
 
-      double val = -pow( -tau * k, k ) / double( Factorial< k - 1 >::value );
-      val *= autodiff::derivatives( phi, autodiff::along( 1. ), autodiff::at( tau_ ) )[k];
-      return val;
-    }
-    /**
-     * @brief Computes the zeroth-order (instantaneous) elastic compliance by numerically integrating the retardance
-     * function.
-     *
-     * Approximates the instantaneous elastic compliance \f$\Phi_0=\frac{1}{E_0}\f$,
-     * \f[\frac{1}{E_0}=\int_{\tau=0}^{\tau}L(\tau)d\ln(\tau)\f]
-     * It is used in order to avoid integrating over the origin of the frequency domain where
-     * \f$\int_0^{\tau_0}d\ln(\tau)\f$ is singular.
-     *
-     * @tparam k \f$k\f$ integer defining the order of differentiation for the \f$k-th\f$ approximation of the
-     * retardance.
-     * @param[in] phi compliance function whose discrete approximation is sought.
-     * @param[in] tauMin the minimum retardation time that is required to be of the same order or smaller than the total
-     * time of the analysis.
-     * @param[in] spacing the increment between two sunsequent retardation times
-     * @return val the value of the zeroth compliance term.
-     *
-     * @note The integral is evaluated numerically using Simpson’s rule via
-     * `NumericalAlgorithms::Integration::integrateScalarFunction`. The integration range
-     * \f$[\tau_{\min}/\sqrt{\text{spacing}},\,1\times10^{-14}]\f$ is chosen to avoid the logarithmic singularity
-     * at \f$\tau=0\f$. As Simpson's rule is sensitive to changes in the sign of the summands, integration should be
-     * handled with care. A Gauss quadrature approach involving Chebyshev polynomials could be implemented in the
-     * future.
-     */
-    template < int k >
-    double approximateZerothCompliance( std::function< autodiff::Real< k, double >( autodiff::Real< k, double > ) > phi,
-                                        double tauMin,
-                                        double spacing = 10. )
-    {
-      NumericalAlgorithms::Integration::scalar_to_scalar_function_type f = [&]( double tau ) {
-        double                      val_ = -pow( -k, k ) * pow( tau, k - 1 ) / double( Factorial< k - 1 >::value );
-        autodiff::Real< k, double > tau_( tau * k );
-        val_ *= autodiff::derivatives( phi, autodiff::along( 1. ), autodiff::at( tau_ ) )[k];
-        return val_;
-      };
+    double val = NumericalAlgorithms::Integration::integrateScalarFunction( f,
+                                                                            { 1e-14, tauMin / sqrt( spacing ) },
+                                                                            100,
+                                                                            NumericalAlgorithms::Integration::simpson );
+    return val;
+  }
+  /**
+   *  @brief Computes the discrete elastic moduli of the equivalent Kelvin chain from the \f$L_k\f$ retardance
+   * approximation.
+   *
+   * Evaluates the elastic moduli based on the \f$L_k\f$ approximation of the retardance,
+   * \f[ \frac{1}{E_\mu}=(\ln 10)L_k(\tau_\mu),\;\mu=1,2,...,M\f]
+   *
+   * @tparam k \f$k\f$ integer defining the order of differentiation for the \f$k-th\f$ approximation of the
+   * retardance.
+   * @param[in] phi compliance function whose discrete approximation is sought
+   * @param[in] retardationTimes the minimum retardation time that is required to be of the same order or smaller than
+   * the total time of the analysis
+   * @param[in] gaussQuadrature flag if on Gauss Quadrature is performed else the Post-Widder formula is applied.
+   * @returns elasticModuli the discrete elastic moduli of the equivalt Kelvin chain.
+   */
 
-      double
-        val = NumericalAlgorithms::Integration::integrateScalarFunction( f,
-                                                                         { 1e-14, tauMin / sqrt( spacing ) },
-                                                                         100,
-                                                                         NumericalAlgorithms::Integration::simpson );
-      return val;
-    }
-    /**
-     *  @brief Computes the discrete elastic moduli of the equivalent Kelvin chain from the \f$L_k\f$ retardance
-     * approximation.
-     *
-     * Evaluates the elastic moduli based on the \f$L_k\f$ approximation of the retardance,
-     * \f[ \frac{1}{E_\mu}=(\ln 10)L_k(\tau_\mu),\;\mu=1,2,...,M\f]
-     *
-     * @tparam k \f$k\f$ integer defining the order of differentiation for the \f$k-th\f$ approximation of the
-     * retardance.
-     * @param[in] phi compliance function whose discrete approximation is sought
-     * @param[in] retardationTimes the minimum retardation time that is required to be of the same order or smaller than
-     * the total time of the analysis
-     * @param[in] gaussQuadrature flag if on Gauss Quadrature is performed else the Post-Widder formula is applied.
-     * @returns elasticModuli the discrete elastic moduli of the equivalt Kelvin chain.
-     */
+  template < int k >
+  Properties computeElasticModuli( std::function< autodiff::Real< k, double >( autodiff::Real< k, double > ) > phi,
+                                   Properties retardationTimes,
+                                   bool       gaussQuadrature = false )
+  {
+    Properties elasticModuli( retardationTimes.size() );
+    double     spacing = retardationTimes( 1 ) / retardationTimes( 0 );
 
-    template < int k >
-    Properties computeElasticModuli( std::function< autodiff::Real< k, double >( autodiff::Real< k, double > ) > phi,
-                                     Properties retardationTimes,
-                                     bool       gaussQuadrature = false )
-    {
-      Properties elasticModuli( retardationTimes.size() );
-      double     spacing = retardationTimes( 1 ) / retardationTimes( 0 );
-
-      for ( int i = 0; i < retardationTimes.size(); i++ ) {
-        double tau = retardationTimes( i );
-        if ( !gaussQuadrature ) {
-          elasticModuli( i ) = 1. / ( log( spacing ) * evaluatePostWidderFormula< k >( phi, tau ) );
-        }
-        else {
-          elasticModuli( i ) = 1. /
-                               ( log( spacing ) / 2. *
-                                 ( evaluatePostWidderFormula< k >( phi, tau * pow( spacing, -sqrt( 3. ) / 6. ) ) +
-                                   evaluatePostWidderFormula< k >( phi, tau * pow( spacing, sqrt( 3. ) / 6. ) ) ) );
-        }
+    for ( int i = 0; i < retardationTimes.size(); i++ ) {
+      double tau = retardationTimes( i );
+      if ( !gaussQuadrature ) {
+        elasticModuli( i ) = 1. / ( log( spacing ) * evaluatePostWidderFormula< k >( phi, tau ) );
       }
-
-      return elasticModuli;
+      else {
+        elasticModuli( i ) = 1. / ( log( spacing ) / 2. *
+                                    ( evaluatePostWidderFormula< k >( phi, tau * pow( spacing, -sqrt( 3. ) / 6. ) ) +
+                                      evaluatePostWidderFormula< k >( phi, tau * pow( spacing, sqrt( 3. ) / 6. ) ) ) );
+      }
     }
-    /**
-     * @brief Generates a sequence of logarithmically spaced retardation times for the Kelvin chain model.
-     *
-     * This function evaluates the retardation times.
-     * @param[in] n the number of kelvin units in the equivalent Kelvin chain.
-     * @param[in] min the first retardation time.
-     * @param[in] spacing the spacing between the retardation times.
-     * @returns retardationTimes a vector containing the retardation time for each Kelvin unit in the Kelvin chain.
-     */
 
-    Properties generateRetardationTimes( int n, double min, double spacing );
-    /**
-     * @brief Updates the viscoelastic strain state variables for each Kelvin unit over a given time increment.
-     *
-     * For the given time increment \f$\Delta t_k\f$ this function updates the visco-elastic state variables according
-     * to the update rule: \f[\varepsilon^{ev,\mu,k+1}_{ij} = \frac{\lambda^{\mu
-     * k}}{E_\mu}C^\nu_{ijkl}\Delta\sigma_{kl}+\beta^{\mu ,k}\varepsilon^{ev,\mu, k}_{ij}\f]
-     *
-     * @param[in] dT the time increment.
-     * @param[in] elasticModuli vector containing the elastic moduli of ech Kelvin unit in the Kelvin chain.
-     * @param[in] retardationTimes vector containing the retardation time for each Kelvin unit in the Kelvin chain.
-     * @param[in,out] stateVars the \f$[6\times \mu]\f$ matrix that contains the viscoelastic strain update for each
-     * unit of the Kelvin chain.
-     * @param[in] dStress the \f$[6 \times 1]\f$ vector of the total stress increment.
-     * @param[in] unitComplianceMatrix the \f$[6\times 6]\f$ compliance matrix of the material with unit compliance and
-     * given Poisson coefficient.
-     */
+    return elasticModuli;
+  }
+  /**
+   * @brief Generates a sequence of logarithmically spaced retardation times for the Kelvin chain model.
+   *
+   * This function evaluates the retardation times.
+   * @param[in] n the number of kelvin units in the equivalent Kelvin chain.
+   * @param[in] min the first retardation time.
+   * @param[in] spacing the spacing between the retardation times.
+   * @returns retardationTimes a vector containing the retardation time for each Kelvin unit in the Kelvin chain.
+   */
 
-    void updateStateVarMatrix( const double                 dT,
-                               Properties                   elasticModuli,
-                               Properties                   retardationTimes,
-                               Eigen::Ref< StateVarMatrix > stateVars,
-                               const Marmot::Vector6d&      dStress,
-                               const Marmot::Matrix6d&      unitComplianceMatrix );
-    /**
-     * @brief Evaluates the viscoelastic response of the Kelvin chain over a time increment.
-     *
-     * For the given time increment \f$\Delta t_k\f$ this function updates the visco-elastic state variables according
-     *to the update rule: \f[\overline{J}^k=\sum_{\mu=1}^M\frac{1-\lambda^{\mu,k}}{E^\mu}\f]
-     *\f[\Delta\varepsilon^{'',k}_{ij} = \sum_{\mu=1}^M\left(1-\beta^{\mu,k}\right)\varepsilon^{ev,\kappa}_{ij}\f]
-     *
-     * @param[in] dT the time increment.
-     * @param[in] elasticModuli vector containing the elastic moduli of ech Kelvin unit in the Kelvin chain.
-     * @param[in] retardationTimes vector containing the retardation time for each Kelvin unit in the Kelvin chain.
-     * @param[in] stateVars the \f$[6\times \mu]\f$ matrix that contains the viscoelastic strain update for each unit of
-     *the Kelvin chain.
-     * @param[in,out] uniaxialCompliance number containing the \f$\sum^M_{\mu=1}\frac{\lambda^{\mu, k}}{E_\mu}\f$.
-     * @param[in,out] dStrain the viscoelastic update of the strain based on the state variables of the Kelvin chain.
-     * @param[in] factor the solidification factor (in non aging viscoelasticity set to 1).
-     */
+  Properties generateRetardationTimes( int n, double min, double spacing );
+  /**
+   * @brief Updates the viscoelastic strain state variables for each Kelvin unit over a given time increment.
+   *
+   * For the given time increment \f$\Delta t_k\f$ this function updates the visco-elastic state variables according
+   * to the update rule: \f[\varepsilon^{ev,\mu,k+1}_{ij} = \frac{\lambda^{\mu
+   * k}}{E_\mu}C^\nu_{ijkl}\Delta\sigma_{kl}+\beta^{\mu ,k}\varepsilon^{ev,\mu, k}_{ij}\f]
+   *
+   * @param[in] dT the time increment.
+   * @param[in] elasticModuli vector containing the elastic moduli of ech Kelvin unit in the Kelvin chain.
+   * @param[in] retardationTimes vector containing the retardation time for each Kelvin unit in the Kelvin chain.
+   * @param[in,out] stateVars the \f$[6\times \mu]\f$ matrix that contains the viscoelastic strain update for each
+   * unit of the Kelvin chain.
+   * @param[in] dStress the \f$[6 \times 1]\f$ vector of the total stress increment.
+   * @param[in] unitComplianceMatrix the \f$[6\times 6]\f$ compliance matrix of the material with unit compliance and
+   * given Poisson coefficient.
+   */
 
-    void evaluateKelvinChain( const double      dT,
-                              Properties        elasticModuli,
-                              Properties        retardationTimes,
-                              StateVarMatrix    stateVars,
-                              double&           uniaxialCompliance,
-                              Marmot::Vector6d& dStrain,
-                              const double      factor );
-    /**
-     * @brief Computes the time-dependent relaxation factors \f$\lambda\f$ and \f$\beta\f$ for a given Kelvin unit.
-     *
-     * This function evaluates the time parameters for each Kelvin chain.
-     * @param[in] dT the time increment.
-     * @param[in] tau the retardation time for a given Kelvin unit.
-     * @param[out] lambda time dependent factor for each Kelvin unit.
-     * @param[out] beta time dependemnt factor for each Kelvin unit.
-     */
+  void updateStateVarMatrix( const double                 dT,
+                             Properties                   elasticModuli,
+                             Properties                   retardationTimes,
+                             Eigen::Ref< StateVarMatrix > stateVars,
+                             const Marmot::Vector6d&      dStress,
+                             const Marmot::Matrix6d&      unitComplianceMatrix );
+  /**
+   * @brief Evaluates the viscoelastic response of the Kelvin chain over a time increment.
+   *
+   * For the given time increment \f$\Delta t_k\f$ this function updates the visco-elastic state variables according
+   *to the update rule: \f[\overline{J}^k=\sum_{\mu=1}^M\frac{1-\lambda^{\mu,k}}{E^\mu}\f]
+   *\f[\Delta\varepsilon^{'',k}_{ij} = \sum_{\mu=1}^M\left(1-\beta^{\mu,k}\right)\varepsilon^{ev,\kappa}_{ij}\f]
+   *
+   * @param[in] dT the time increment.
+   * @param[in] elasticModuli vector containing the elastic moduli of ech Kelvin unit in the Kelvin chain.
+   * @param[in] retardationTimes vector containing the retardation time for each Kelvin unit in the Kelvin chain.
+   * @param[in] stateVars the \f$[6\times \mu]\f$ matrix that contains the viscoelastic strain update for each unit of
+   *the Kelvin chain.
+   * @param[in,out] uniaxialCompliance number containing the \f$\sum^M_{\mu=1}\frac{\lambda^{\mu, k}}{E_\mu}\f$.
+   * @param[in,out] dStrain the viscoelastic update of the strain based on the state variables of the Kelvin chain.
+   * @param[in] factor the solidification factor (in non aging viscoelasticity set to 1).
+   */
 
-    void computeLambdaAndBeta( double dT, double tau, double& lambda, double& beta );
+  void evaluateKelvinChain( const double      dT,
+                            Properties        elasticModuli,
+                            Properties        retardationTimes,
+                            StateVarMatrix    stateVars,
+                            double&           uniaxialCompliance,
+                            Marmot::Vector6d& dStrain,
+                            const double      factor );
+  /**
+   * @brief Computes the time-dependent relaxation factors \f$\lambda\f$ and \f$\beta\f$ for a given Kelvin unit.
+   *
+   * This function evaluates the time parameters for each Kelvin chain.
+   * @param[in] dT the time increment.
+   * @param[in] tau the retardation time for a given Kelvin unit.
+   * @param[out] lambda time dependent factor for each Kelvin unit.
+   * @param[out] beta time dependemnt factor for each Kelvin unit.
+   */
 
-  } // namespace KelvinChain
-} // namespace Marmot::Materials
+  void computeLambdaAndBeta( double dT, double tau, double& lambda, double& beta );
+
+} // namespace Marmot::Materials::KelvinChain

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotKinematics.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotKinematics.h
@@ -28,52 +28,50 @@
 #include "Marmot/MarmotTypedefs.h"
 #include "Marmot/MarmotVoigt.h"
 
-namespace Marmot {
-  namespace ContinuumMechanics::Kinematics {
-    namespace Strain {
-      /**
-       * @brief Computes the Green-Lagrange strain tensor from the deformation gradient.
-       *
-       * @param F The deformation gradient tensor as a 3x3 matrix.
-       * @return The Green-Lagrange strain tensor represented as a 6D vector in Voigt notation.
-       */
-      Marmot::Vector6d GreenLagrange( const Eigen::Matrix3d& F );
-      /**
-       * @brief Computes the derivative of the Green-Lagrange strain tensor with respect to the deformation gradient.
-       *
-       * @param F The deformation gradient tensor as a 3x3 matrix.
-       * @return A \f$6 \times 3 \times 3\f$ tensor representing the derivative of the Green-Lagrange strain tensor.
-       */
-      Marmot::EigenTensors::Tensor633d dGreenLagrangedDeformationGradient( const Eigen::Matrix3d& F );
-    } // namespace Strain
+namespace Marmot::ContinuumMechanics::Kinematics {
+  namespace Strain {
+    /**
+     * @brief Computes the Green-Lagrange strain tensor from the deformation gradient.
+     *
+     * @param F The deformation gradient tensor as a 3x3 matrix.
+     * @return The Green-Lagrange strain tensor represented as a 6D vector in Voigt notation.
+     */
+    Marmot::Vector6d GreenLagrange( const Eigen::Matrix3d& F );
+    /**
+     * @brief Computes the derivative of the Green-Lagrange strain tensor with respect to the deformation gradient.
+     *
+     * @param F The deformation gradient tensor as a 3x3 matrix.
+     * @return A \f$6 \times 3 \times 3\f$ tensor representing the derivative of the Green-Lagrange strain tensor.
+     */
+    Marmot::EigenTensors::Tensor633d dGreenLagrangedDeformationGradient( const Eigen::Matrix3d& F );
+  } // namespace Strain
 
-    namespace VelocityGradient {
-      /**
-       * @brief A 4th-order tensor representing the derivative of the spin tensor \f$ \Omega \f$
-       *        with respect to the velocity gradient tensor.
-       */
-      extern const Eigen::TensorFixedSize< double, Eigen::Sizes< 3, 3, 3, 3 > > dOmega_dVelocityGradient;
+  namespace VelocityGradient {
+    /**
+     * @brief A 4th-order tensor representing the derivative of the spin tensor \f$ \Omega \f$
+     *        with respect to the velocity gradient tensor.
+     */
+    extern const Eigen::TensorFixedSize< double, Eigen::Sizes< 3, 3, 3, 3 > > dOmega_dVelocityGradient;
 
-      /** @brief Tensor representing the derivative of the stretching rate with respect to the velocity gradient.*/
-      extern const Eigen::TensorFixedSize< double, Eigen::Sizes< 6, 3, 3 > > dStretchingRate_dVelocityGradient;
-    } // namespace VelocityGradient
+    /** @brief Tensor representing the derivative of the stretching rate with respect to the velocity gradient.*/
+    extern const Eigen::TensorFixedSize< double, Eigen::Sizes< 6, 3, 3 > > dStretchingRate_dVelocityGradient;
+  } // namespace VelocityGradient
 
-    namespace DeformationGradient {
-      /**
-       * @brief Embeds a lower-dimensional square tensor into a 3x3 tensor.
-       *
-       * This function takes an \f$n \times n\f$ tensor (with \f$n=1,2,3\f$)
-       * and returns a 3x3 tensor:
-       * - For \f$n=1\f$: the scalar is placed in the (0,0) entry of a 3x3 identity matrix.
-       * - For \f$n=2\f$: the 2x2 tensor is placed in the top-left block of a 3x3 identity matrix.
-       * - For \f$n=3\f$: the tensor is returned unchanged.
-       *
-       * @tparam nDim Dimension of the input tensor (1, 2, or 3).
-       * @param tensor An \f$n \times n\f$ tensor represented as Eigen::Matrix<double,nDim,nDim>.
-       * @return A 3x3 tensor embedding the input according to the rules above.
-       */
-      template < int nDim >
-      Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, nDim, nDim > >& tensor );
-    } // namespace DeformationGradient
-  }   // namespace ContinuumMechanics::Kinematics
-} // namespace Marmot
+  namespace DeformationGradient {
+    /**
+     * @brief Embeds a lower-dimensional square tensor into a 3x3 tensor.
+     *
+     * This function takes an \f$n \times n\f$ tensor (with \f$n=1,2,3\f$)
+     * and returns a 3x3 tensor:
+     * - For \f$n=1\f$: the scalar is placed in the (0,0) entry of a 3x3 identity matrix.
+     * - For \f$n=2\f$: the 2x2 tensor is placed in the top-left block of a 3x3 identity matrix.
+     * - For \f$n=3\f$: the tensor is returned unchanged.
+     *
+     * @tparam nDim Dimension of the input tensor (1, 2, or 3).
+     * @param tensor An \f$n \times n\f$ tensor represented as Eigen::Matrix<double,nDim,nDim>.
+     * @return A 3x3 tensor embedding the input according to the rules above.
+     */
+    template < int nDim >
+    Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, nDim, nDim > >& tensor );
+  } // namespace DeformationGradient
+} // namespace Marmot::ContinuumMechanics::Kinematics

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotLocalization.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotLocalization.h
@@ -35,39 +35,37 @@
  * loses positive definiteness for some normal vector \f$\mathbf{n}\f$.
  */
 
-namespace Marmot {
-  namespace ContinuumMechanics::LocalizationAnalysis {
+namespace Marmot::ContinuumMechanics::LocalizationAnalysis {
 
-    /**
-     * @brief Computes the acoustic tensor for a given material tangent and normal vector.
-     * @param materialTangent  Fourth-order material tangent in Voigt notation.
-     * @param normalVector     Candidate band normal \f$\mathbf{n}\f$.
-     * @return Acoustic tensor \f$\mathbf{Q} = \mathbf{n} \cdot \mathbb{C} \cdot \mathbf{n}\f$.
-     */
-    Marmot::Matrix3d computeAcousticTensor( const Marmot::Matrix6d& materialTangent,
-                                            const Marmot::Vector3d& normalVector );
+  /**
+   * @brief Computes the acoustic tensor for a given material tangent and normal vector.
+   * @param materialTangent  Fourth-order material tangent in Voigt notation.
+   * @param normalVector     Candidate band normal \f$\mathbf{n}\f$.
+   * @return Acoustic tensor \f$\mathbf{Q} = \mathbf{n} \cdot \mathbb{C} \cdot \mathbf{n}\f$.
+   */
+  Marmot::Matrix3d computeAcousticTensor( const Marmot::Matrix6d& materialTangent,
+                                          const Marmot::Vector3d& normalVector );
 
-    /**
-     * @brief Checks whether the given acoustic tensor indicates localization.
-     * @param acousticTensor Acoustic tensor to test.
-     * @return @c true if \f$\det(\mathbf{Q}) \le 0\f$ (localization detected).
-     */
-    bool localizationChecker( const Marmot::Matrix3d& acousticTensor );
+  /**
+   * @brief Checks whether the given acoustic tensor indicates localization.
+   * @param acousticTensor Acoustic tensor to test.
+   * @return @c true if \f$\det(\mathbf{Q}) \le 0\f$ (localization detected).
+   */
+  bool localizationChecker( const Marmot::Matrix3d& acousticTensor );
 
-    /**
-     * @brief Constructs a unit normal vector from spherical angles.
-     * @param alpha Polar angle (rad).
-     * @param beta  Azimuthal angle (rad).
-     * @return Unit normal vector \f$\mathbf{n}\f$.
-     */
-    Marmot::Vector3d computeNormalVector( double alpha, double beta );
+  /**
+   * @brief Constructs a unit normal vector from spherical angles.
+   * @param alpha Polar angle (rad).
+   * @param beta  Azimuthal angle (rad).
+   * @return Unit normal vector \f$\mathbf{n}\f$.
+   */
+  Marmot::Vector3d computeNormalVector( double alpha, double beta );
 
-    /**
-     * @brief Computes the minimum determinant of the acoustic tensor over all band normals.
-     * @param materialTangent Fourth-order material tangent in Voigt notation.
-     * @return Minimum determinant of the acoustic tensor.
-     */
-    double minimumDeterminantAcousticTensor( const Marmot::Matrix6d& materialTangent );
+  /**
+   * @brief Computes the minimum determinant of the acoustic tensor over all band normals.
+   * @param materialTangent Fourth-order material tangent in Voigt notation.
+   * @return Minimum determinant of the acoustic tensor.
+   */
+  double minimumDeterminantAcousticTensor( const Marmot::Matrix6d& materialTangent );
 
-  } // namespace ContinuumMechanics::LocalizationAnalysis
-} // namespace Marmot
+} // namespace Marmot::ContinuumMechanics::LocalizationAnalysis

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElastic.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElastic.h
@@ -30,220 +30,226 @@
 #include <cmath>
 #include <vector>
 
-/**
- *
- * Derived abstract base class for elastic materials expressed purely in rate form.
- *
- * In general, the nominal stress rate tensor \f$ \sigRate \f$ can be written as a function of the nominal stress tensor
- * \f$ \sig \f$, the stretching rate tensor \f$ \epsRate \f$ and the time \f$ t \f$.
- *
- * \f[  \displaystyle \sigRate = f( \sig, \epsRate, t, ...) \f]
- *
- * In course of numerical time integration, this relation will be formulated incrementally as
- *
- * \f[  \displaystyle \Delta \sig = f ( \sig_n, \Delta\eps, \Delta t, t_n, ...) \f]
- *
- * with
- *
- * \f[  \displaystyle \Delta\eps =  \epsRate\, \Delta t \f]
- *
- * and the algorithmic tangent
- *
- * \f[ \displaystyle \frac{d \sig }{d \eps } =  \frac{d \Delta \sig }{d \Delta \eps } \f]
- *
- * This formulation is compatible with an Abaqus interface.
- */
-class MarmotMaterialHypoElastic {
+namespace Marmot {
 
-protected:
-  const double* materialProperties;  ///< Pointer to the array of material properties
-  const int     nMaterialProperties; ///< Number of material properties
-
-public:
-  const int materialNumber; ///< Integer identifier for this material instance
   /**
-   * @brief Constructs the material with a given set of material properties and an identifier.
-   * @param[in] matProperties_       Pointer to the array of material properties.
-   * @param[in] nMaterialProperties_ Number of entries in @p matProperties_.
-   * @param[in] materialNumber_      Integer identifying this material instance.
+   *
+   * Derived abstract base class for elastic materials expressed purely in rate form.
+   *
+   * In general, the nominal stress rate tensor \f$ \sigRate \f$ can be written as a function of the nominal stress
+   * tensor \f$ \sig \f$, the stretching rate tensor \f$ \epsRate \f$ and the time \f$ t \f$.
+   *
+   * \f[  \displaystyle \sigRate = f( \sig, \epsRate, t, ...) \f]
+   *
+   * In course of numerical time integration, this relation will be formulated incrementally as
+   *
+   * \f[  \displaystyle \Delta \sig = f ( \sig_n, \Delta\eps, \Delta t, t_n, ...) \f]
+   *
+   * with
+   *
+   * \f[  \displaystyle \Delta\eps =  \epsRate\, \Delta t \f]
+   *
+   * and the algorithmic tangent
+   *
+   * \f[ \displaystyle \frac{d \sig }{d \eps } =  \frac{d \Delta \sig }{d \Delta \eps } \f]
+   *
+   * This formulation is compatible with an Abaqus interface.
    */
-  MarmotMaterialHypoElastic( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
-    : materialProperties( matProperties_ ),
-      nMaterialProperties( nMaterialProperties_ ),
-      materialNumber( materialNumber_ )
-  {
-  }
+  class MarmotMaterialHypoElastic {
 
-  /// Default destructor
-  virtual ~MarmotMaterialHypoElastic() = default;
+  protected:
+    const double* materialProperties;  ///< Pointer to the array of material properties
+    const int     nMaterialProperties; ///< Number of material properties
 
-  /// Layout of the state variables
-  MarmotStateLayoutDynamic stateLayout;
-
-  /// Structure to hold the material state at a material point in 3D
-  struct state3D {
-    Marmot::Vector6d stress;               ///< Cauchy stress tensor in Voigt notation
-    double           elasticEnergyDensity; ///< Elastic strain energy density
-    double           dissipation;          ///< Dissipation
-    double*          stateVars;            ///< Pointer to array of state variables
+  public:
+    const int materialNumber; ///< Integer identifier for this material instance
     /**
-     * @brief Default constructor for state3D
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+     * @brief Constructs the material with a given set of material properties and an identifier.
+     * @param[in] matProperties_       Pointer to the array of material properties.
+     * @param[in] nMaterialProperties_ Number of entries in @p matProperties_.
+     * @param[in] materialNumber_      Integer identifying this material instance.
      */
-    state3D()
-      : stress( Marmot::Vector6d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+    MarmotMaterialHypoElastic( const double* matProperties_, int nMaterialProperties_, int materialNumber_ )
+      : materialProperties( matProperties_ ),
+        nMaterialProperties( nMaterialProperties_ ),
+        materialNumber( materialNumber_ )
     {
     }
+
+    /// Default destructor
+    virtual ~MarmotMaterialHypoElastic() = default;
+
+    /// Layout of the state variables
+    MarmotStateLayoutDynamic stateLayout;
+
+    /// Structure to hold the material state at a material point in 3D
+    struct state3D {
+      Marmot::Vector6d stress;               ///< Cauchy stress tensor in Voigt notation
+      double           elasticEnergyDensity; ///< Elastic strain energy density
+      double           dissipation;          ///< Dissipation
+      double*          stateVars;            ///< Pointer to array of state variables
+      /**
+       * @brief Default constructor for state3D
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      state3D()
+        : stress( Marmot::Vector6d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+      {
+      }
+      /**
+       * @brief Constructor for initializing state3D
+       * @param stress_ Cauchy stress tensor in Voigt notation
+       * @param elasticEnergyDensity_ Elastic strain energy density
+       * @param dissipation_ Dissipation
+       * @param stateVars_ Pointer to array of state variables
+       */
+      state3D( Marmot::Vector6d stress_, double elasticEnergyDensity_, double dissipation_, double* stateVars_ )
+        : stress( stress_ ),
+          elasticEnergyDensity( elasticEnergyDensity_ ),
+          dissipation( dissipation_ ),
+          stateVars( stateVars_ )
+      {
+      }
+    };
+
+    // Structure to hold the material state at a material point for 2D plane stress
+    /// @brief Structure holding the material state at a material point for 2D plane stress.
+    struct state2D {
+      Marmot::Vector3d stress;               ///< 2D Cauchy stress tensor in Voigt notation
+      double           elasticEnergyDensity; ///< Elastic strain energy density
+      double           dissipation;          ///< Dissipation
+      double*          stateVars;            ///< Pointer to array of state variables
+
+      state2D()
+        : stress( Marmot::Vector3d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+      {
+      }
+    };
+
+    // Structure to hold the material state at a material point for 1D uniaxial stress
+    /// @brief Structure holding the material state at a material point for 1D uniaxial stress.
+    struct state1D {
+      double  stress;               ///< 1D Cauchy stress
+      double  elasticEnergyDensity; ///< Elastic strain energy density
+      double  dissipation;          ///< Dissipation
+      double* stateVars;            ///< Pointer to array of state variables
+
+      state1D() : stress( 0.0 ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr ) {}
+    };
+
+    /// @brief Structure carrying (pseudo-)time information passed to the material routines.
+    struct timeInfo {
+      double time; ///< Current (pseudo-)time
+      double dT;   ///< (Pseudo-)time increment from the old (pseudo-)time to the current (pseudo-)time
+    };
+
+    /// Characteristic element length
+    double characteristicElementLength;
     /**
-     * @brief Constructor for initializing state3D
-     * @param stress_ Cauchy stress tensor in Voigt notation
-     * @param elasticEnergyDensity_ Elastic strain energy density
-     * @param dissipation_ Dissipation
-     * @param stateVars_ Pointer to array of state variables
+     * Set the characteristic element length at the considered quadrature point.
+     * It is needed for the regularization of materials with softening behavior based on the mesh-adjusted softening
+     * modulus.
+     *
+     * @param[in] length characteristic length; will be assigned to @ref characteristicElementLength
      */
-    state3D( Marmot::Vector6d stress_, double elasticEnergyDensity_, double dissipation_, double* stateVars_ )
-      : stress( stress_ ),
-        elasticEnergyDensity( elasticEnergyDensity_ ),
-        dissipation( dissipation_ ),
-        stateVars( stateVars_ )
+    void setCharacteristicElementLength( double length );
+
+    /**
+     * For a given linearized strain increment \f$\Delta\boldsymbol{\varepsilon}\f$ at the old and the current time,
+     * compute the Cauchy stress and the algorithmic tangent
+     * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$.
+     *
+     * @param[in,out]	state  A state3D instance carrying stress, strain energy, and state variables
+     * @param[in,out]	dStress_dStrain	Algorithmic tangent representing the derivative of the Cauchy stress tensor with
+     * respect to the linearized strain
+     * @param[in]	dStrain linearized strain increment
+     * @param[in]	timeInfo Structure carrying the current (pseudo-)time and the (pseudo-)time increment
+     */
+    virtual void computeStress( state3D&                state,
+                                Marmot::Matrix6d&       dStress_dStrain,
+                                const Marmot::Vector6d& dStrain,
+                                const timeInfo&         timeInfo ) const = 0;
+
+    /**
+     * Explicit version of @ref computeStress for use in explicit time integration schemes.
+     * The algorithmic tangent is not needed in explicit schemes and will therefore not be computed.
+     * @param[in,out] state  A state3D instance carrying stress, strain energy, and state variables
+     * @param[in]   dStrain linearized strain increment
+     * @param[in]   timeInfo Structure carrying time information
+     *
+     * @note The default implementation calls @ref computeStress and ignores the algorithmic tangent.
+     * @note Derived classes may override this method for efficiency reasons.
+     */
+    virtual void computeStressExplicit( state3D&                state,
+                                        const Marmot::Vector6d& dStrain,
+                                        const timeInfo&         timeInfo ) const
     {
+      Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
+      computeStress( state, dStress_dStrain, dStrain, timeInfo );
     }
-  };
 
-  // Structure to hold the material state at a material point for 2D plane stress
-  /// @brief Structure holding the material state at a material point for 2D plane stress.
-  struct state2D {
-    Marmot::Vector3d stress;               ///< 2D Cauchy stress tensor in Voigt notation
-    double           elasticEnergyDensity; ///< Elastic strain energy density
-    double           dissipation;          ///< Dissipation
-    double*          stateVars;            ///< Pointer to array of state variables
+    /**
+     * Plane stress implementation of @ref computeStress.
+     */
+    virtual void computePlaneStress( state2D&                stress2D,
+                                     Marmot::Matrix3d&       dStress_dStrain2D,
+                                     const Marmot::Vector3d& dStrain2D,
+                                     const timeInfo&         timeInfo ) const;
 
-    state2D()
-      : stress( Marmot::Vector3d::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr )
+    /**
+     * Uniaxial stress implementation of @ref computeStress.
+     */
+    virtual void computeUniaxialStress( state1D&        stress1D,
+                                        double&         dStress_dStrain1D,
+                                        const double    dStrain,
+                                        const timeInfo& timeInfo ) const;
+
+    /**
+     * @brief Get a view to the state variables.
+     * @param stateName Name of the state variable
+     * @param stateVars Pointer to the state variable array
+     * @return StatView to access the state variable
+     */
+    StateView getStateView( const std::string& stateName, double* stateVars ) const
     {
+      return stateLayout.getStateView( stateVars, stateName );
     }
-  };
 
-  // Structure to hold the material state at a material point for 1D uniaxial stress
-  /// @brief Structure holding the material state at a material point for 1D uniaxial stress.
-  struct state1D {
-    double  stress;               ///< 1D Cauchy stress
-    double  elasticEnergyDensity; ///< Elastic strain energy density
-    double  dissipation;          ///< Dissipation
-    double* stateVars;            ///< Pointer to array of state variables
+    /**
+     * @brief Get the total number of required state variables.
+     * @return Total number of required state variables
+     */
+    int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
 
-    state1D() : stress( 0.0 ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr ) {}
-  };
-
-  /// @brief Structure carrying (pseudo-)time information passed to the material routines.
-  struct timeInfo {
-    double time; ///< Current (pseudo-)time
-    double dT;   ///< (Pseudo-)time increment from the old (pseudo-)time to the current (pseudo-)time
-  };
-
-  /// Characteristic element length
-  double characteristicElementLength;
-  /**
-   * Set the characteristic element length at the considered quadrature point.
-   * It is needed for the regularization of materials with softening behavior based on the mesh-adjusted softening
-   * modulus.
-   *
-   * @param[in] length characteristic length; will be assigned to @ref characteristicElementLength
-   */
-  void setCharacteristicElementLength( double length );
-
-  /**
-   * For a given linearized strain increment \f$\Delta\boldsymbol{\varepsilon}\f$ at the old and the current time,
-   * compute the Cauchy stress and the algorithmic tangent
-   * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$.
-   *
-   * @param[in,out]	state  A state3D instance carrying stress, strain energy, and state variables
-   * @param[in,out]	dStress_dStrain	Algorithmic tangent representing the derivative of the Cauchy stress tensor with
-   * respect to the linearized strain
-   * @param[in]	dStrain linearized strain increment
-   * @param[in]	timeInfo Structure carrying the current (pseudo-)time and the (pseudo-)time increment
-   */
-  virtual void computeStress( state3D&                state,
-                              Marmot::Matrix6d&       dStress_dStrain,
-                              const Marmot::Vector6d& dStrain,
-                              const timeInfo&         timeInfo ) const = 0;
-
-  /**
-   * Explicit version of @ref computeStress for use in explicit time integration schemes.
-   * The algorithmic tangent is not needed in explicit schemes and will therefore not be computed.
-   * @param[in,out] state  A state3D instance carrying stress, strain energy, and state variables
-   * @param[in]   dStrain linearized strain increment
-   * @param[in]   timeInfo Structure carrying time information
-   *
-   * @note The default implementation calls @ref computeStress and ignores the algorithmic tangent.
-   * @note Derived classes may override this method for efficiency reasons.
-   */
-  virtual void computeStressExplicit( state3D& state, const Marmot::Vector6d& dStrain, const timeInfo& timeInfo ) const
-  {
-    Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
-    computeStress( state, dStress_dStrain, dStrain, timeInfo );
-  }
-
-  /**
-   * Plane stress implementation of @ref computeStress.
-   */
-  virtual void computePlaneStress( state2D&                stress2D,
-                                   Marmot::Matrix3d&       dStress_dStrain2D,
-                                   const Marmot::Vector3d& dStrain2D,
-                                   const timeInfo&         timeInfo ) const;
-
-  /**
-   * Uniaxial stress implementation of @ref computeStress.
-   */
-  virtual void computeUniaxialStress( state1D&        stress1D,
-                                      double&         dStress_dStrain1D,
-                                      const double    dStrain,
-                                      const timeInfo& timeInfo ) const;
-
-  /**
-   * @brief Get a view to the state variables.
-   * @param stateName Name of the state variable
-   * @param stateVars Pointer to the state variable array
-   * @return StatView to access the state variable
-   */
-  StateView getStateView( const std::string& stateName, double* stateVars ) const
-  {
-    return stateLayout.getStateView( stateVars, stateName );
-  }
-
-  /**
-   * @brief Get the total number of required state variables.
-   * @return Total number of required state variables
-   */
-  int getNumberOfRequiredStateVars() const { return stateLayout.totalSize(); }
-
-  /**
-   * @brief Initialize the state variables at a material point.
-   * @param stateVars Pointer to the state variable array
-   * @param nStateVars Number of state variables
-   *
-   * @note The default implementation initializes all state variables to zero.
-   */
-  virtual void initializeYourself( double* stateVars, int nStateVars )
-  {
-    for ( int i = 0; i < nStateVars; ++i ) {
-      stateVars[i] = 0.0;
+    /**
+     * @brief Initialize the state variables at a material point.
+     * @param stateVars Pointer to the state variable array
+     * @param nStateVars Number of state variables
+     *
+     * @note The default implementation initializes all state variables to zero.
+     */
+    virtual void initializeYourself( double* stateVars, int nStateVars )
+    {
+      for ( int i = 0; i < nStateVars; ++i ) {
+        stateVars[i] = 0.0;
+      }
     }
-  }
 
-  /**
-   * @brief Get the maximum wave speed of the material.
-   * @param[in] state Current material state
-   * @return Maximum wave speed
-   * @details The default implementation computes the 3D algorithmic tangent and returns
-   *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
-   */
-  virtual double getMaximumWaveSpeed( const state3D& state ) const;
+    /**
+     * @brief Get the maximum wave speed of the material.
+     * @param[in] state Current material state
+     * @return Maximum wave speed
+     * @details The default implementation computes the 3D algorithmic tangent and returns
+     *          `sqrt(max(C_ii) / rho)` with `C_ii` from the Voigt tangent diagonal entries.
+     */
+    virtual double getMaximumWaveSpeed( const state3D& state ) const;
 
-  /**
-   * @brief Get the mass density of the material.
-   * @param stateVars Pointer to the state variable array
-   * @return Mass density of the material
-   */
-  virtual double getDensity( const double* stateVars ) const = 0;
-};
+    /**
+     * @brief Get the mass density of the material.
+     * @param stateVars Pointer to the state variable array
+     * @return Mass density of the material
+     */
+    virtual double getDensity( const double* stateVars ) const = 0;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticAD.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticAD.h
@@ -26,58 +26,65 @@
 #pragma once
 #include "Marmot/MarmotMaterialHypoElastic.h"
 
-/**
- * @brief Derived class of MarmotMaterialHypoElastic providing automatic differentiation support
- *        for computing the algorithmic tangent via dual numbers.
- */
-class MarmotMaterialHypoElasticAD : public MarmotMaterialHypoElastic {
+namespace Marmot {
 
-public:
-  /// @brief Inherits the base-class constructor; see MarmotMaterialHypoElastic::MarmotMaterialHypoElastic().
-  using MarmotMaterialHypoElastic::MarmotMaterialHypoElastic;
-
-  /// @brief Structure holding the material state for 3D using dual numbers (for automatic differentiation).
-  struct state3DAD {
-    Marmot::Vector6dual stress;               ///< Cauchy stress tensor in Voigt notation
-    double              elasticEnergyDensity; ///< Elastic strain energy density
-    double              dissipation;          ///< Dissipation
-    double*             stateVars;            ///< Pointer to array of state variables
-    /**
-     * @brief Default constructor for initializing state3DAD
-     * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
-     */
-    state3DAD()
-      : stress( Marmot::Vector6dual::Zero() ), elasticEnergyDensity( 0.0 ), dissipation( 0.0 ), stateVars( nullptr ){};
-    /**
-     * @brief Constructor for initializing state3DAD
-     *@param state A state3D object containing the initial values for stress, energy density, dissipation, and state
-     *variables.
-     */
-    state3DAD( const state3D& state )
-      : stress( state.stress ),
-        elasticEnergyDensity( state.elasticEnergyDensity ),
-        dissipation( state.dissipation ),
-        stateVars( state.stateVars ){};
-  };
   /**
-   * @brief Compute the Cauchy stress tensor \f$\boldsymbol{\sigma}\f$ given an increment of the linearized strain
-   * tensor \f$\Delta\boldsymbol{\varepsilon}\f$.
-   *
-   * Dual numbers are used for both the Cauchy stress tensor and the linearized strain increment, such that the
-   * algorithmic tangent operator
-   * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$ can be obtained by means
-   * of automatic differentiation.
-   *
-   * @param[in,out] state  State carrying the dual Cauchy stress, strain energy, and state variables
-   * @param[in]             dStrain linearized strain increment
-   * @param[in]             timeInfo Old (pseudo-)time
+   * @brief Derived class of MarmotMaterialHypoElastic providing automatic differentiation support
+   *        for computing the algorithmic tangent via dual numbers.
    */
-  virtual void computeStressAD( state3DAD&                 state,
-                                const Marmot::Vector6dual& dStrain,
-                                const timeInfo&            timeInfo ) const = 0;
+  class MarmotMaterialHypoElasticAD : public MarmotMaterialHypoElastic {
 
-  virtual void computeStress( state3D&                state,
-                              Marmot::Matrix6d&       dStressDDStrain,
-                              const Marmot::Vector6d& dStrain,
-                              const timeInfo&         timeInfo ) const override;
-};
+  public:
+    /// @brief Inherits the base-class constructor; see MarmotMaterialHypoElastic::MarmotMaterialHypoElastic().
+    using MarmotMaterialHypoElastic::MarmotMaterialHypoElastic;
+
+    /// @brief Structure holding the material state for 3D using dual numbers (for automatic differentiation).
+    struct state3DAD {
+      Marmot::Vector6dual stress;               ///< Cauchy stress tensor in Voigt notation
+      double              elasticEnergyDensity; ///< Elastic strain energy density
+      double              dissipation;          ///< Dissipation
+      double*             stateVars;            ///< Pointer to array of state variables
+      /**
+       * @brief Default constructor for initializing state3DAD
+       * Initializes stress to zero, energy and dissipation to zero, and stateVars to nullptr.
+       */
+      state3DAD()
+        : stress( Marmot::Vector6dual::Zero() ),
+          elasticEnergyDensity( 0.0 ),
+          dissipation( 0.0 ),
+          stateVars( nullptr ){};
+      /**
+       * @brief Constructor for initializing state3DAD
+       *@param state A state3D object containing the initial values for stress, energy density, dissipation, and state
+       *variables.
+       */
+      state3DAD( const state3D& state )
+        : stress( state.stress ),
+          elasticEnergyDensity( state.elasticEnergyDensity ),
+          dissipation( state.dissipation ),
+          stateVars( state.stateVars ){};
+    };
+    /**
+     * @brief Compute the Cauchy stress tensor \f$\boldsymbol{\sigma}\f$ given an increment of the linearized strain
+     * tensor \f$\Delta\boldsymbol{\varepsilon}\f$.
+     *
+     * Dual numbers are used for both the Cauchy stress tensor and the linearized strain increment, such that the
+     * algorithmic tangent operator
+     * \f$\frac{\partial\boldsymbol{\sigma}^{(n+1)}}{\partial\boldsymbol{\varepsilon}^{(n+1)}}\f$ can be obtained by
+     * means of automatic differentiation.
+     *
+     * @param[in,out] state  State carrying the dual Cauchy stress, strain energy, and state variables
+     * @param[in]             dStrain linearized strain increment
+     * @param[in]             timeInfo Old (pseudo-)time
+     */
+    virtual void computeStressAD( state3DAD&                 state,
+                                  const Marmot::Vector6dual& dStrain,
+                                  const timeInfo&            timeInfo ) const = 0;
+
+    virtual void computeStress( state3D&                state,
+                                Marmot::Matrix6d&       dStressDDStrain,
+                                const Marmot::Vector6d& dStrain,
+                                const timeInfo&         timeInfo ) const override;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
@@ -42,8 +42,9 @@ namespace MarmotLibrary {
   class MarmotMaterialHypoElasticFactory {
   public:
     /// Function signature for material factory functions registered in the map.
-    using materialFactoryFunction = std::function<
-      MarmotMaterialHypoElastic*( const double* materialProperties, int nMaterialProperties, int materialNumber ) >;
+    using materialFactoryFunction = std::function< Marmot::MarmotMaterialHypoElastic*( const double* materialProperties,
+                                                                                       int nMaterialProperties,
+                                                                                       int materialNumber ) >;
 
     MarmotMaterialHypoElasticFactory() = delete;
 
@@ -55,10 +56,10 @@ namespace MarmotLibrary {
      * @param[in] materialNumber Unique identifier for the material instance.
      * @return Pointer to the created MarmotMaterial instance, or nullptr if creation failed.
      */
-    static MarmotMaterialHypoElastic* createMaterial( const std::string& materialName,
-                                                      const double*      materialProperties,
-                                                      int                nMaterialProperties,
-                                                      int                materialNumber );
+    static Marmot::MarmotMaterialHypoElastic* createMaterial( const std::string& materialName,
+                                                              const double*      materialProperties,
+                                                              int                nMaterialProperties,
+                                                              int                materialNumber );
 
     /**
      * @brief Register a material with its name and an auto-generated factory function.
@@ -72,8 +73,11 @@ namespace MarmotLibrary {
 
       assert( map.find( materialName ) == map.end() && "Material already registered!" );
 
-      map[materialName] = []( const double* materialProperties, int nMaterialProperties, int materialNumber )
-        -> MarmotMaterialHypoElastic* { return new T( materialProperties, nMaterialProperties, materialNumber ); };
+      map[materialName] = []( const double* materialProperties,
+                              int           nMaterialProperties,
+                              int           materialNumber ) -> Marmot::MarmotMaterialHypoElastic* {
+        return new T( materialProperties, nMaterialProperties, materialNumber );
+      };
       return true;
     }
 

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialHypoElasticFactory.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace MarmotLibrary {
+namespace Marmot::Registration {
 
   /**
    * @class MarmotMaterialHypoElasticFactory
@@ -85,4 +85,4 @@ namespace MarmotLibrary {
     using MaterialFactoryMap = std::unordered_map< std::string, materialFactoryFunction >;
     static MaterialFactoryMap& materialFactoryFunctionByName();
   };
-} // namespace MarmotLibrary
+} // namespace Marmot::Registration

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialPointSolverHypoElastic.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotMaterialPointSolverHypoElastic.h
@@ -28,270 +28,268 @@
 #include <iostream>
 #pragma once
 
-namespace Marmot {
-  namespace Solvers {
+namespace Marmot::Solvers {
+  /**
+   * @brief Solver for material point problems with hypo-elastic materials
+   * @details This class implements a solver for material point problems
+   * using hypo-elastic material models. It supports loading steps with
+   * controlled strain and stress components, adaptive time stepping,
+   * and history recording.
+   */
+  class MarmotMaterialPointSolverHypoElastic {
+
+  public:
     /**
-     * @brief Solver for material point problems with hypo-elastic materials
-     * @details This class implements a solver for material point problems
-     * using hypo-elastic material models. It supports loading steps with
-     * controlled strain and stress components, adaptive time stepping,
-     * and history recording.
+     * @struct Step
+     * @brief Struct to define a loading step
+     * @details Each step contains target strain and stress states,
+     * time information and time step control parameters.
      */
-    class MarmotMaterialPointSolverHypoElastic {
+    struct Step {
+      Marmot::Vector6d strainIncrementTarget; ///< Target strain increment for the step
+      Marmot::Vector6d stressIncrementTarget; ///< Target stress increment for the step
+      Eigen::Vector< bool, 6 >
+        isStrainComponentControlled;          ///< Flags to indicate which strain components are controlled
+      Eigen::Vector< bool, 6 >
+             isStressComponentControlled;     ///< Flags to indicate which stress components are controlled
+      double timeStart     = 0.0;             ///< Start time of the step
+      double timeEnd       = 1.0;             ///< End time of the step
+      double dTStart       = 0.1;             ///< Initial time step size
+      double dTMin         = 1e-6;            ///< Minimum time step size
+      double dTMax         = 0.5;             ///< Maximum time step size
+      int    maxIncrements = 100;             ///< Maximum number of increments in the step
 
-    public:
       /**
-       * @struct Step
-       * @brief Struct to define a loading step
-       * @details Each step contains target strain and stress states,
-       * time information and time step control parameters.
+       * @brief Check that for each component, either strain or stress is controlled
+       * @throws std::runtime_error if the condition is not met
        */
-      struct Step {
-        Marmot::Vector6d strainIncrementTarget; ///< Target strain increment for the step
-        Marmot::Vector6d stressIncrementTarget; ///< Target stress increment for the step
-        Eigen::Vector< bool, 6 >
-          isStrainComponentControlled;          ///< Flags to indicate which strain components are controlled
-        Eigen::Vector< bool, 6 >
-               isStressComponentControlled;     ///< Flags to indicate which stress components are controlled
-        double timeStart     = 0.0;             ///< Start time of the step
-        double timeEnd       = 1.0;             ///< End time of the step
-        double dTStart       = 0.1;             ///< Initial time step size
-        double dTMin         = 1e-6;            ///< Minimum time step size
-        double dTMax         = 0.5;             ///< Maximum time step size
-        int    maxIncrements = 100;             ///< Maximum number of increments in the step
-
-        /**
-         * @brief Check that for each component, either strain or stress is controlled
-         * @throws std::runtime_error if the condition is not met
-         */
-        void checkControl() const
-        {
-          for ( int i = 0; i < 6; i++ ) {
-            if ( isStrainComponentControlled[i] == isStressComponentControlled[i] ) {
-              throw std::runtime_error(
-                "exactly one of strain or stress component must be controlled for each component." );
-            }
+      void checkControl() const
+      {
+        for ( int i = 0; i < 6; i++ ) {
+          if ( isStrainComponentControlled[i] == isStressComponentControlled[i] ) {
+            throw std::runtime_error(
+              "exactly one of strain or stress component must be controlled for each component." );
           }
         }
-      };
-      /**
-       * @struct Increment
-       * @brief Struct to define a loading increment
-       * @details Each increment contains strain and stress increments,
-       * control flags, time information, and iteration limits.
-       */
-      struct Increment {
-        Marmot::Vector6d strainIncrement;   ///< Strain increment for the increment
-        Marmot::Vector6d stressIncrement;   ///< Stress increment for the increment
-        Eigen::Vector< bool, 6 >
-          isStrainComponentControlled;      ///< Flags to indicate which strain components are controlled
-        Eigen::Vector< bool, 6 >
-               isStressComponentControlled; ///< Flags to indicate which stress components are controlled
-        double timeOld;                     ///< Old time at the beginning of the increment
-        double dT;                          ///< Time step size for the increment
-      };
-      /**
-       * @struct HistoryEntry
-       * @brief Struct to record the history of the simulation
-       * @details Each entry contains time, stress, strain, and state variables.
-       */
-      struct HistoryEntry {
-        double           time;           ///< Time at the history entry
-        Marmot::Vector6d stress;         ///< Stress at the history entry
-        Marmot::Vector6d strain;         ///< Strain at the history entry
-        Marmot::Matrix6d dStressdStrain; ///< Material tangent at the history entry
-        Eigen::VectorXd  stateVars;      ///< State variables at the history entry
-
-        /**
-         * @brief Print this history entry to `stdout`.
-         */
-        void print() const
-        {
-          std::cout.precision( 6 );
-          std::cout << std::scientific << "Time: " << time << std::endl;
-          std::cout << "  Stress:     " << stress.transpose() << std::endl;
-          std::cout << "  Strain:     " << strain.transpose() << std::endl;
-          std::cout << "  dStress_dStrain:\n" << dStressdStrain.transpose() << std::endl;
-          std::cout << "  State Vars: " << stateVars.transpose() << std::endl;
-        }
-      };
-
-      /**
-       * @struct SolverOptions
-       * @brief Struct to define solver options
-       * @details Contains parameters for controlling the solver's behavior.
-       */
-      struct SolverOptions {
-        int    maxIterations       = 25;    ///< Maximum number of iterations per increment
-        double residualTolerance   = 1e-10; ///< Convergence tolerance
-        double correctionTolerance = 1e-10; ///< Correction tolerance
-      };
-
-      /**
-       * @brief Constructor for the MarmotMaterialPointSolverHypoElastic class
-       * @param materialName Name of the hypo-elastic material model
-       * @param materialProperties Array of material properties
-       * @param nMaterialProperties Number of material properties
-       * @param options Solver options controlling iteration limits and tolerances
-       */
-      MarmotMaterialPointSolverHypoElastic( std::string&         materialName,
-                                            double*              materialProperties,
-                                            int                  nMaterialProperties,
-                                            const SolverOptions& options );
-
-      /**
-       * @brief Add a loading step to the solver
-       * @param step The Step to be added
-       */
-      void addStep( const Step& step );
-
-      /**
-       * @brief Get the list of added loading steps
-       * @return A vector of Step containing the added steps
-       */
-      std::vector< Step > getSteps() const { return steps; }
-
-      /**
-       * @brief Clear all added loading steps
-       */
-      void clearSteps() { steps.clear(); }
-
-      /**
-       * @brief Set the initial state of the material model
-       * @param initialStress The initial stress in Voigt notation
-       * @param initialStateVars The initial state variables
-       */
-      void setInitialState( const Marmot::Vector6d& initialStress, const Eigen::VectorXd& initialStateVars );
-
-      /**
-       * @brief Get the number of state variables in the material model
-       * @return The number of state variables
-       */
-      int getNumberOfStateVariables() const { return nStateVars; }
-
-      /**
-       * @brief Reset the solver to the initial state
-       * @details This function resets the initial stress
-       * and state variables of the material model.
-       */
-      void resetToInitialState();
-
-      /**
-       * @brief Solve the material point problem for all added steps
-       */
-      void solve();
-
-      /**
-       * @brief Get the recorded history of the simulation
-       * @return A vector of HistoryEntry containing the recorded history
-       */
-      std::vector< HistoryEntry > getHistory() const { return history; }
-
-      /**
-       * @brief Clear the recorded history
-       */
-      void clearHistory() { history.clear(); }
-
-      /**
-       * @brief Print the recorded history to the console
-       */
-      void printHistory();
-
-      /**
-       * @brief Export the recorded history to a CSV file
-       * @param filename The name of the CSV file to export to
-       */
-      void exportHistoryToCSV( const std::string& filename );
-
-    private:
-      /**
-       * @brief Solve a single loading step
-       * @param step The Step to be solved
-       *
-       * @details This function iterates over the increments
-       * defined in the step, calling solveIncrement for each increment.
-       * It manages time stepping and ensures that the entire step
-       * is covered.
-       */
-      void solveStep( const Step& step );
-
-      /**
-       * @brief Solve a single increment within a loading step
-       * @param increment The Increment to be solved
-       * @throws std::runtime_error if the solver does not converge
-       *
-       * @details This function implements a Newton-Raphson iterative
-       * solver to compute the stress and strain state for the given increment.
-       * It updates the material state variables and records the history
-       * after convergence.
-       *
-       */
-      void solveIncrement( const Increment& increment );
-
-      /**
-       * @brief Compute the residual for the current increment
-       * @param stressIncrement The computed stress increment
-       * @param target The target (mixed) stress/strain increment
-       * @param increment The Increment containing control information
-       * @return The computed residual vector
-       *
-       * @details This function calculates the residual vector
-       * based on the difference between the computed stress increment
-       * and the target increment, taking into account which components
-       * are controlled by strain or stress.
-       */
-      Marmot::Vector6d computeResidual( const Marmot::Vector6d& stressIncrement,
-                                        const Marmot::Vector6d& target,
-                                        const Increment&        increment );
-
-      /**
-       * @brief Modify the material tangent matrix based on control type
-       * @param tangent The material tangent matrix to be modified
-       * @param increment The Increment containing control information
-       *
-       * @details This function adjusts the tangent matrix to account for
-       * the components that are controlled by strain or stress, ensuring
-       * that the solver correctly handles mixed control scenarios.
-       * This is done by zeroing out rows corresponding to strain-controlled
-       * components and setting their diagonal entries to one.
-       */
-      void modifyTangent( Eigen::Matrix< double, 6, 6 >& tangent, const Increment& increment );
-
-      /// @brief The hypo-elastic material model
-      std::unique_ptr< MarmotMaterialHypoElastic > material;
-
-      /// @brief Number of state variables in the material model
-      int nStateVars;
-
-      /// @brief Current state variables
-      Eigen::VectorXd stateVars;
-
-      /// @brief Initial state variables
-      Eigen::VectorXd _initialStateVars;
-
-      /// @brief Temporary state variables for computations
-      Eigen::VectorXd stateVarsTemp;
-
-      /// @brief The stress in Voigt notation
-      Marmot::Vector6d stress = Marmot::Vector6d::Zero();
-
-      /// @brief The initial stress in Voigt notation
-      Marmot::Vector6d _initialStress = Marmot::Vector6d::Zero();
-
-      /// @brief The strain in Voigt notation
-      Marmot::Vector6d strain = Marmot::Vector6d::Zero();
-
-      /// @brief The material tangent matrix in Voigt notation
-      Marmot::Matrix6d dStressDStrain = Marmot::Matrix6d::Zero();
-
-      /// @brief List of loading steps
-      std::vector< Step > steps;
-
-      /// @brief History of the simulation
-      std::vector< HistoryEntry > history;
-
-      /// @brief Solver options
-      const SolverOptions options;
+      }
     };
-  } // namespace Solvers
-} // namespace Marmot
+    /**
+     * @struct Increment
+     * @brief Struct to define a loading increment
+     * @details Each increment contains strain and stress increments,
+     * control flags, time information, and iteration limits.
+     */
+    struct Increment {
+      Marmot::Vector6d strainIncrement;   ///< Strain increment for the increment
+      Marmot::Vector6d stressIncrement;   ///< Stress increment for the increment
+      Eigen::Vector< bool, 6 >
+        isStrainComponentControlled;      ///< Flags to indicate which strain components are controlled
+      Eigen::Vector< bool, 6 >
+             isStressComponentControlled; ///< Flags to indicate which stress components are controlled
+      double timeOld;                     ///< Old time at the beginning of the increment
+      double dT;                          ///< Time step size for the increment
+    };
+    /**
+     * @struct HistoryEntry
+     * @brief Struct to record the history of the simulation
+     * @details Each entry contains time, stress, strain, and state variables.
+     */
+    struct HistoryEntry {
+      double           time;           ///< Time at the history entry
+      Marmot::Vector6d stress;         ///< Stress at the history entry
+      Marmot::Vector6d strain;         ///< Strain at the history entry
+      Marmot::Matrix6d dStressdStrain; ///< Material tangent at the history entry
+      Eigen::VectorXd  stateVars;      ///< State variables at the history entry
+
+      /**
+       * @brief Print this history entry to `stdout`.
+       */
+      void print() const
+      {
+        std::cout.precision( 6 );
+        std::cout << std::scientific << "Time: " << time << std::endl;
+        std::cout << "  Stress:     " << stress.transpose() << std::endl;
+        std::cout << "  Strain:     " << strain.transpose() << std::endl;
+        std::cout << "  dStress_dStrain:\n" << dStressdStrain.transpose() << std::endl;
+        std::cout << "  State Vars: " << stateVars.transpose() << std::endl;
+      }
+    };
+
+    /**
+     * @struct SolverOptions
+     * @brief Struct to define solver options
+     * @details Contains parameters for controlling the solver's behavior.
+     */
+    struct SolverOptions {
+      int    maxIterations       = 25;    ///< Maximum number of iterations per increment
+      double residualTolerance   = 1e-10; ///< Convergence tolerance
+      double correctionTolerance = 1e-10; ///< Correction tolerance
+    };
+
+    /**
+     * @brief Constructor for the MarmotMaterialPointSolverHypoElastic class
+     * @param materialName Name of the hypo-elastic material model
+     * @param materialProperties Array of material properties
+     * @param nMaterialProperties Number of material properties
+     * @param options Solver options controlling iteration limits and tolerances
+     */
+    MarmotMaterialPointSolverHypoElastic( std::string&         materialName,
+                                          double*              materialProperties,
+                                          int                  nMaterialProperties,
+                                          const SolverOptions& options );
+
+    /**
+     * @brief Add a loading step to the solver
+     * @param step The Step to be added
+     */
+    void addStep( const Step& step );
+
+    /**
+     * @brief Get the list of added loading steps
+     * @return A vector of Step containing the added steps
+     */
+    std::vector< Step > getSteps() const { return steps; }
+
+    /**
+     * @brief Clear all added loading steps
+     */
+    void clearSteps() { steps.clear(); }
+
+    /**
+     * @brief Set the initial state of the material model
+     * @param initialStress The initial stress in Voigt notation
+     * @param initialStateVars The initial state variables
+     */
+    void setInitialState( const Marmot::Vector6d& initialStress, const Eigen::VectorXd& initialStateVars );
+
+    /**
+     * @brief Get the number of state variables in the material model
+     * @return The number of state variables
+     */
+    int getNumberOfStateVariables() const { return nStateVars; }
+
+    /**
+     * @brief Reset the solver to the initial state
+     * @details This function resets the initial stress
+     * and state variables of the material model.
+     */
+    void resetToInitialState();
+
+    /**
+     * @brief Solve the material point problem for all added steps
+     */
+    void solve();
+
+    /**
+     * @brief Get the recorded history of the simulation
+     * @return A vector of HistoryEntry containing the recorded history
+     */
+    std::vector< HistoryEntry > getHistory() const { return history; }
+
+    /**
+     * @brief Clear the recorded history
+     */
+    void clearHistory() { history.clear(); }
+
+    /**
+     * @brief Print the recorded history to the console
+     */
+    void printHistory();
+
+    /**
+     * @brief Export the recorded history to a CSV file
+     * @param filename The name of the CSV file to export to
+     */
+    void exportHistoryToCSV( const std::string& filename );
+
+  private:
+    /**
+     * @brief Solve a single loading step
+     * @param step The Step to be solved
+     *
+     * @details This function iterates over the increments
+     * defined in the step, calling solveIncrement for each increment.
+     * It manages time stepping and ensures that the entire step
+     * is covered.
+     */
+    void solveStep( const Step& step );
+
+    /**
+     * @brief Solve a single increment within a loading step
+     * @param increment The Increment to be solved
+     * @throws std::runtime_error if the solver does not converge
+     *
+     * @details This function implements a Newton-Raphson iterative
+     * solver to compute the stress and strain state for the given increment.
+     * It updates the material state variables and records the history
+     * after convergence.
+     *
+     */
+    void solveIncrement( const Increment& increment );
+
+    /**
+     * @brief Compute the residual for the current increment
+     * @param stressIncrement The computed stress increment
+     * @param target The target (mixed) stress/strain increment
+     * @param increment The Increment containing control information
+     * @return The computed residual vector
+     *
+     * @details This function calculates the residual vector
+     * based on the difference between the computed stress increment
+     * and the target increment, taking into account which components
+     * are controlled by strain or stress.
+     */
+    Marmot::Vector6d computeResidual( const Marmot::Vector6d& stressIncrement,
+                                      const Marmot::Vector6d& target,
+                                      const Increment&        increment );
+
+    /**
+     * @brief Modify the material tangent matrix based on control type
+     * @param tangent The material tangent matrix to be modified
+     * @param increment The Increment containing control information
+     *
+     * @details This function adjusts the tangent matrix to account for
+     * the components that are controlled by strain or stress, ensuring
+     * that the solver correctly handles mixed control scenarios.
+     * This is done by zeroing out rows corresponding to strain-controlled
+     * components and setting their diagonal entries to one.
+     */
+    void modifyTangent( Eigen::Matrix< double, 6, 6 >& tangent, const Increment& increment );
+
+    /// @brief The hypo-elastic material model
+    std::unique_ptr< MarmotMaterialHypoElastic > material;
+
+    /// @brief Number of state variables in the material model
+    int nStateVars;
+
+    /// @brief Current state variables
+    Eigen::VectorXd stateVars;
+
+    /// @brief Initial state variables
+    Eigen::VectorXd _initialStateVars;
+
+    /// @brief Temporary state variables for computations
+    Eigen::VectorXd stateVarsTemp;
+
+    /// @brief The stress in Voigt notation
+    Marmot::Vector6d stress = Marmot::Vector6d::Zero();
+
+    /// @brief The initial stress in Voigt notation
+    Marmot::Vector6d _initialStress = Marmot::Vector6d::Zero();
+
+    /// @brief The strain in Voigt notation
+    Marmot::Vector6d strain = Marmot::Vector6d::Zero();
+
+    /// @brief The material tangent matrix in Voigt notation
+    Marmot::Matrix6d dStressDStrain = Marmot::Matrix6d::Zero();
+
+    /// @brief List of loading steps
+    std::vector< Step > steps;
+
+    /// @brief History of the simulation
+    std::vector< HistoryEntry > history;
+
+    /// @brief Solver options
+    const SolverOptions options;
+  };
+} // namespace Marmot::Solvers

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotPronySeries.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotPronySeries.h
@@ -26,137 +26,133 @@
 #pragma once
 #include "Marmot/MarmotTypedefs.h"
 
-namespace Marmot::ContinuumMechanics::Viscoelasticity {
+namespace Marmot::ContinuumMechanics::Viscoelasticity::PronySeries {
+  using namespace Eigen;
 
-  namespace PronySeries {
-    using namespace Marmot;
-    using namespace Eigen;
+  /**
+   * @brief Material properties for a generalized Maxwell (Prony series) model.
+   *
+   * This structure stores the parameters required for evaluating the viscoelastic
+   * stress response of a material represented by a Prony series expansion.
+   */
 
+  struct Properties {
     /**
-     * @brief Material properties for a generalized Maxwell (Prony series) model.
+     * @brief Number of Prony series terms.
      *
-     * This structure stores the parameters required for evaluating the viscoelastic
-     * stress response of a material represented by a Prony series expansion.
+     * Corresponds to the number of Maxwell branches in the generalized Maxwell model.
      */
 
-    struct Properties {
-      /**
-       * @brief Number of Prony series terms.
-       *
-       * Corresponds to the number of Maxwell branches in the generalized Maxwell model.
-       */
-
-      size_t nPronyTerms;
-      /**
-       * @brief Ultimate (equilibrium) stiffness matrix.
-       *
-       * Represents the stiffness contribution that persists at long times
-       * (\f$t \to \infty\f$), outside the viscoelastic relaxation terms.
-       */
-
-      Matrix6d ultimateStiffnessMatrix;
-      /**
-       * @brief Stiffness matrices of each Prony series term.
-       *
-       * Stored as a block matrix of size \f$6 \times (6 \cdot nPronyTerms)\f$,
-       * with each \f$6\times 6\f$ block corresponding to the stiffness matrix
-       * of one Maxwell branch.
-       */
-
-      Matrix< double, 6, -1 > pronyStiffnesses;
-      /**
-       * @brief Relaxation times of each Prony series term.
-       *
-       * Stored as a block matrix of size \f$6 \times (6 \cdot nPronyTerms)\f$,
-       * with each \f$6\times 6\f$ block containing the relaxation times
-       * associated with one Maxwell branch.
-       */
-
-      Matrix< double, 6, -1 > pronyRelaxationTimes;
-    };
+    size_t nPronyTerms;
     /**
-     * @typedef StateVarMatrix
-     * @brief Matrix of viscoelastic state variables.
+     * @brief Ultimate (equilibrium) stiffness matrix.
      *
-     * Dynamic-size matrix of shape \f$[6 \times n]\f$, where each
-     * \f$6\times 1\f$ block corresponds to the internal state variables
-     * of a Maxwell branch in the Prony series.
+     * Represents the stiffness contribution that persists at long times
+     * (\f$t \to \infty\f$), outside the viscoelastic relaxation terms.
      */
 
-    typedef Eigen::Matrix< double, 6, Eigen::Dynamic > StateVarMatrix;
+    Matrix6d ultimateStiffnessMatrix;
     /**
-     * @typedef mapStateVarMatrix
-     * @brief Mapped view of a state variable matrix.
+     * @brief Stiffness matrices of each Prony series term.
      *
-     * Provides an Eigen::Map wrapper around a contiguous block of memory
-     * that stores state variables in the same layout as StateVarMatrix,
-     * avoiding copies.
+     * Stored as a block matrix of size \f$6 \times (6 \cdot nPronyTerms)\f$,
+     * with each \f$6\times 6\f$ block corresponding to the stiffness matrix
+     * of one Maxwell branch.
      */
 
-    typedef Eigen::Map< StateVarMatrix > mapStateVarMatrix;
-
+    Matrix< double, 6, -1 > pronyStiffnesses;
     /**
-     * @brief Evaluate the Prony series viscoelastic response.
+     * @brief Relaxation times of each Prony series term.
      *
-     * Computes the stress and tangent stiffness matrix contributions of a
-     * generalized Maxwell (Prony series) viscoelastic material, and optionally
-     * updates the internal state variables.
-     *
-     * In what follows we use indicial notation without the Einstein summation over repeated indices except explicitly
-     * stated. The stress is updated as \f[ \sigma^{k+1}_{ij} =\; \sum_{k,l}C^\infty_{ijkl} \Delta \varepsilon_{kl}
-     *          \;+\; \sum_{\mu=1}^{M} \left[
-     *              \sum_{k,l}\eta^\mu_{ijkl}\left(1 - e^{-\Delta t /
-     * \tau^{\mu}_{ij}}\right)\frac{\Delta\varepsilon_{kl}}{\Delta t}
-     *              \;-\; \sigma^{ve,\mu}_{ij}\left(1 - e^{-\Delta t/\tau^\mu_{ij}}\right)
-     *          \right],
-     * \f]
-     * where \f$C^\infty_{ijkl}\f$ is the ultimate stiffness, \f$\tau^\mu_{ij}\f$ the relaxation
-     * times for each strain component, \f$\eta^\mu_{ijkl} = \tau^\mu_{ij} C^\mu_{ijkl}\f$ the effective viscosities,
-     * and \f$\sigma^{ve,k}_{kl}\f$ the internal state variables.
-     *
-     * @param[in] props Prony series material properties (relaxation times,
-     *                  stiffnesses, number of terms, and ultimate stiffness).
-     * @param[in,out] stress 6-component stress vector to be updated.
-     * @param[in,out] stiffness 6×6 tangent stiffness matrix to be updated.
-     * @param[in,out] stateVars State variable matrix of size [6×(6·nPronyTerms)],
-     *                          storing internal viscoelastic strain-like variables.
-     * @param[in] dStrain Incremental strain vector (6-components).
-     * @param[in] dT Time increment.
-     * @param[in] updateStateVars If true, update the state variables for the next step.
+     * Stored as a block matrix of size \f$6 \times (6 \cdot nPronyTerms)\f$,
+     * with each \f$6\times 6\f$ block containing the relaxation times
+     * associated with one Maxwell branch.
      */
 
-    void evaluatePronySeries( const Properties&               props,
-                              Vector6d&                       stress,
-                              Matrix6d&                       stiffness,
-                              Eigen::Ref< mapStateVarMatrix > stateVars,
-                              const Vector6d&                 dStrain,
-                              const double                    dT,
-                              const bool                      updateStateVars = false );
+    Matrix< double, 6, -1 > pronyRelaxationTimes;
+  };
+  /**
+   * @typedef StateVarMatrix
+   * @brief Matrix of viscoelastic state variables.
+   *
+   * Dynamic-size matrix of shape \f$[6 \times n]\f$, where each
+   * \f$6\times 1\f$ block corresponds to the internal state variables
+   * of a Maxwell branch in the Prony series.
+   */
 
-    /**
-     * @brief Update the Prony series state variables.
-     *
-     * Propagates the internal viscoelastic state variables
-     *
-     * In what follows we don't use the Einstein summation over repeated indices, the products are to be taken as
-     * hadamard products except otherwise stated. \f$\sigma^{ve,\mu,k}_{kl}\f$ from time step \f$t^k\f$ to \f$t^{k+1}\f$
-     * according to \f[ \sigma^{ve,\mu,k+1}_{kl} = e^{-\Delta t / \tau^\mu_{ij}}\, \sigma^{ve,\mu,k}_{kl}
-     *             + \sum_{k,l}\left( \frac{\eta^\mu_{ijkl}}{\Delta t}(1 - e^{-\Delta t / \tau^\mu_{ij}})
-     * \right)\Delta\varepsilon_{kl}, \f] where \f$\tau^\mu_{ij}\f$ are the relaxation times and \f$\eta^\mu_{ij} =
-     * \tau^\mu_{ij} C^\mu_{ijkl}\f$.
-     *
-     * @param[in] props Prony series material properties (relaxation times,
-     *                  stiffnesses, and number of terms).
-     * @param[in,out] stateVars State variable matrix of size [6×(6·nPronyTerms)],
-     *                          storing internal viscoelastic strain-like variables.
-     * @param[in] dStrain Incremental strain vector (6-components).
-     * @param[in] dT Time increment.
-     */
+  typedef Eigen::Matrix< double, 6, Eigen::Dynamic > StateVarMatrix;
+  /**
+   * @typedef mapStateVarMatrix
+   * @brief Mapped view of a state variable matrix.
+   *
+   * Provides an Eigen::Map wrapper around a contiguous block of memory
+   * that stores state variables in the same layout as StateVarMatrix,
+   * avoiding copies.
+   */
 
-    void updateStateVars( const Properties&               props,
-                          Eigen::Ref< mapStateVarMatrix > stateVars,
-                          const Vector6d&                 dStrain,
-                          const double                    dT );
+  typedef Eigen::Map< StateVarMatrix > mapStateVarMatrix;
 
-  } // namespace PronySeries
-} // namespace Marmot::ContinuumMechanics::Viscoelasticity
+  /**
+   * @brief Evaluate the Prony series viscoelastic response.
+   *
+   * Computes the stress and tangent stiffness matrix contributions of a
+   * generalized Maxwell (Prony series) viscoelastic material, and optionally
+   * updates the internal state variables.
+   *
+   * In what follows we use indicial notation without the Einstein summation over repeated indices except explicitly
+   * stated. The stress is updated as \f[ \sigma^{k+1}_{ij} =\; \sum_{k,l}C^\infty_{ijkl} \Delta \varepsilon_{kl}
+   *          \;+\; \sum_{\mu=1}^{M} \left[
+   *              \sum_{k,l}\eta^\mu_{ijkl}\left(1 - e^{-\Delta t /
+   * \tau^{\mu}_{ij}}\right)\frac{\Delta\varepsilon_{kl}}{\Delta t}
+   *              \;-\; \sigma^{ve,\mu}_{ij}\left(1 - e^{-\Delta t/\tau^\mu_{ij}}\right)
+   *          \right],
+   * \f]
+   * where \f$C^\infty_{ijkl}\f$ is the ultimate stiffness, \f$\tau^\mu_{ij}\f$ the relaxation
+   * times for each strain component, \f$\eta^\mu_{ijkl} = \tau^\mu_{ij} C^\mu_{ijkl}\f$ the effective viscosities,
+   * and \f$\sigma^{ve,k}_{kl}\f$ the internal state variables.
+   *
+   * @param[in] props Prony series material properties (relaxation times,
+   *                  stiffnesses, number of terms, and ultimate stiffness).
+   * @param[in,out] stress 6-component stress vector to be updated.
+   * @param[in,out] stiffness 6×6 tangent stiffness matrix to be updated.
+   * @param[in,out] stateVars State variable matrix of size [6×(6·nPronyTerms)],
+   *                          storing internal viscoelastic strain-like variables.
+   * @param[in] dStrain Incremental strain vector (6-components).
+   * @param[in] dT Time increment.
+   * @param[in] updateStateVars If true, update the state variables for the next step.
+   */
+
+  void evaluatePronySeries( const Properties&               props,
+                            Vector6d&                       stress,
+                            Matrix6d&                       stiffness,
+                            Eigen::Ref< mapStateVarMatrix > stateVars,
+                            const Vector6d&                 dStrain,
+                            const double                    dT,
+                            const bool                      updateStateVars = false );
+
+  /**
+   * @brief Update the Prony series state variables.
+   *
+   * Propagates the internal viscoelastic state variables
+   *
+   * In what follows we don't use the Einstein summation over repeated indices, the products are to be taken as
+   * hadamard products except otherwise stated. \f$\sigma^{ve,\mu,k}_{kl}\f$ from time step \f$t^k\f$ to \f$t^{k+1}\f$
+   * according to \f[ \sigma^{ve,\mu,k+1}_{kl} = e^{-\Delta t / \tau^\mu_{ij}}\, \sigma^{ve,\mu,k}_{kl}
+   *             + \sum_{k,l}\left( \frac{\eta^\mu_{ijkl}}{\Delta t}(1 - e^{-\Delta t / \tau^\mu_{ij}})
+   * \right)\Delta\varepsilon_{kl}, \f] where \f$\tau^\mu_{ij}\f$ are the relaxation times and \f$\eta^\mu_{ij} =
+   * \tau^\mu_{ij} C^\mu_{ijkl}\f$.
+   *
+   * @param[in] props Prony series material properties (relaxation times,
+   *                  stiffnesses, and number of terms).
+   * @param[in,out] stateVars State variable matrix of size [6×(6·nPronyTerms)],
+   *                          storing internal viscoelastic strain-like variables.
+   * @param[in] dStrain Incremental strain vector (6-components).
+   * @param[in] dT Time increment.
+   */
+
+  void updateStateVars( const Properties&               props,
+                        Eigen::Ref< mapStateVarMatrix > stateVars,
+                        const Vector6d&                 dStrain,
+                        const double                    dT );
+
+} // namespace Marmot::ContinuumMechanics::Viscoelasticity::PronySeries

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotStateVarVectorManager.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotStateVarVectorManager.h
@@ -30,66 +30,70 @@
 #include <unordered_map>
 #include <vector>
 
-/// @brief A convenience auxiliary class for managing multiple statevars with arbitrary length in a single consecutive
-/// double array
-class MarmotStateVarVectorManager {
+namespace Marmot {
 
-public:
-  /// get a StateView for a statevar entry
-  inline StateView getStateView( const std::string& name ) const
-  {
-    auto entry = theLayout.entries.at( name );
-    return { theStateVars + entry.index, entry.length };
-  }
+  /// @brief A convenience auxiliary class for managing multiple statevars with arbitrary length in a single consecutive
+  /// double array
+  class MarmotStateVarVectorManager {
 
-  /// get the reference to the first array element of an entry in the statevar vector
-  inline double& find( const std::string& name ) const { return theStateVars[theLayout.entries.at( name ).index]; }
-
-  /// check if the entry with name is managed
-  inline bool contains( const std::string& name ) const { return theLayout.entries.count( name ); }
-
-protected:
-  /// An entry in the statevar vector consists of the name and a certain length
-  struct StateVarEntryDefinition {
-    std::string name;   ///< Unique name identifying the state variable entry
-    int         length; ///< Number of consecutive doubles occupied by this entry
-  };
-
-  /// The location in the statevar vector consists of the index and its certain length
-  struct StateVarEntryLocation {
-    int index;  ///< Zero-based offset into the statevar array where the entry begins
-    int length; ///< Number of consecutive doubles occupied by this entry
-  };
-
-  /// The layout is defined by a map of names to Locations, and the resulting required total length of the statevar
-  /// vector
-  struct StateVarVectorLayout {
-    std::unordered_map< std::string, StateVarEntryLocation > entries; ///< Map from entry name to its location
-    int                                                      nRequiredStateVars; ///< Total number of doubles required
-  };
-
-  /// generate the statevar vector layout from a list of entries, defined by name and length
-  static StateVarVectorLayout makeLayout( const std::vector< StateVarEntryDefinition >& theEntries )
-  {
-    std::unordered_map< std::string, StateVarEntryLocation > theMap;
-    int                                                      sizeOccupied = 0;
-    for ( const auto& theEntry : theEntries ) {
-      const auto nextLocation = sizeOccupied;
-      theMap[theEntry.name]   = { nextLocation, theEntry.length };
-      sizeOccupied += theEntry.length;
+  public:
+    /// get a StateView for a statevar entry
+    inline StateView getStateView( const std::string& name ) const
+    {
+      auto entry = theLayout.entries.at( name );
+      return { theStateVars + entry.index, entry.length };
     }
-    return { theMap, sizeOccupied };
-  }
 
-  /// pointer to the first element in the statevar vector
-  double* theStateVars;
+    /// get the reference to the first array element of an entry in the statevar vector
+    inline double& find( const std::string& name ) const { return theStateVars[theLayout.entries.at( name ).index]; }
 
-  /// a const reference to the respective layout
-  const StateVarVectorLayout& theLayout;
+    /// check if the entry with name is managed
+    inline bool contains( const std::string& name ) const { return theLayout.entries.count( name ); }
 
-  /// @brief Constructs the manager from an existing statevar array and a pre-built layout.
-  /// @param theStateVars Pointer to the first element of the statevar array.
-  /// @param theLayout_ Layout describing the offsets and lengths of each named entry.
-  MarmotStateVarVectorManager( double* theStateVars, const StateVarVectorLayout& theLayout_ )
-    : theStateVars( theStateVars ), theLayout( theLayout_ ){};
-};
+  protected:
+    /// An entry in the statevar vector consists of the name and a certain length
+    struct StateVarEntryDefinition {
+      std::string name;   ///< Unique name identifying the state variable entry
+      int         length; ///< Number of consecutive doubles occupied by this entry
+    };
+
+    /// The location in the statevar vector consists of the index and its certain length
+    struct StateVarEntryLocation {
+      int index;  ///< Zero-based offset into the statevar array where the entry begins
+      int length; ///< Number of consecutive doubles occupied by this entry
+    };
+
+    /// The layout is defined by a map of names to Locations, and the resulting required total length of the statevar
+    /// vector
+    struct StateVarVectorLayout {
+      std::unordered_map< std::string, StateVarEntryLocation > entries; ///< Map from entry name to its location
+      int                                                      nRequiredStateVars; ///< Total number of doubles required
+    };
+
+    /// generate the statevar vector layout from a list of entries, defined by name and length
+    static StateVarVectorLayout makeLayout( const std::vector< StateVarEntryDefinition >& theEntries )
+    {
+      std::unordered_map< std::string, StateVarEntryLocation > theMap;
+      int                                                      sizeOccupied = 0;
+      for ( const auto& theEntry : theEntries ) {
+        const auto nextLocation = sizeOccupied;
+        theMap[theEntry.name]   = { nextLocation, theEntry.length };
+        sizeOccupied += theEntry.length;
+      }
+      return { theMap, sizeOccupied };
+    }
+
+    /// pointer to the first element in the statevar vector
+    double* theStateVars;
+
+    /// a const reference to the respective layout
+    const StateVarVectorLayout& theLayout;
+
+    /// @brief Constructs the manager from an existing statevar array and a pre-built layout.
+    /// @param theStateVars Pointer to the first element of the statevar array.
+    /// @param theLayout_ Layout describing the offsets and lengths of each named entry.
+    MarmotStateVarVectorManager( double* theStateVars, const StateVarVectorLayout& theLayout_ )
+      : theStateVars( theStateVars ), theLayout( theLayout_ ){};
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotViscoelasticity.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotViscoelasticity.h
@@ -26,62 +26,53 @@
 #pragma once
 #include "Marmot/MarmotVoigt.h"
 
-namespace Marmot {
+namespace Marmot::ContinuumMechanics::Viscoelasticity::ComplianceFunctions {
 
-  namespace ContinuumMechanics {
+  /**
+   * @brief Logarithmic power-law compliance function.
+   *
+   * Computes the compliance function
+   * \f[
+   *   \Phi(\tau) = m \, \ln\!\left( 1 + \tau^n \right),
+   * \f]
+   * creep for long times.
+   *
+   * @tparam T_ Scalar or autodiff type of the argument.
+   *
+   * @param[in] tau Retardation time or evaluation point.
+   * @param[in] m Scaling factor.
+   * @param[in] n Exponent controlling the growth rate.
+   *
+   * @return The compliance value \f$\Phi(\tau)\f$.
+   */
 
-    namespace Viscoelasticity {
-
-      namespace ComplianceFunctions {
-
-        /**
-         * @brief Logarithmic power-law compliance function.
-         *
-         * Computes the compliance function
-         * \f[
-         *   \Phi(\tau) = m \, \ln\!\left( 1 + \tau^n \right),
-         * \f]
-         * creep for long times.
-         *
-         * @tparam T_ Scalar or autodiff type of the argument.
-         *
-         * @param[in] tau Retardation time or evaluation point.
-         * @param[in] m Scaling factor.
-         * @param[in] n Exponent controlling the growth rate.
-         *
-         * @return The compliance value \f$\Phi(\tau)\f$.
-         */
-
-        template < typename T_ >
-        T_ logPowerLaw( T_ tau, double m, double n )
-        {
-          T_ val = m * log( 1. + pow( tau, n ) );
-          return val;
-        }
-        /**
-         * @brief Power-law compliance function.
-         *
-         * Computes the compliance function
-         * \f[
-         *   \Phi(\tau) = m \, \tau^n,
-         * \f]
-         * creep for short times.
-         *
-         * @tparam T_ Scalar or autodiff type of the argument.
-         *
-         * @param[in] tau Retardation time or evaluation point.
-         * @param[in] m Scaling factor.
-         * @param[in] n Exponent controlling the growth rate.
-         *
-         * @return The compliance value \f$\Phi(\tau)\f$.
-         */
-        template < typename T_ >
-        T_ powerLaw( T_ tau, double m, double n )
-        {
-          T_ val = m * pow( tau, n );
-          return val;
-        }
-      } // namespace ComplianceFunctions
-    }   // namespace Viscoelasticity
-  }     // namespace ContinuumMechanics
-} // namespace Marmot
+  template < typename T_ >
+  T_ logPowerLaw( T_ tau, double m, double n )
+  {
+    T_ val = m * log( 1. + pow( tau, n ) );
+    return val;
+  }
+  /**
+   * @brief Power-law compliance function.
+   *
+   * Computes the compliance function
+   * \f[
+   *   \Phi(\tau) = m \, \tau^n,
+   * \f]
+   * creep for short times.
+   *
+   * @tparam T_ Scalar or autodiff type of the argument.
+   *
+   * @param[in] tau Retardation time or evaluation point.
+   * @param[in] m Scaling factor.
+   * @param[in] n Exponent controlling the growth rate.
+   *
+   * @return The compliance value \f$\Phi(\tau)\f$.
+   */
+  template < typename T_ >
+  T_ powerLaw( T_ tau, double m, double n )
+  {
+    T_ val = m * pow( tau, n );
+    return val;
+  }
+} // namespace Marmot::ContinuumMechanics::Viscoelasticity::ComplianceFunctions

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MarmotVoigt.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MarmotVoigt.h
@@ -33,1135 +33,1132 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotTypedefs.h"
 
-namespace Marmot {
+/**
+ * @namespace ContinuumMechanics::VoigtNotation
+ * @brief This namespace includes functions needed for calculations with stress and strain tensors written in voigt
+ * notation.
+ */
+namespace Marmot::ContinuumMechanics::VoigtNotation {
+
+  /* constexpr int VoigtSize = 6; */
+
+  enum VoigtSize { OneD = 1, TwoD = 3, ThreeD = 6, Axial = 4 };
+
   /**
-   * @namespace ContinuumMechanics::VoigtNotation
-   * @brief This namespace includes functions needed for calculations with stress and strain tensors written in voigt
-   * notation.
+   * @brief Computes the size of the Voigt notation array based on the spatial dimension.
+   * @param x The spatial dimension (e.g., 2 for 2D, 3 for 3D).
+   * @return The size of the Voigt notation array as a VoigtSize.
+   * @note The calculation is based on the formula: \f$ \frac{x * x + x}{2} \f$.
    */
-  namespace ContinuumMechanics::VoigtNotation {
+  constexpr VoigtSize voigtSizeFromDimension( int x )
+  {
+    return (VoigtSize)( ( ( x * x ) + x ) >> 1 );
+  }
 
-    /* constexpr int VoigtSize = 6; */
+  inline constexpr int IndicesToVoigtIndex[3][3] = { { 0, 3, 4 }, { 3, 1, 5 }, { 4, 5, 2 } };
 
-    enum VoigtSize { OneD = 1, TwoD = 3, ThreeD = 6, Axial = 4 };
+  /** @brief Predefined 6D vector with scaling factor (2x) for shear components in Voigt notation.
+   * @details The vector contains scaling factors: {1, 1, 1, 2, 2, 2}.
+   */
+  extern const Marmot::Vector6d P;
 
-    /**
-     * @brief Computes the size of the Voigt notation array based on the spatial dimension.
-     * @param x The spatial dimension (e.g., 2 for 2D, 3 for 3D).
-     * @return The size of the Voigt notation array as a VoigtSize.
-     * @note The calculation is based on the formula: \f$ \frac{x * x + x}{2} \f$.
-     */
-    constexpr VoigtSize voigtSizeFromDimension( int x )
-    {
-      return (VoigtSize)( ( ( x * x ) + x ) >> 1 );
-    }
+  /** @brief Predefined 6D vector with inverse scaling factor (0.5x) for shear components in Voigt notation.
+   * @details The vector contains inverse scaling factors: {1, 1, 1, 0.5, 0.5, 0.5}.
+   */
+  extern const Marmot::Vector6d PInv;
 
-    inline constexpr int IndicesToVoigtIndex[3][3] = { { 0, 3, 4 }, { 3, 1, 5 }, { 4, 5, 2 } };
+  /** @brief Predefined 6D Vector representing the identity tensor in Voigt notation.
+   * @details The vector contains ones in all components: {1, 1, 1, 0, 0, 0}.
+   */
+  extern const Marmot::Vector6d I;
 
-    /** @brief Predefined 6D vector with scaling factor (2x) for shear components in Voigt notation.
-     * @details The vector contains scaling factors: {1, 1, 1, 2, 2, 2}.
-     */
-    extern const Marmot::Vector6d P;
+  /** @brief Predefined 6D Vector representing the hydrostatic projection tensor in Voigt notation.
+   * @details The vector contains: {1/3, 1/3, 1/3, 0, 0, 0}.
+   */
+  extern const Marmot::Vector6d IHyd;
 
-    /** @brief Predefined 6D vector with inverse scaling factor (0.5x) for shear components in Voigt notation.
-     * @details The vector contains inverse scaling factors: {1, 1, 1, 0.5, 0.5, 0.5}.
-     */
-    extern const Marmot::Vector6d PInv;
+  /** @brief Deviatoric projection tensor in Voigt notation.
+   * @details \f$ 6 \times 6 \f$ matrix.
+   */
+  extern const Matrix6d IDev;
 
-    /** @brief Predefined 6D Vector representing the identity tensor in Voigt notation.
-     * @details The vector contains ones in all components: {1, 1, 1, 0, 0, 0}.
-     */
-    extern const Marmot::Vector6d I;
+  // Plane Stress handling
 
-    /** @brief Predefined 6D Vector representing the hydrostatic projection tensor in Voigt notation.
-     * @details The vector contains: {1/3, 1/3, 1/3, 0, 0, 0}.
-     */
-    extern const Marmot::Vector6d IHyd;
+  /**
+   * @brief Converts a 3D stress vector in Voigt notation to a plane stress vector.
+   * @param voigt 6-component 3D stress vector in Voigt notation:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
+   * \end{bmatrix}^T
+   * \f]
+   * where \f$\sigma_{33} = \sigma_{13} = \sigma_{23} = 0\f$ in plane stress conditions.
+   * @return 3-component plane stress vector in Voigt notation:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{22} & \sigma_{12}
+   * \end{bmatrix}^T
+   * \f]
+   * @note This function extracts only the in-plane components of a 3D stress vector.
+   */
+  Eigen::Vector3d voigtToPlaneVoigt( const Marmot::Vector6d& voigt );
+  Vector4d        voigtToAxisymmetricVoigt( const Vector6d& voigt );
 
-    /** @brief Deviatoric projection tensor in Voigt notation.
-     * @details \f$ 6 \times 6 \f$ matrix.
-     */
-    extern const Matrix6d IDev;
+  /**
+   * @brief Converts a plane stress vector in Voigt notation back to a 3D Voigt vector.
+   * @param voigtPlane 3-component plane stress vector in Voigt notation:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{22} & \sigma_{12}
+   * \end{bmatrix}^T
+   * \f]
+   * @return 6-component 3D stress vector in Voigt notation:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{22} & 0 & \sigma_{12} & 0 & 0
+   * \end{bmatrix}^T
+   * \f]
+   * @note The out-of-plane components are set to zero, suitable for plane stress conditions.
+   */
+  Marmot::Vector6d planeVoigtToVoigt( const Eigen::Vector3d& voigtPlane );
+  Vector6d         axisymmetricVoigtToVoigt( const Vector4d& voigtAxisymmetric );
 
-    // Plane Stress handling
+  /**
+   * @brief Reduces a 3D Voigt vector to a lower-dimensional vector defined by `voigtSize`.
+   * @tparam voigtSize Target Voigt dimension (1, 3, or 6).
+   * @param Voigt3D Input 6-component 3D Voigt vector.
+   * @return Reduced Voigt vector of size `voigtSize`.
+   * @note Considered cases:
+   * - `voigtSize = 1`: Returns the \f$\sigma_{11}\f$ component.
+   * - `voigtSize = 3`: Returns the plane stress components using `voigtToPlaneVoigt()`.
+   * - `voigtSize = 6`: Returns the input 3D vector unchanged.
+   * @throws std::invalid_argument if `voigtSize` is not 1, 3, or 6.
+   */
+  template < enum VoigtSize voigtSize >
+  Eigen::Matrix< double, voigtSize, 1 > reduce3DVoigt( const Marmot::Vector6d& Voigt3D )
+  {
+    if constexpr ( voigtSize == OneD )
+      return ( Eigen::Matrix< double, 1, 1 >() << Voigt3D( 0 ) ).finished();
+    else if constexpr ( voigtSize == TwoD )
+      return voigtToPlaneVoigt( Voigt3D );
+    else if constexpr ( voigtSize == ThreeD )
+      return Voigt3D;
+    else
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
+  }
 
-    /**
-     * @brief Converts a 3D stress vector in Voigt notation to a plane stress vector.
-     * @param voigt 6-component 3D stress vector in Voigt notation:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
-     * \end{bmatrix}^T
-     * \f]
-     * where \f$\sigma_{33} = \sigma_{13} = \sigma_{23} = 0\f$ in plane stress conditions.
-     * @return 3-component plane stress vector in Voigt notation:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{22} & \sigma_{12}
-     * \end{bmatrix}^T
-     * \f]
-     * @note This function extracts only the in-plane components of a 3D stress vector.
-     */
-    Eigen::Vector3d voigtToPlaneVoigt( const Marmot::Vector6d& voigt );
-    Vector4d        voigtToAxisymmetricVoigt( const Vector6d& voigt );
+  /**
+   * @brief Constructs a 3D Voigt vector from a lower-dimensional Voigt vector.
+   * @tparam voigtSize Dimension of the input Voigt vector (1, 3, or 6).
+   * @param Voigt Input Voigt vector of size `voigtSize`.
+   * @return 6-component 3D Voigt vector.
+   * @note Considered cases:
+   * - `voigtSize = 1`: Returns a 3D vector with only \f$\sigma_{11}\f$ non-zero:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & 0 & 0 & 0 & 0 & 0
+   * \end{bmatrix}^T
+   * \f]
+   * - `voigtSize = 3`: Returns a 3D Voigt vector by calling `planeVoigtToVoigt()`.
+   * - `voigtSize = 6`: Returns the input vector unchanged.
+   * @throws std::invalid_argument if `voigtSize` is not 1, 3, or 6.
+   */
+  template < enum VoigtSize voigtSize >
+  Marmot::Vector6d make3DVoigt( const Eigen::Matrix< double, voigtSize, 1 >& Voigt )
+  {
+    if constexpr ( voigtSize == OneD )
+      return ( Marmot::Vector6d() << Voigt( 0 ), 0, 0, 0, 0, 0 ).finished();
+    else if constexpr ( voigtSize == TwoD )
+      return planeVoigtToVoigt( Voigt );
+    else if constexpr ( voigtSize == ThreeD )
+      return Voigt;
+    else if constexpr ( voigtSize == Axial )
+      return axisymmetricVoigtToVoigt( Voigt );
+    else
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
+  }
 
-    /**
-     * @brief Converts a plane stress vector in Voigt notation back to a 3D Voigt vector.
-     * @param voigtPlane 3-component plane stress vector in Voigt notation:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{22} & \sigma_{12}
-     * \end{bmatrix}^T
-     * \f]
-     * @return 6-component 3D stress vector in Voigt notation:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{22} & 0 & \sigma_{12} & 0 & 0
-     * \end{bmatrix}^T
-     * \f]
-     * @note The out-of-plane components are set to zero, suitable for plane stress conditions.
-     */
-    Marmot::Vector6d planeVoigtToVoigt( const Eigen::Vector3d& voigtPlane );
-    Vector6d         axisymmetricVoigtToVoigt( const Vector4d& voigtAxisymmetric );
+  // function prototypes for  Marmot::Vector6d handling
 
-    /**
-     * @brief Reduces a 3D Voigt vector to a lower-dimensional vector defined by `voigtSize`.
-     * @tparam voigtSize Target Voigt dimension (1, 3, or 6).
-     * @param Voigt3D Input 6-component 3D Voigt vector.
-     * @return Reduced Voigt vector of size `voigtSize`.
-     * @note Considered cases:
-     * - `voigtSize = 1`: Returns the \f$\sigma_{11}\f$ component.
-     * - `voigtSize = 3`: Returns the plane stress components using `voigtToPlaneVoigt()`.
-     * - `voigtSize = 6`: Returns the input 3D vector unchanged.
-     * @throws std::invalid_argument if `voigtSize` is not 1, 3, or 6.
-     */
-    template < enum VoigtSize voigtSize >
-    Eigen::Matrix< double, voigtSize, 1 > reduce3DVoigt( const Marmot::Vector6d& Voigt3D )
-    {
-      if constexpr ( voigtSize == OneD )
-        return ( Eigen::Matrix< double, 1, 1 >() << Voigt3D( 0 ) ).finished();
-      else if constexpr ( voigtSize == TwoD )
-        return voigtToPlaneVoigt( Voigt3D );
-      else if constexpr ( voigtSize == ThreeD )
-        return Voigt3D;
-      else
-        throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
-    }
-
-    /**
-     * @brief Constructs a 3D Voigt vector from a lower-dimensional Voigt vector.
-     * @tparam voigtSize Dimension of the input Voigt vector (1, 3, or 6).
-     * @param Voigt Input Voigt vector of size `voigtSize`.
-     * @return 6-component 3D Voigt vector.
-     * @note Considered cases:
-     * - `voigtSize = 1`: Returns a 3D vector with only \f$\sigma_{11}\f$ non-zero:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & 0 & 0 & 0 & 0 & 0
-     * \end{bmatrix}^T
-     * \f]
-     * - `voigtSize = 3`: Returns a 3D Voigt vector by calling `planeVoigtToVoigt()`.
-     * - `voigtSize = 6`: Returns the input vector unchanged.
-     * @throws std::invalid_argument if `voigtSize` is not 1, 3, or 6.
-     */
-    template < enum VoigtSize voigtSize >
-    Marmot::Vector6d make3DVoigt( const Eigen::Matrix< double, voigtSize, 1 >& Voigt )
-    {
-      if constexpr ( voigtSize == OneD )
-        return ( Marmot::Vector6d() << Voigt( 0 ), 0, 0, 0, 0, 0 ).finished();
-      else if constexpr ( voigtSize == TwoD )
-        return planeVoigtToVoigt( Voigt );
-      else if constexpr ( voigtSize == ThreeD )
-        return Voigt;
-      else if constexpr ( voigtSize == Axial )
-        return axisymmetricVoigtToVoigt( Voigt );
-      else
-        throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
-    }
-
-    // function prototypes for  Marmot::Vector6d handling
-
-    /**
-     * @brief Converts a 6-component Voigt strain vector to a 3x3 strain tensor.
-     * @tparam T Scalar type (e.g., double, float).
-     * @param voigt 6-component strain vector in Voigt notation:
-     * \f[
-     * \begin{bmatrix}
-     * \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & \gamma_{12} & \gamma_{13} & \gamma_{23}
-     * \end{bmatrix}^T
-     * \f]
-     * @return 3x3 strain tensor:
-     * \f[
-     * \begin{bmatrix}
-     * \varepsilon_{11} & \gamma_{12}/2 & \gamma_{13}/2 \\
-     * \gamma_{12}/2 & \varepsilon_{22} & \gamma_{23}/2 \\
-     * \gamma_{13}/2 & \gamma_{23}/2 & \varepsilon_{33} \\
-     * \end{bmatrix}
-     * \f]
-     * @note Shear components in Voigt notation are engineering strains and are halved in the resulting tensor.
-     */
-    template < typename T >
-    Eigen::Matrix< T, 3, 3 > voigtToStrain( const Eigen::Matrix< T, 6, 1 >& voigt )
-    {
-      Eigen::Matrix< T, 3, 3 > strain;
-      // clang-format off
+  /**
+   * @brief Converts a 6-component Voigt strain vector to a 3x3 strain tensor.
+   * @tparam T Scalar type (e.g., double, float).
+   * @param voigt 6-component strain vector in Voigt notation:
+   * \f[
+   * \begin{bmatrix}
+   * \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & \gamma_{12} & \gamma_{13} & \gamma_{23}
+   * \end{bmatrix}^T
+   * \f]
+   * @return 3x3 strain tensor:
+   * \f[
+   * \begin{bmatrix}
+   * \varepsilon_{11} & \gamma_{12}/2 & \gamma_{13}/2 \\
+   * \gamma_{12}/2 & \varepsilon_{22} & \gamma_{23}/2 \\
+   * \gamma_{13}/2 & \gamma_{23}/2 & \varepsilon_{33} \\
+   * \end{bmatrix}
+   * \f]
+   * @note Shear components in Voigt notation are engineering strains and are halved in the resulting tensor.
+   */
+  template < typename T >
+  Eigen::Matrix< T, 3, 3 > voigtToStrain( const Eigen::Matrix< T, 6, 1 >& voigt )
+  {
+    Eigen::Matrix< T, 3, 3 > strain;
+    // clang-format off
       strain << voigt[0],       voigt[3] * 0.5, voigt[4] * 0.5,
                 voigt[3] * 0.5, voigt[1],       voigt[5] * 0.5,
                 voigt[4] * 0.5, voigt[5] * 0.5, voigt[2];
-      // clang-format on
-      return strain;
-    }
+    // clang-format on
+    return strain;
+  }
 
-    /**
-     * @brief Converts a 6-component Voigt stress vector to a 3x3 stress tensor.
-     * @tparam T Scalar type (e.g., double, float).
-     * @param voigt 6-component stress vector in Voigt notation:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
-     * \end{bmatrix}^T
-     * \f]
-     * @return 3x3 stress tensor:
-     * \f[
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{12} & \sigma_{13} \\
-     * \sigma_{12} & \sigma_{22} & \sigma_{23} \\
-     * \sigma_{13} & \sigma_{23} & \sigma_{33} \\
-     * \end{bmatrix}
-     * \f]
-     */
-    template < typename T >
-    Eigen::Matrix< T, 3, 3 > voigtToStress( const Eigen::Matrix< T, 6, 1 >& voigt )
-    {
-      Eigen::Matrix< T, 3, 3 > stress;
-      // clang-format off
+  /**
+   * @brief Converts a 6-component Voigt stress vector to a 3x3 stress tensor.
+   * @tparam T Scalar type (e.g., double, float).
+   * @param voigt 6-component stress vector in Voigt notation:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
+   * \end{bmatrix}^T
+   * \f]
+   * @return 3x3 stress tensor:
+   * \f[
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{12} & \sigma_{13} \\
+   * \sigma_{12} & \sigma_{22} & \sigma_{23} \\
+   * \sigma_{13} & \sigma_{23} & \sigma_{33} \\
+   * \end{bmatrix}
+   * \f]
+   */
+  template < typename T >
+  Eigen::Matrix< T, 3, 3 > voigtToStress( const Eigen::Matrix< T, 6, 1 >& voigt )
+  {
+    Eigen::Matrix< T, 3, 3 > stress;
+    // clang-format off
       stress << voigt[0], voigt[3], voigt[4],
                 voigt[3], voigt[1], voigt[5],
                 voigt[4], voigt[5], voigt[2];
-      // clang-format on
-      return stress;
-    }
+    // clang-format on
+    return stress;
+  }
 
-    /**
-     * @brief Converts a 3x3 strain tensor to a 6-component Voigt strain vector.
-     * @param strainTensor 3x3 strain tensor:
-     * \f[
-     * \boldsymbol{\varepsilon} =
-     * \begin{bmatrix}
-     * \varepsilon_{11} & \varepsilon_{12} & \varepsilon_{13} \\
-     * \varepsilon_{21} & \varepsilon_{22} & \varepsilon_{23} \\
-     * \varepsilon_{31} & \varepsilon_{32} & \varepsilon_{33} \\
-     * \end{bmatrix}
-     * \f]
-     * @return 6-component strain vector in Voigt notation:
-     * \f[
-     * \begin{aligned}
-     * \boldsymbol{\varepsilon}^{\text{Voigt}} &=
-     * \begin{bmatrix}
-     *   \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & \gamma_{12} & \gamma_{13} & \gamma_{23}
-     * \end{bmatrix}^T \\
-     * &=
-     * \begin{bmatrix}
-     *   \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & 2 \varepsilon_{12} & 2 \varepsilon_{13} & 2
-     * \varepsilon_{23}
-     * \end{bmatrix}^T
-     * \end{aligned}
-     * \f]
-     * @note Shear components in the Voigt vector (\f$\gamma_{ij}\f$ ) are engineering strains,
-     * which are twice the tensor shear components.
-     */
-    Marmot::Vector6d strainToVoigt( const Eigen::Matrix3d& strainTensor );
+  /**
+   * @brief Converts a 3x3 strain tensor to a 6-component Voigt strain vector.
+   * @param strainTensor 3x3 strain tensor:
+   * \f[
+   * \boldsymbol{\varepsilon} =
+   * \begin{bmatrix}
+   * \varepsilon_{11} & \varepsilon_{12} & \varepsilon_{13} \\
+   * \varepsilon_{21} & \varepsilon_{22} & \varepsilon_{23} \\
+   * \varepsilon_{31} & \varepsilon_{32} & \varepsilon_{33} \\
+   * \end{bmatrix}
+   * \f]
+   * @return 6-component strain vector in Voigt notation:
+   * \f[
+   * \begin{aligned}
+   * \boldsymbol{\varepsilon}^{\text{Voigt}} &=
+   * \begin{bmatrix}
+   *   \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & \gamma_{12} & \gamma_{13} & \gamma_{23}
+   * \end{bmatrix}^T \\
+   * &=
+   * \begin{bmatrix}
+   *   \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & 2 \varepsilon_{12} & 2 \varepsilon_{13} & 2
+   * \varepsilon_{23}
+   * \end{bmatrix}^T
+   * \end{aligned}
+   * \f]
+   * @note Shear components in the Voigt vector (\f$\gamma_{ij}\f$ ) are engineering strains,
+   * which are twice the tensor shear components.
+   */
+  Marmot::Vector6d strainToVoigt( const Eigen::Matrix3d& strainTensor );
 
-    /**
-     * @brief Converts a 3x3 stress tensor to a 6-component Voigt stress vector.
-     * @tparam T Scalar type (e.g., double, float).
-     * @param stressTensor 3x3 stress tensor:
-     * \f[
-     * \boldsymbol{\sigma} =
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{12} & \sigma_{13} \\
-     * \sigma_{21} & \sigma_{22} & \sigma_{23} \\
-     * \sigma_{31} & \sigma_{32} & \sigma_{33} \\
-     * \end{bmatrix}
-     * \f]
-     * @return 6-component stress vector in Voigt notation:
-     * \f[
-     * \boldsymbol{\sigma}^{\text{Voigt}} =
-     * \begin{bmatrix}
-     * \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
-     * \end{bmatrix}^T
-     * \f]
-     * @note Shear components are copied directly; no factor of 2 is applied.
-     */
-    template < typename T = double >
-    Eigen::Matrix< T, 6, 1 > stressToVoigt( const Eigen::Matrix< T, 3, 3 >& stressTensor )
-    {
-      Eigen::Matrix< T, 6, 1 > stress;
-      // clang-format off
+  /**
+   * @brief Converts a 3x3 stress tensor to a 6-component Voigt stress vector.
+   * @tparam T Scalar type (e.g., double, float).
+   * @param stressTensor 3x3 stress tensor:
+   * \f[
+   * \boldsymbol{\sigma} =
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{12} & \sigma_{13} \\
+   * \sigma_{21} & \sigma_{22} & \sigma_{23} \\
+   * \sigma_{31} & \sigma_{32} & \sigma_{33} \\
+   * \end{bmatrix}
+   * \f]
+   * @return 6-component stress vector in Voigt notation:
+   * \f[
+   * \boldsymbol{\sigma}^{\text{Voigt}} =
+   * \begin{bmatrix}
+   * \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
+   * \end{bmatrix}^T
+   * \f]
+   * @note Shear components are copied directly; no factor of 2 is applied.
+   */
+  template < typename T = double >
+  Eigen::Matrix< T, 6, 1 > stressToVoigt( const Eigen::Matrix< T, 3, 3 >& stressTensor )
+  {
+    Eigen::Matrix< T, 6, 1 > stress;
+    // clang-format off
             stress << stressTensor( 0, 0 ),
                       stressTensor( 1, 1 ),
                       stressTensor( 2, 2 ),
                       stressTensor( 0, 1 ),
                       stressTensor( 0, 2 ),
                       stressTensor( 1, 2 );
-      // clang-format on
-      return stress;
-    }
+    // clang-format on
+    return stress;
+  }
+
+  /**
+   * @brief Converts a fourth-order stiffness tensor to its Voigt notation representation (\f$ 6 \times 6 \f$ matrix).
+   * @param C The fourth-order stiffness tensor represented as an Eigen::Tensor<double, 4>.
+   * @return An Eigen::Matrix<double, 6, 6> representing the stiffness tensor in Voigt notation.
+   * @note The input tensor `C` must follow the symmetry properties of a stiffness tensor for the
+   *       conversion to be valid (minor symmetry).
+   */
+  Eigen::Matrix< double, 6, 6 > stiffnessToVoigt( const EigenTensors::Tensor3333d& C );
+
+  /**
+   * @brief Converts a stiffness matrix in Voigt notation (\f$ 6 \times 6 \f$ matrix) to a 4th-order stiffness tensor
+   * (\f$ 3 \times 3 \times 3 \times 3 \f$ tensor).
+   * @param voigtStiffness The \f$ 6 \times 6 \f$ matrix representing the stiffness in Voigt notation.
+   * @return An Eigen::Tensor of rank 4 (4th-order tensor) representing the stiffness tensor.
+   *         The dimensions of the tensor are \f$ 3 \times 3 \times 3 \times 3 \f$.
+   */
+  EigenTensors::Tensor3333d voigtToStiffness( const Eigen::Matrix< double, 6, 6 >& voigtStiffness );
+
+  /**
+   * @brief Converts a stiffness matrix in Voigt notation (\f$ 6 \times 6 \f$ matrix) to a 4th-order stiffness tensor
+   * (\f$ 3 \times 3 \times 3 \times 3 \f$ tensor).
+   * @param voigtStiffness The \f$ 6 \times 6 \f$ matrix representing the stiffness in Voigt notation.
+   * @return a Fastor::Tensor of rank 4 (4th-order tensor) representing the stiffness tensor.
+   *         The dimensions of the tensor are \f$ 3 \times 3 \times 3 \times 3 \f$.
+   */
+  Marmot::FastorStandardTensors::Tensor3333d voigtToStiffnessFastor( const Marmot::Matrix6d& voigtStiffness );
+
+  /**
+   * @brief Converts a stress vector in Voigt notation to its corresponding tensor form.
+   *
+   * @details This function handles 1D, 2D, and 3D stress vectors in Voigt notation and returns
+   * the full symmetric stress tensor.
+   * @tparam nDim Dimension of the stress tensor (1, 2, or 3).
+   * @param Voigt Input stress vector in Voigt notation, size `VOIGTFROMDIM(nDim) x 1`:
+   * - 1D: \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
+   *   \begin{bmatrix} \sigma_{11} \end{bmatrix}^T \f$
+   * - 2D: \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
+   *   \begin{bmatrix} \sigma_{11} & \sigma_{22} & \sigma_{12} \end{bmatrix}^T \f$
+   * - 3D: \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
+   *   \begin{bmatrix} \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
+   * \end{bmatrix}^T \f$
+   * @return Symmetric stress tensor of size \f$ nDim \times nDim \f$.
+   * @throws std::invalid_argument If `nDim` is not 1, 2, or 3.
+   * @note For 2D and 3D, the off-diagonal shear components in the tensor are taken
+   *       directly from the Voigt vector (no factor of 2 applied).
+   */
+  template < int nDim >
+  Eigen::Matrix< double, nDim, nDim > stressMatrixFromVoigt(
+    const Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 >& Voigt )
+  {
+    if constexpr ( nDim == 1 )
+      return ( Eigen::Matrix< double, nDim, nDim >() << Voigt( 0 ) ).finished();
+    else if constexpr ( nDim == 2 )
+      return ( Eigen::Matrix< double, nDim, nDim >() << Voigt( 0 ), Voigt( 2 ), Voigt( 2 ), Voigt( 1 ) ).finished();
+    else if constexpr ( nDim == 3 )
+      return voigtToStress( Voigt );
+    else
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
+  }
+
+  /**
+   * @brief Converts a strain tensor to its corresponding Voigt notation vector.
+   *
+   * @details This function supports 1D, 2D, and 3D strain tensors and returns the corresponding
+   * Voigt vector (column vector). Shear components are scaled appropriately for engineering strain.
+   * @tparam nDim Dimension of the strain tensor (1, 2, or 3).
+   * @param strain Input strain tensor of size `nDim x nDim`.
+   * @return Column vector of size `VOIGTFROMDIM(nDim) x 1` representing the strain in Voigt notation.
+   * - 1D: \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
+   *   \begin{bmatrix} \varepsilon_{11} \end{bmatrix}^T \f$
+   * - 2D: \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
+   *   \begin{bmatrix} \varepsilon_{11} & \varepsilon_{22} & 2 \varepsilon_{12} \end{bmatrix}^T \f$
+   * - 3D: \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
+   *   \begin{bmatrix} \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & 2 \varepsilon_{12} & 2
+   * \varepsilon_{13} & 2 \varepsilon_{23} \end{bmatrix}^T \f$
+   * @throws std::invalid_argument If `nDim` is not 1, 2, or 3.
+   * @note Axisymmetric voigt vectors are not supported.
+   */
+  template < int nDim >
+  Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 > voigtFromStrainMatrix(
+    const Eigen::Matrix< double, nDim, nDim >& strain )
+  {
+    if constexpr ( nDim == 1 )
+      return ( Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 >() << strain( 0, 0 ) ).finished();
+    else if constexpr ( nDim == 2 )
+      return ( Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 >() << strain( 0, 0 ),
+               strain( 1, 1 ),
+               2 * strain( 0, 1 ) )
+        .finished();
+    else if constexpr ( nDim == 3 )
+      return strainToVoigt( strain );
+    else
+      throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
+  }
+
+  namespace Invariants {
 
     /**
-     * @brief Converts a fourth-order stiffness tensor to its Voigt notation representation (\f$ 6 \times 6 \f$ matrix).
-     * @param C The fourth-order stiffness tensor represented as an Eigen::Tensor<double, 4>.
-     * @return An Eigen::Matrix<double, 6, 6> representing the stiffness tensor in Voigt notation.
-     * @note The input tensor `C` must follow the symmetry properties of a stiffness tensor for the
-     *       conversion to be valid (minor symmetry).
-     */
-    Eigen::Matrix< double, 6, 6 > stiffnessToVoigt( const EigenTensors::Tensor3333d& C );
-
-    /**
-     * @brief Converts a stiffness matrix in Voigt notation (\f$ 6 \times 6 \f$ matrix) to a 4th-order stiffness tensor
-     * (\f$ 3 \times 3 \times 3 \times 3 \f$ tensor).
-     * @param voigtStiffness The \f$ 6 \times 6 \f$ matrix representing the stiffness in Voigt notation.
-     * @return An Eigen::Tensor of rank 4 (4th-order tensor) representing the stiffness tensor.
-     *         The dimensions of the tensor are \f$ 3 \times 3 \times 3 \times 3 \f$.
-     */
-    EigenTensors::Tensor3333d voigtToStiffness( const Eigen::Matrix< double, 6, 6 >& voigtStiffness );
-
-    /**
-     * @brief Converts a stiffness matrix in Voigt notation (\f$ 6 \times 6 \f$ matrix) to a 4th-order stiffness tensor
-     * (\f$ 3 \times 3 \times 3 \times 3 \f$ tensor).
-     * @param voigtStiffness The \f$ 6 \times 6 \f$ matrix representing the stiffness in Voigt notation.
-     * @return a Fastor::Tensor of rank 4 (4th-order tensor) representing the stiffness tensor.
-     *         The dimensions of the tensor are \f$ 3 \times 3 \times 3 \times 3 \f$.
-     */
-    Marmot::FastorStandardTensors::Tensor3333d voigtToStiffnessFastor( const Marmot::Matrix6d& voigtStiffness );
-
-    /**
-     * @brief Converts a stress vector in Voigt notation to its corresponding tensor form.
+     * @brief Computes the principal strains by solving the eigenvalue problem.
      *
-     * @details This function handles 1D, 2D, and 3D stress vectors in Voigt notation and returns
-     * the full symmetric stress tensor.
-     * @tparam nDim Dimension of the stress tensor (1, 2, or 3).
-     * @param Voigt Input stress vector in Voigt notation, size `VOIGTFROMDIM(nDim) x 1`:
-     * - 1D: \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
-     *   \begin{bmatrix} \sigma_{11} \end{bmatrix}^T \f$
-     * - 2D: \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
-     *   \begin{bmatrix} \sigma_{11} & \sigma_{22} & \sigma_{12} \end{bmatrix}^T \f$
-     * - 3D: \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
-     *   \begin{bmatrix} \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
-     * \end{bmatrix}^T \f$
-     * @return Symmetric stress tensor of size \f$ nDim \times nDim \f$.
-     * @throws std::invalid_argument If `nDim` is not 1, 2, or 3.
-     * @note For 2D and 3D, the off-diagonal shear components in the tensor are taken
-     *       directly from the Voigt vector (no factor of 2 applied).
+     * @details This function computes the eigenvalues of the strain tensor reconstructed
+     * from the given Voigt strain vector. The eigenvalues correspond to the
+     * principal strains \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$:
+     *\f[
+         \displaystyle |\varepsilon_{ij} - \lambda\, \delta_{ij}| = 0 \hspace{.5cm} \Rightarrow \hspace{.5cm}
+     \lambda^{(1)},\lambda^{(2)},\lambda^{(3)}\hspace{0.3cm} \widehat{=}\hspace{0.3cm} \varepsilon_1,\,
+     \varepsilon_2,\, \varepsilon_3 \f]
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return A 3D vector containing the principal strains (unsorted).
      */
-    template < int nDim >
-    Eigen::Matrix< double, nDim, nDim > stressMatrixFromVoigt(
-      const Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 >& Voigt )
+    Eigen::Vector3d principalStrains( const Marmot::Vector6d& strain );
+
+    /**
+     * @brief Computes the principal stresses by solving the eigenvalue problem.
+     *
+     * @details This function computes the eigenvalues of the stress tensor reconstructed
+     * from the given Voigt stress vector. The eigenvalues correspond to the
+     * principal stresses \f$ \sigma_1, \sigma_2, \sigma_3 \f$:
+     * \f[
+        \displaystyle |\sigma_{ij} - \lambda\, \delta_{ij}| = 0 \hspace{.5cm} \Rightarrow \hspace{.5cm}
+    \lambda^{(1)},\lambda^{(2)},\lambda^{(3)}\hspace{0.3cm} \widehat{=}\hspace{0.3cm}\sigma_1,\, \sigma_2,\, \sigma_3
+     \f]
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return A 3D vector containing the principal stresses (unsorted).
+     */
+    Eigen::Vector3d principalStresses( const Marmot::Vector6d& stress );
+    // principal strains calculated from haigh westergaard strains ( sorted --> e1 > e2 > e3 )
+
+    /**
+     * @brief Computes the principal strains from Haigh–Westergaard coordinates.
+     *
+     * @details This function transforms the Haigh–Westergaard coordinates
+     * \f$ (\xi, \rho, \theta) \f$ into the corresponding principal strains
+     * \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$ using:
+     * \f[
+     *   \begin{bmatrix}
+     *     \varepsilon_{1} \\
+     *     \varepsilon_{2} \\
+     *     \varepsilon_{3}
+     *   \end{bmatrix}
+     *   =
+     *   \frac{1}{\sqrt{3}}
+     *   \begin{bmatrix}
+     *     \xi \\
+     *     \xi \\
+     *     \xi
+     *   \end{bmatrix}
+     *   + \sqrt{\tfrac{2}{3}}\, \rho \,
+     *   \begin{bmatrix}
+     *     \cos(\theta) \\
+     *     -\sin\!\left(\tfrac{\pi}{6} - \theta\right) \\
+     *     -\sin\!\left(\tfrac{\pi}{6} + \theta\right)
+     *   \end{bmatrix}
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return A 3D vector of the principal strains, sorted by magnitude.
+     * @note The computation of \f$ \xi \f$, \f$ \rho \f$, and \f$ \theta \f$
+     *       is performed in `haighWestergaardFromStrain()`.
+     */
+    Eigen::Vector3d sortedPrincipalStrains( const Marmot::Vector6d& strain );
+    // principal stressDirections calculated by solving eigenvalue problem ( !NOT sorted! )
+
+    /**
+     * @brief Computes the principal stress directions corresponding to the principal stresses.
+     *
+     * @details This function solves the eigenvalue problem
+     * \f[
+     *   \left( \boldsymbol{\sigma} - \sigma_k \cdot \boldsymbol{I} \right) \cdot
+     *   \boldsymbol{x}^{(k)} = 0
+     * \f]
+     * to obtain the eigenvectors \f$ \boldsymbol{x}^{(k)} \f$ associated with
+     * the principal stresses \f$ \sigma_k \f$.
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return A 3x3 matrix whose columns are the principal stress directions (unsorted).
+     */
+    Eigen::Matrix3d principalStressesDirections( const Marmot::Vector6d& stress );
+
+    /**
+     * @brief Computes the equivalent von Mises stress.
+     *
+     * @details Defined as:
+     * \f[
+     *   \sigma_\text{eq} = \sqrt{3 \cdot J_2}
+     * \f]
+     * where \f$ J_2 \f$ is the second invariant of the deviatoric stress tensor
+     * (see `J2()`).
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return The von Mises equivalent stress.
+     */
+    double vonMisesEquivalentStress( const Marmot::Vector6d& stress );
+
+    /**
+     * @brief Computes the equivalent von Mises strain.
+     *
+     * @details Based on the deviatoric strain tensor \f$ e_{ij} \f$:
+     * \f[
+     *   \varepsilon^\text{(eq)} = \sqrt{\tfrac{2}{3} \, e_{ij} e_{ij}}
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return The von Mises equivalent strain.
+     */
+    double vonMisesEquivalentStrain( const Marmot::Vector6d& strain );
+
+    /**
+     * @brief Computes the Euclidean norm of the strain tensor.
+     *
+     * @details Defined as:
+     * \f[
+     *   ||\boldsymbol{\varepsilon}|| = \sqrt{ \varepsilon_{ij}\varepsilon_{ij}}
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return The Euclidean norm of the strain tensor.
+     */
+    template < typename T >
+    T normStrain( const Eigen::Matrix< T, 6, 1 >& strain )
     {
-      if constexpr ( nDim == 1 )
-        return ( Eigen::Matrix< double, nDim, nDim >() << Voigt( 0 ) ).finished();
-      else if constexpr ( nDim == 2 )
-        return ( Eigen::Matrix< double, nDim, nDim >() << Voigt( 0 ), Voigt( 2 ), Voigt( 2 ), Voigt( 1 ) ).finished();
-      else if constexpr ( nDim == 3 )
-        return voigtToStress( Voigt );
-      else
-        throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
+      return ContinuumMechanics::VoigtNotation::voigtToStrain( strain ).norm();
     }
 
     /**
-     * @brief Converts a strain tensor to its corresponding Voigt notation vector.
+     * @brief Computes the Euclidean norm of the stress tensor.
      *
-     * @details This function supports 1D, 2D, and 3D strain tensors and returns the corresponding
-     * Voigt vector (column vector). Shear components are scaled appropriately for engineering strain.
-     * @tparam nDim Dimension of the strain tensor (1, 2, or 3).
-     * @param strain Input strain tensor of size `nDim x nDim`.
-     * @return Column vector of size `VOIGTFROMDIM(nDim) x 1` representing the strain in Voigt notation.
-     * - 1D: \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
-     *   \begin{bmatrix} \varepsilon_{11} \end{bmatrix}^T \f$
-     * - 2D: \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
-     *   \begin{bmatrix} \varepsilon_{11} & \varepsilon_{22} & 2 \varepsilon_{12} \end{bmatrix}^T \f$
-     * - 3D: \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
-     *   \begin{bmatrix} \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} & 2 \varepsilon_{12} & 2
-     * \varepsilon_{13} & 2 \varepsilon_{23} \end{bmatrix}^T \f$
-     * @throws std::invalid_argument If `nDim` is not 1, 2, or 3.
-     * @note Axisymmetric voigt vectors are not supported.
+     * @details Defined as:
+     * \f[
+     *   ||\boldsymbol{\sigma}|| = \sqrt{\sigma_{ij}\sigma_{ij}}
+     * \f]
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return The Euclidean norm of the stress tensor.
      */
-    template < int nDim >
-    Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 > voigtFromStrainMatrix(
-      const Eigen::Matrix< double, nDim, nDim >& strain )
+    double normStress( const Marmot::Vector6d& stress );
+    // Trace of compressive strains
+
+    /**
+     * @brief Computes the volumetric plastic strain in compression.
+     *
+     * @details Defined as:
+     * \f[
+     *   \varepsilon^{\text{vol}}_{\ominus}
+     *   = \sum_{i=1}^3 \left\langle -\varepsilon_i \right\rangle
+     * \f]
+     * where \f$ \varepsilon_i \f$ are the principal strains and
+     * \f$ \langle \bullet \rangle \f$ denotes the Macaulay brackets.
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return The volumetric compressive strain.
+     */
+    double StrainVolumetricNegative( const Marmot::Vector6d& strain );
+
+    /**
+     * @brief Computes the first invariant \f$ I_1 \f$ of the stress tensor.
+     *
+     * @details The first invariant of the stress tensor \f$ \boldsymbol{\sigma} \f$ is the trace:
+     * \f[
+     *   I_1 = \operatorname{tr}(\boldsymbol{\sigma})
+     *       = \sigma_{11} + \sigma_{22} + \sigma_{33}
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param stress 6-component stress vector in Voigt notation:
+     *   \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
+     *     \begin{bmatrix}
+     *       \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
+     *     \end{bmatrix}^T \f$
+     * @return Value of the first invariant \f$ I_1 \f$.
+     */
+    template < typename T >
+    T I1( const Eigen::Matrix< T, 6, 1 >& stress )
     {
-      if constexpr ( nDim == 1 )
-        return ( Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 >() << strain( 0, 0 ) ).finished();
-      else if constexpr ( nDim == 2 )
-        return ( Eigen::Matrix< double, VOIGTFROMDIM( nDim ), 1 >() << strain( 0, 0 ),
-                 strain( 1, 1 ),
-                 2 * strain( 0, 1 ) )
-          .finished();
-      else if constexpr ( nDim == 3 )
-        return strainToVoigt( strain );
-      else
-        throw std::invalid_argument( MakeString() << __PRETTY_FUNCTION__ << ": invalid dimension specified" );
+      return stress( 0 ) + stress( 1 ) + stress( 2 );
     }
 
-    namespace Invariants {
+    /**
+     * @brief Computes the first invariant \f$ I^{(\varepsilon)}_1 \f$ of the strain tensor.
+     *
+     * @details The first invariant of the strain tensor \f$ \boldsymbol{\varepsilon} \f$ is the trace:
+     * \f[
+     *   I^{(\varepsilon)}_1 = \operatorname{tr}(\boldsymbol{\varepsilon})
+     *       = \varepsilon_{11} + \varepsilon_{22} + \varepsilon_{33}
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation:
+     *   \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
+     *     \begin{bmatrix}
+     *       \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} &
+     *       \gamma_{12} & \gamma_{13} & \gamma_{23}
+     *     \end{bmatrix}^T \f$
+     * @return Value of the first strain invariant \f$ I^{(\varepsilon)}_1 \f$.
+     */
+    double I1Strain( const Marmot::Vector6d& strain ); //
 
-      /**
-       * @brief Computes the principal strains by solving the eigenvalue problem.
-       *
-       * @details This function computes the eigenvalues of the strain tensor reconstructed
-       * from the given Voigt strain vector. The eigenvalues correspond to the
-       * principal strains \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$:
-       *\f[
-           \displaystyle |\varepsilon_{ij} - \lambda\, \delta_{ij}| = 0 \hspace{.5cm} \Rightarrow \hspace{.5cm}
-       \lambda^{(1)},\lambda^{(2)},\lambda^{(3)}\hspace{0.3cm} \widehat{=}\hspace{0.3cm} \varepsilon_1,\,
-       \varepsilon_2,\, \varepsilon_3 \f]
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return A 3D vector containing the principal strains (unsorted).
-       */
-      Eigen::Vector3d principalStrains( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the second invariant \f$ I_2 \f$ of the stress tensor.
+     *
+     * @details The second invariant of the stress tensor \f$ \boldsymbol{\sigma} \f$ is defined as:
+     * \f[
+     *   I_2 = \tfrac{1}{2}\left( \operatorname{tr}(\boldsymbol{\sigma})^2
+     *         - \operatorname{tr}(\boldsymbol{\sigma}^2) \right)
+     * \f]
+     * In Voigt notation, this expands to:
+     * \f[
+     *   I_2 = \sigma_{11}\sigma_{22} + \sigma_{22}\sigma_{33} + \sigma_{33}\sigma_{11}
+     *         - \sigma_{12}^2 - \sigma_{13}^2 - \sigma_{23}^2
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param stress 6-component stress vector in Voigt notation:
+     *   \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
+     *     \begin{bmatrix}
+     *       \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
+     *     \end{bmatrix}^T \f$
+     *
+     * @return Value of the second invariant \f$ I_2 \f$.
+     */
+    template < typename T >
+    T I2( const Eigen::Matrix< T, 6, 1 >& stress )
+    {
+      const Eigen::Matrix< T, 6, 1 >& s = stress;
+      return s( 0 ) * s( 1 ) + s( 1 ) * s( 2 ) + s( 2 ) * s( 0 ) - s( 3 ) * s( 3 ) - s( 4 ) * s( 4 ) - s( 5 ) * s( 5 );
+    }
 
-      /**
-       * @brief Computes the principal stresses by solving the eigenvalue problem.
-       *
-       * @details This function computes the eigenvalues of the stress tensor reconstructed
-       * from the given Voigt stress vector. The eigenvalues correspond to the
-       * principal stresses \f$ \sigma_1, \sigma_2, \sigma_3 \f$:
-       * \f[
-          \displaystyle |\sigma_{ij} - \lambda\, \delta_{ij}| = 0 \hspace{.5cm} \Rightarrow \hspace{.5cm}
-      \lambda^{(1)},\lambda^{(2)},\lambda^{(3)}\hspace{0.3cm} \widehat{=}\hspace{0.3cm}\sigma_1,\, \sigma_2,\, \sigma_3
-       \f]
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return A 3D vector containing the principal stresses (unsorted).
-       */
-      Eigen::Vector3d principalStresses( const Marmot::Vector6d& stress );
-      // principal strains calculated from haigh westergaard strains ( sorted --> e1 > e2 > e3 )
+    /**
+     * @brief Computes the second invariant \f$ I^{(\varepsilon)}_2 \f$ of the strain tensor.
+     *
+     * @details For a strain tensor \f$ \boldsymbol{\varepsilon} \f$ in Voigt notation,
+     * the second invariant is:
+     * \f[
+     *   I^{(\varepsilon)}_2 =
+     *     \varepsilon_{11}\varepsilon_{22} +
+     *     \varepsilon_{22}\varepsilon_{33} +
+     *     \varepsilon_{33}\varepsilon_{11}
+     *     - \tfrac{1}{4}\left(\gamma_{12}^2 + \gamma_{13}^2 + \gamma_{23}^2\right)
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation:
+     *   \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
+     *     [ \varepsilon_{11}, \varepsilon_{22}, \varepsilon_{33},
+     *       \gamma_{12}, \gamma_{13}, \gamma_{23} ]^T \f$
+     * @return Value of the second invariant \f$ I^{(\varepsilon)}_2 \f$.
+     */
+    double I2Strain( const Marmot::Vector6d& strain );
 
-      /**
-       * @brief Computes the principal strains from Haigh–Westergaard coordinates.
-       *
-       * @details This function transforms the Haigh–Westergaard coordinates
-       * \f$ (\xi, \rho, \theta) \f$ into the corresponding principal strains
-       * \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$ using:
-       * \f[
-       *   \begin{bmatrix}
-       *     \varepsilon_{1} \\
-       *     \varepsilon_{2} \\
-       *     \varepsilon_{3}
-       *   \end{bmatrix}
-       *   =
-       *   \frac{1}{\sqrt{3}}
-       *   \begin{bmatrix}
-       *     \xi \\
-       *     \xi \\
-       *     \xi
-       *   \end{bmatrix}
-       *   + \sqrt{\tfrac{2}{3}}\, \rho \,
-       *   \begin{bmatrix}
-       *     \cos(\theta) \\
-       *     -\sin\!\left(\tfrac{\pi}{6} - \theta\right) \\
-       *     -\sin\!\left(\tfrac{\pi}{6} + \theta\right)
-       *   \end{bmatrix}
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return A 3D vector of the principal strains, sorted by magnitude.
-       * @note The computation of \f$ \xi \f$, \f$ \rho \f$, and \f$ \theta \f$
-       *       is performed in `haighWestergaardFromStrain()`.
-       */
-      Eigen::Vector3d sortedPrincipalStrains( const Marmot::Vector6d& strain );
-      // principal stressDirections calculated by solving eigenvalue problem ( !NOT sorted! )
+    /**
+     * @brief Computes the third invariant \f$ I_3 \f$ of the stress tensor.
+     *
+     * @details Defined as the determinant of the Cauchy stress tensor \f$ \boldsymbol{\sigma} \f$:
+     * \f[
+     *   I_3 = \det(\boldsymbol{\sigma})
+     * \f]
+     * Expanded in Voigt notation:
+     * \f[
+     *   I_3 =
+     *     \sigma_{11}\sigma_{22}\sigma_{33}
+     *     + 2\sigma_{12}\sigma_{13}\sigma_{23}
+     *     - \sigma_{11}\sigma_{23}^2
+     *     - \sigma_{22}\sigma_{13}^2
+     *     - \sigma_{33}\sigma_{12}^2
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return Value of the third invariant \f$ I_3 \f$.
+     */
+    template < typename T >
+    T I3( const Eigen::Matrix< T, 6, 1 >& stress )
+    {
+      const Eigen::Matrix< T, 6, 1 >& s = stress;
+      return s( 0 ) * s( 1 ) * s( 2 ) + 2. * s( 3 ) * s( 4 ) * s( 5 ) - s( 0 ) * s( 5 ) * s( 5 ) -
+             s( 1 ) * s( 4 ) * s( 4 ) - s( 2 ) * s( 3 ) * s( 3 );
+    }
 
-      /**
-       * @brief Computes the principal stress directions corresponding to the principal stresses.
-       *
-       * @details This function solves the eigenvalue problem
-       * \f[
-       *   \left( \boldsymbol{\sigma} - \sigma_k \cdot \boldsymbol{I} \right) \cdot
-       *   \boldsymbol{x}^{(k)} = 0
-       * \f]
-       * to obtain the eigenvectors \f$ \boldsymbol{x}^{(k)} \f$ associated with
-       * the principal stresses \f$ \sigma_k \f$.
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return A 3x3 matrix whose columns are the principal stress directions (unsorted).
-       */
-      Eigen::Matrix3d principalStressesDirections( const Marmot::Vector6d& stress );
+    /**
+     * @brief Computes the third invariant \f$ I^{(\varepsilon)}_3 \f$ of the strain tensor.
+     *
+     * @details The third invariant is given by the determinant of the strain tensor:
+     * \f[
+     *   I^{(\varepsilon)}_3 = \det(\boldsymbol{\varepsilon})
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return Value of the third strain invariant \f$ I^{(\varepsilon)}_3 \f$.
+     */
+    double I3Strain( const Marmot::Vector6d& strain );
 
-      /**
-       * @brief Computes the equivalent von Mises stress.
-       *
-       * @details Defined as:
-       * \f[
-       *   \sigma_\text{eq} = \sqrt{3 \cdot J_2}
-       * \f]
-       * where \f$ J_2 \f$ is the second invariant of the deviatoric stress tensor
-       * (see `J2()`).
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return The von Mises equivalent stress.
-       */
-      double vonMisesEquivalentStress( const Marmot::Vector6d& stress );
+    /**
+     * @brief Computes the second invariant \f$ J_2 \f$ of the deviatoric stress tensor.
+     *
+     * @details For the deviatoric stress tensor \f$ \boldsymbol{s} \f$:
+     * \f[
+     *   J_2 = \tfrac{1}{3} I_1^2 - I_2
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return Value of the second deviatoric invariant \f$ J_2 \f$ (clamped to non-negative).
+     */
+    template < typename T >
+    T J2( const Eigen::Matrix< T, 6, 1 >& stress )
+    {
+      const T I1_ = I1( stress );
+      const T I2_ = I2( stress );
+      const T res = ( 1. / 3 ) * I1_ * I1_ - I2_;
+      return Marmot::Math::makeReal( res ) >= 0 ? res : T( 0.0 );
+    }
 
-      /**
-       * @brief Computes the equivalent von Mises strain.
-       *
-       * @details Based on the deviatoric strain tensor \f$ e_{ij} \f$:
-       * \f[
-       *   \varepsilon^\text{(eq)} = \sqrt{\tfrac{2}{3} \, e_{ij} e_{ij}}
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return The von Mises equivalent strain.
-       */
-      double vonMisesEquivalentStrain( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the second invariant \f$ J^{(\varepsilon)}_2 \f$ of the deviatoric strain tensor.
+     *
+     * @details For the deviatoric strain tensor \f$ \boldsymbol{e} \f$:
+     * \f[
+     *   J^{(\varepsilon)}_2 =
+     *     \tfrac{1}{3} \left(I^{(\varepsilon)}_1\right)^2
+     *     - I^{(\varepsilon)}_2
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return Value of the second deviatoric strain invariant \f$ J^{(\varepsilon)}_2 \f$.
+     */
+    double J2Strain( const Marmot::Vector6d& strain );
 
-      /**
-       * @brief Computes the Euclidean norm of the strain tensor.
-       *
-       * @details Defined as:
-       * \f[
-       *   ||\boldsymbol{\varepsilon}|| = \sqrt{ \varepsilon_{ij}\varepsilon_{ij}}
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return The Euclidean norm of the strain tensor.
-       */
-      template < typename T >
-      T normStrain( const Eigen::Matrix< T, 6, 1 >& strain )
-      {
-        return ContinuumMechanics::VoigtNotation::voigtToStrain( strain ).norm();
-      }
+    /**
+     * @brief Computes the third invariant \f$ J_3 \f$ of the deviatoric stress tensor.
+     *
+     * @details For the deviatoric stress tensor \f$ \boldsymbol{s} \f$:
+     * \f[
+     *   J_3 = \tfrac{2}{27} I_1^3 - \tfrac{1}{3} I_1 I_2 + I_3
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return Value of the third deviatoric stress invariant \f$ J_3 \f$.
+     */
+    template < typename T >
+    T J3( const Eigen::Matrix< T, 6, 1 >& stress )
+    {
+      const T I1_ = I1( stress );
+      const T I2_ = I2( stress );
+      const T I3_ = I3( stress );
 
-      /**
-       * @brief Computes the Euclidean norm of the stress tensor.
-       *
-       * @details Defined as:
-       * \f[
-       *   ||\boldsymbol{\sigma}|| = \sqrt{\sigma_{ij}\sigma_{ij}}
-       * \f]
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return The Euclidean norm of the stress tensor.
-       */
-      double normStress( const Marmot::Vector6d& stress );
-      // Trace of compressive strains
+      return ( 2. / 27 ) * pow( I1_, 3 ) - ( 1. / 3 ) * I1_ * I2_ + I3_;
+    }
 
-      /**
-       * @brief Computes the volumetric plastic strain in compression.
-       *
-       * @details Defined as:
-       * \f[
-       *   \varepsilon^{\text{vol}}_{\ominus}
-       *   = \sum_{i=1}^3 \left\langle -\varepsilon_i \right\rangle
-       * \f]
-       * where \f$ \varepsilon_i \f$ are the principal strains and
-       * \f$ \langle \bullet \rangle \f$ denotes the Macaulay brackets.
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return The volumetric compressive strain.
-       */
-      double StrainVolumetricNegative( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the third invariant \f$ J^{(\varepsilon)}_3 \f$ of the deviatoric strain tensor \f$
+     * \boldsymbol{e} \f$.
+     *
+     * The third invariant is obtained by reconstructing the strain tensor
+     * from Voigt notation and computing its determinant:
+     * \f[
+     *   J^{(\varepsilon)}_3 = \det(\boldsymbol{e})
+     * \f]
+     * @param strain 6-component strain vector in Voigt notation.
+     * @return Value of the third deviatoric strain invariant \f$ J^{(\varepsilon)}_3 \f$.
+     */
+    double J3Strain( const Marmot::Vector6d& strain );
 
-      /**
-       * @brief Computes the first invariant \f$ I_1 \f$ of the stress tensor.
-       *
-       * @details The first invariant of the stress tensor \f$ \boldsymbol{\sigma} \f$ is the trace:
-       * \f[
-       *   I_1 = \operatorname{tr}(\boldsymbol{\sigma})
-       *       = \sigma_{11} + \sigma_{22} + \sigma_{33}
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param stress 6-component stress vector in Voigt notation:
-       *   \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
-       *     \begin{bmatrix}
-       *       \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
-       *     \end{bmatrix}^T \f$
-       * @return Value of the first invariant \f$ I_1 \f$.
-       */
-      template < typename T >
-      T I1( const Eigen::Matrix< T, 6, 1 >& stress )
-      {
-        return stress( 0 ) + stress( 1 ) + stress( 2 );
-      }
+    /**
+     * @brief Computes principal values and their derivatives for a symmetric 3×3 matrix in Voigt notation.
+     *
+     * @details This routine implements a fast algorithm to compute the principal values
+     * (eigenvalues) of a symmetric second-order tensor in Voigt notation
+     * (off-diagonal entries are expected without the factor of 2).
+     * @param S 6-component symmetric matrix in Voigt notation.
+     * @return A pair consisting of:
+     *   - A vector containing the (unsorted) principal values.
+     *   - An \f$ 3 \times 6 \f$ matrix containing the derivatives of the
+     *     principal values with respect to the Voigt components of \f$ S \f$.
+     */
+    std::pair< Eigen::Vector3d, Eigen::Matrix< double, 3, 6 > > principalValuesAndDerivatives(
+      const Eigen::Matrix< double, 6, 1 >& S );
 
-      /**
-       * @brief Computes the first invariant \f$ I^{(\varepsilon)}_1 \f$ of the strain tensor.
-       *
-       * @details The first invariant of the strain tensor \f$ \boldsymbol{\varepsilon} \f$ is the trace:
-       * \f[
-       *   I^{(\varepsilon)}_1 = \operatorname{tr}(\boldsymbol{\varepsilon})
-       *       = \varepsilon_{11} + \varepsilon_{22} + \varepsilon_{33}
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation:
-       *   \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
-       *     \begin{bmatrix}
-       *       \varepsilon_{11} & \varepsilon_{22} & \varepsilon_{33} &
-       *       \gamma_{12} & \gamma_{13} & \gamma_{23}
-       *     \end{bmatrix}^T \f$
-       * @return Value of the first strain invariant \f$ I^{(\varepsilon)}_1 \f$.
-       */
-      double I1Strain( const Marmot::Vector6d& strain ); //
+  } // namespace Invariants
 
-      /**
-       * @brief Computes the second invariant \f$ I_2 \f$ of the stress tensor.
-       *
-       * @details The second invariant of the stress tensor \f$ \boldsymbol{\sigma} \f$ is defined as:
-       * \f[
-       *   I_2 = \tfrac{1}{2}\left( \operatorname{tr}(\boldsymbol{\sigma})^2
-       *         - \operatorname{tr}(\boldsymbol{\sigma}^2) \right)
-       * \f]
-       * In Voigt notation, this expands to:
-       * \f[
-       *   I_2 = \sigma_{11}\sigma_{22} + \sigma_{22}\sigma_{33} + \sigma_{33}\sigma_{11}
-       *         - \sigma_{12}^2 - \sigma_{13}^2 - \sigma_{23}^2
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param stress 6-component stress vector in Voigt notation:
-       *   \f$ \boldsymbol{\sigma}^{\text{Voigt}} =
-       *     \begin{bmatrix}
-       *       \sigma_{11} & \sigma_{22} & \sigma_{33} & \sigma_{12} & \sigma_{13} & \sigma_{23}
-       *     \end{bmatrix}^T \f$
-       *
-       * @return Value of the second invariant \f$ I_2 \f$.
-       */
-      template < typename T >
-      T I2( const Eigen::Matrix< T, 6, 1 >& stress )
-      {
-        const Eigen::Matrix< T, 6, 1 >& s = stress;
-        return s( 0 ) * s( 1 ) + s( 1 ) * s( 2 ) + s( 2 ) * s( 0 ) - s( 3 ) * s( 3 ) - s( 4 ) * s( 4 ) -
-               s( 5 ) * s( 5 );
-      }
+  namespace Derivatives {
 
-      /**
-       * @brief Computes the second invariant \f$ I^{(\varepsilon)}_2 \f$ of the strain tensor.
-       *
-       * @details For a strain tensor \f$ \boldsymbol{\varepsilon} \f$ in Voigt notation,
-       * the second invariant is:
-       * \f[
-       *   I^{(\varepsilon)}_2 =
-       *     \varepsilon_{11}\varepsilon_{22} +
-       *     \varepsilon_{22}\varepsilon_{33} +
-       *     \varepsilon_{33}\varepsilon_{11}
-       *     - \tfrac{1}{4}\left(\gamma_{12}^2 + \gamma_{13}^2 + \gamma_{23}^2\right)
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation:
-       *   \f$ \boldsymbol{\varepsilon}^{\text{Voigt}} =
-       *     [ \varepsilon_{11}, \varepsilon_{22}, \varepsilon_{33},
-       *       \gamma_{12}, \gamma_{13}, \gamma_{23} ]^T \f$
-       * @return Value of the second invariant \f$ I^{(\varepsilon)}_2 \f$.
-       */
-      double I2Strain( const Marmot::Vector6d& strain );
+    // derivatives of Haigh Westergaard stresses with respect to cauchy stress in eng. notation
 
-      /**
-       * @brief Computes the third invariant \f$ I_3 \f$ of the stress tensor.
-       *
-       * @details Defined as the determinant of the Cauchy stress tensor \f$ \boldsymbol{\sigma} \f$:
-       * \f[
-       *   I_3 = \det(\boldsymbol{\sigma})
-       * \f]
-       * Expanded in Voigt notation:
-       * \f[
-       *   I_3 =
-       *     \sigma_{11}\sigma_{22}\sigma_{33}
-       *     + 2\sigma_{12}\sigma_{13}\sigma_{23}
-       *     - \sigma_{11}\sigma_{23}^2
-       *     - \sigma_{22}\sigma_{13}^2
-       *     - \sigma_{33}\sigma_{12}^2
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return Value of the third invariant \f$ I_3 \f$.
-       */
-      template < typename T >
-      T I3( const Eigen::Matrix< T, 6, 1 >& stress )
-      {
-        const Eigen::Matrix< T, 6, 1 >& s = stress;
-        return s( 0 ) * s( 1 ) * s( 2 ) + 2. * s( 3 ) * s( 4 ) * s( 5 ) - s( 0 ) * s( 5 ) * s( 5 ) -
-               s( 1 ) * s( 4 ) * s( 4 ) - s( 2 ) * s( 3 ) * s( 3 );
-      }
+    /**
+     * @brief Computes the derivative of the mean stress with respect to the stress vector.
+     *
+     * \f[
+     *   \frac{\partial \sigma_m}{\partial \boldsymbol{\sigma}}
+     * \f]
+     * @return 6-component vector representing \f$ \tfrac{\partial \sigma_m}{\partial \boldsymbol{\sigma}} \f$
+     *         in Voigt notation.
+     */
+    Vector6d dStressMean_dStress();
 
-      /**
-       * @brief Computes the third invariant \f$ I^{(\varepsilon)}_3 \f$ of the strain tensor.
-       *
-       * @details The third invariant is given by the determinant of the strain tensor:
-       * \f[
-       *   I^{(\varepsilon)}_3 = \det(\boldsymbol{\varepsilon})
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return Value of the third strain invariant \f$ I^{(\varepsilon)}_3 \f$.
-       */
-      double I3Strain( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the derivative of the Haigh–Westergaard deviatoric radius \f$ \rho \f$
+     *        with respect to the stress vector.
+     *
+     * \f[
+     *   \frac{\partial \rho}{\partial \boldsymbol{\sigma}}
+     * \f]
+     * @tparam T Scalar type (e.g., double, float).
+     * @param rho Precomputed Haigh–Westergaard coordinate \f$ \rho \f$.
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return 6-component vector of partial derivatives
+     *         \f$ \tfrac{\partial \rho}{\partial \boldsymbol{\sigma}} \f$ in Voigt notation.
+     * @note Returns zero if \f$ \rho \leq 10^{-16} \f$ to avoid division by zero.
+     */
+    template < typename T >
+    Eigen::Matrix< T, 6, 1 > dRho_dStress( T rho, const Eigen::Matrix< T, 6, 1 >& stress )
+    {
+      if ( Marmot::Math::makeReal( rho ) <= 1e-16 )
+        return Eigen::Matrix< T, 6, 1 >::Zero();
 
-      /**
-       * @brief Computes the second invariant \f$ J_2 \f$ of the deviatoric stress tensor.
-       *
-       * @details For the deviatoric stress tensor \f$ \boldsymbol{s} \f$:
-       * \f[
-       *   J_2 = \tfrac{1}{3} I_1^2 - I_2
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return Value of the second deviatoric invariant \f$ J_2 \f$ (clamped to non-negative).
-       */
-      template < typename T >
-      T J2( const Eigen::Matrix< T, 6, 1 >& stress )
-      {
-        const T I1_ = I1( stress );
-        const T I2_ = I2( stress );
-        const T res = ( 1. / 3 ) * I1_ * I1_ - I2_;
-        return Marmot::Math::makeReal( res ) >= 0 ? res : T( 0.0 );
-      }
+      Eigen::Matrix< T, 6, 1 > s = IDev * stress;
+      // P array results from the derivative of the double contraction s:s in voigt notation
+      return T( 1. / rho ) * P.array() * s.array();
+    }
+    /**
+     * Computes the derivative \f$ \frac{d\, \varepsilon_\rho}{d\, \boldsymbol{\varepsilon}}\f$ of the haigh
+     * westergaard coordinate \f$
+     * \strain_\rho \f$ with respect to the voigt notated strain vector \f$ \boldsymbol{\varepsilon} \f$
+     */
+    template < typename T >
+    Eigen::Matrix< T, 6, 1 > dRhoStrain_dStrain( T rhoStrain, const Eigen::Matrix< T, 6, 1 >& strain )
+    {
+      if ( Marmot::Math::makeReal( rhoStrain ) <= 1e-16 )
+        return Eigen::Matrix< T, 6, 1 >::Zero();
 
-      /**
-       * @brief Computes the second invariant \f$ J^{(\varepsilon)}_2 \f$ of the deviatoric strain tensor.
-       *
-       * @details For the deviatoric strain tensor \f$ \boldsymbol{e} \f$:
-       * \f[
-       *   J^{(\varepsilon)}_2 =
-       *     \tfrac{1}{3} \left(I^{(\varepsilon)}_1\right)^2
-       *     - I^{(\varepsilon)}_2
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return Value of the second deviatoric strain invariant \f$ J^{(\varepsilon)}_2 \f$.
-       */
-      double J2Strain( const Marmot::Vector6d& strain );
+      Eigen::Matrix< T, 6, 1 > e = IDev * strain;
+      // P array results from the derivative of the double contraction e:e in voigt notation
+      return T( 1. / rhoStrain ) * PInv.array() * e.array();
+    }
 
-      /**
-       * @brief Computes the third invariant \f$ J_3 \f$ of the deviatoric stress tensor.
-       *
-       * @details For the deviatoric stress tensor \f$ \boldsymbol{s} \f$:
-       * \f[
-       *   J_3 = \tfrac{2}{27} I_1^3 - \tfrac{1}{3} I_1 I_2 + I_3
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return Value of the third deviatoric stress invariant \f$ J_3 \f$.
-       */
-      template < typename T >
-      T J3( const Eigen::Matrix< T, 6, 1 >& stress )
-      {
-        const T I1_ = I1( stress );
-        const T I2_ = I2( stress );
-        const T I3_ = I3( stress );
+    /**
+     * @brief Computes the derivative of the lode angle \f$ \theta \f$
+     *        with respect to the stress vector.
+     *
+     * @param theta Lode angle \f$ \theta \f$.
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return 6-component vector of partial derivatives
+     *         \f$ \tfrac{\partial \theta}{\partial \boldsymbol{\sigma}} \f$ in Voigt notation.
+     * @note Returns zero if \f$ \theta \leq 10^{-15} \f$ or if \f$ \theta \geq \frac{\pi}{3} - 10^{-15} \f$.
+     */
+    Marmot::Vector6d dTheta_dStress( double theta, const Marmot::Vector6d& stress );
 
-        return ( 2. / 27 ) * pow( I1_, 3 ) - ( 1. / 3 ) * I1_ * I2_ + I3_;
-      }
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \theta}{\partial J_2}\f$ of the lode angle \f$ \theta
+     * \f$ with respect to the second deviatoric invariant \f$ J_2 \f$.
+     * @param stress 6-component stress vector in Voigt notation.
+     * @return Scalar derivative \f$ \tfrac{\partial \theta}{\partial J_2} \f$.
+     */
+    double dTheta_dJ2( const Marmot::Vector6d& stress );
 
-      /**
-       * @brief Computes the third invariant \f$ J^{(\varepsilon)}_3 \f$ of the deviatoric strain tensor \f$
-       * \boldsymbol{e} \f$.
-       *
-       * The third invariant is obtained by reconstructing the strain tensor
-       * from Voigt notation and computing its determinant:
-       * \f[
-       *   J^{(\varepsilon)}_3 = \det(\boldsymbol{e})
-       * \f]
-       * @param strain 6-component strain vector in Voigt notation.
-       * @return Value of the third deviatoric strain invariant \f$ J^{(\varepsilon)}_3 \f$.
-       */
-      double J3Strain( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \theta}{\partial J_3}\f$ of the Lode angle
+     * \f$ \theta \f$ with respect to the third deviatoric invariant \f$ J_3 \f$.
+     *
+     * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
+     * @return Value of the derivative \f$ \frac{\partial \theta}{\partial J_3} \f$.
+     */
+    double dTheta_dJ3( const Marmot::Vector6d& stress );
 
-      /**
-       * @brief Computes principal values and their derivatives for a symmetric 3×3 matrix in Voigt notation.
-       *
-       * @details This routine implements a fast algorithm to compute the principal values
-       * (eigenvalues) of a symmetric second-order tensor in Voigt notation
-       * (off-diagonal entries are expected without the factor of 2).
-       * @param S 6-component symmetric matrix in Voigt notation.
-       * @return A pair consisting of:
-       *   - A vector containing the (unsorted) principal values.
-       *   - An \f$ 3 \times 6 \f$ matrix containing the derivatives of the
-       *     principal values with respect to the Voigt components of \f$ S \f$.
-       */
-      std::pair< Eigen::Vector3d, Eigen::Matrix< double, 3, 6 > > principalValuesAndDerivatives(
-        const Eigen::Matrix< double, 6, 1 >& S );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_2}\f$ of
+     * the Lode angle in strain space \f$ \theta^{(\varepsilon)} \f$ with respect to the second deviatoric invariant
+     * \f$ J^{(\varepsilon)}_2 \f$.
+     *
+     * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
+     * @return Value of the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_2} \f$.
+     */
+    double dThetaStrain_dJ2Strain( const Marmot::Vector6d& strain );
 
-    } // namespace Invariants
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_3}\f$ of
+     * the Lode angle in strain space \f$ \theta^{(\varepsilon)} \f$ with respect to the third deviatoric invariant
+     * \f$ J^{(\varepsilon)}_3 \f$.
+     *
+     * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
+     * @return Value of the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_3} \f$.
+     */
+    double dThetaStrain_dJ3Strain( const Marmot::Vector6d& strain );
 
-    namespace Derivatives {
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial J_2}{\partial \boldsymbol{\sigma}}\f$ of the second
+     * deviatoric invariant \f$ J_2 \f$ with respect to the stress vector in Voigt notation.
+     *
+     * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
+     * @return Vector of partial derivatives \f$ \frac{\partial J_2}{\partial \boldsymbol{\sigma}} \f$ in Voigt
+     * notation.
+     */
+    Marmot::Vector6d dJ2_dStress( const Marmot::Vector6d& stress );
 
-      // derivatives of Haigh Westergaard stresses with respect to cauchy stress in eng. notation
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial J_3}{\partial \boldsymbol{\sigma}}\f$ of the third deviatoric
+     * invariant \f$ J_3 \f$ with respect to the stress vector in Voigt notation.
+     *
+     * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
+     * @return Vector of partial derivatives \f$ \frac{\partial J_3}{\partial \boldsymbol{\sigma}} \f$ in Voigt
+     * notation.
+     */
+    Marmot::Vector6d dJ3_dStress( const Marmot::Vector6d& stress );
 
-      /**
-       * @brief Computes the derivative of the mean stress with respect to the stress vector.
-       *
-       * \f[
-       *   \frac{\partial \sigma_m}{\partial \boldsymbol{\sigma}}
-       * \f]
-       * @return 6-component vector representing \f$ \tfrac{\partial \sigma_m}{\partial \boldsymbol{\sigma}} \f$
-       *         in Voigt notation.
-       */
-      Vector6d dStressMean_dStress();
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial J^{(\varepsilon)}_2}{\partial \boldsymbol{\varepsilon}} \f$
+     * of the second deviatoric invariant \f$ J^{(\varepsilon)}_2 \f$ with respect to the strain vector in Voigt
+     * notation.
+     *
+     * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
+     * @return Vector of partial derivatives \f$ \frac{\partial J^{(\varepsilon)}_2}{\partial
+     * \boldsymbol{\varepsilon}} \f$ in Voigt notation.
+     */
+    Marmot::Vector6d dJ2Strain_dStrain( const Marmot::Vector6d& strain );
 
-      /**
-       * @brief Computes the derivative of the Haigh–Westergaard deviatoric radius \f$ \rho \f$
-       *        with respect to the stress vector.
-       *
-       * \f[
-       *   \frac{\partial \rho}{\partial \boldsymbol{\sigma}}
-       * \f]
-       * @tparam T Scalar type (e.g., double, float).
-       * @param rho Precomputed Haigh–Westergaard coordinate \f$ \rho \f$.
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return 6-component vector of partial derivatives
-       *         \f$ \tfrac{\partial \rho}{\partial \boldsymbol{\sigma}} \f$ in Voigt notation.
-       * @note Returns zero if \f$ \rho \leq 10^{-16} \f$ to avoid division by zero.
-       */
-      template < typename T >
-      Eigen::Matrix< T, 6, 1 > dRho_dStress( T rho, const Eigen::Matrix< T, 6, 1 >& stress )
-      {
-        if ( Marmot::Math::makeReal( rho ) <= 1e-16 )
-          return Eigen::Matrix< T, 6, 1 >::Zero();
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial J^{(\varepsilon)}_3}{\partial \boldsymbol{\varepsilon}} \f$
+     * of the third deviatoric invariant \f$ J^{(\varepsilon)}_3 \f$ with respect to the strain vector in Voigt
+     * notation.
+     *
+     * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
+     * @return Vector of partial derivatives \f$ \frac{\partial J^{(\varepsilon)}_3}{\partial
+     * \boldsymbol{\varepsilon}} \f$ in Voigt notation.
+     */
+    Marmot::Vector6d dJ3Strain_dStrain( const Marmot::Vector6d& strain );
 
-        Eigen::Matrix< T, 6, 1 > s = IDev * stress;
-        // P array results from the derivative of the double contraction s:s in voigt notation
-        return T( 1. / rho ) * P.array() * s.array();
-      }
-      /**
-       * Computes the derivative \f$ \frac{d\, \varepsilon_\rho}{d\, \boldsymbol{\varepsilon}}\f$ of the haigh
-       * westergaard coordinate \f$
-       * \strain_\rho \f$ with respect to the voigt notated strain vector \f$ \boldsymbol{\varepsilon} \f$
-       */
-      template < typename T >
-      Eigen::Matrix< T, 6, 1 > dRhoStrain_dStrain( T rhoStrain, const Eigen::Matrix< T, 6, 1 >& strain )
-      {
-        if ( Marmot::Math::makeReal( rhoStrain ) <= 1e-16 )
-          return Eigen::Matrix< T, 6, 1 >::Zero();
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial \boldsymbol{\varepsilon}}
+     * \f$ of the Lode angle in strain space \f$ \theta^{(\varepsilon)} \f$ with respect to the strain vector in Voigt
+     * notation.
+     *
+     * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
+     * @return Vector of partial derivatives \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial
+     * \boldsymbol{\varepsilon}} \f$ in Voigt notation.
+     */
+    Marmot::Vector6d dThetaStrain_dStrain( const Marmot::Vector6d& strain );
 
-        Eigen::Matrix< T, 6, 1 > e = IDev * strain;
-        // P array results from the derivative of the double contraction e:e in voigt notation
-        return T( 1. / rhoStrain ) * PInv.array() * e.array();
-      }
+    // derivatives of principalStess with respect to stress
 
-      /**
-       * @brief Computes the derivative of the lode angle \f$ \theta \f$
-       *        with respect to the stress vector.
-       *
-       * @param theta Lode angle \f$ \theta \f$.
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return 6-component vector of partial derivatives
-       *         \f$ \tfrac{\partial \theta}{\partial \boldsymbol{\sigma}} \f$ in Voigt notation.
-       * @note Returns zero if \f$ \theta \leq 10^{-15} \f$ or if \f$ \theta \geq \frac{\pi}{3} - 10^{-15} \f$.
-       */
-      Marmot::Vector6d dTheta_dStress( double theta, const Marmot::Vector6d& stress );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \sigma_I}{\partial \boldsymbol{\sigma}} \f$ of the principal
+     * stresses
+     * \f$ \sigma_I \f$ with respect to the stress vector in Voigt notation.
+     *
+     * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
+     * @return Matrix of partial derivatives \f$ \frac{\partial \sigma_I}{\partial \boldsymbol{\sigma}} \f$,
+     * where each row corresponds to the gradient of one principal stress with respect to \f$ \boldsymbol{\sigma} \f$.
+     */
+    Marmot::Matrix36 dStressPrincipals_dStress( const Marmot::Vector6d& stress );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \theta}{\partial J_2}\f$ of the lode angle \f$ \theta
-       * \f$ with respect to the second deviatoric invariant \f$ J_2 \f$.
-       * @param stress 6-component stress vector in Voigt notation.
-       * @return Scalar derivative \f$ \tfrac{\partial \theta}{\partial J_2} \f$.
-       */
-      double dTheta_dJ2( const Marmot::Vector6d& stress );
+    // derivatives of plastic strains with respect to strains
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \theta}{\partial J_3}\f$ of the Lode angle
-       * \f$ \theta \f$ with respect to the third deviatoric invariant \f$ J_3 \f$.
-       *
-       * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
-       * @return Value of the derivative \f$ \frac{\partial \theta}{\partial J_3} \f$.
-       */
-      double dTheta_dJ3( const Marmot::Vector6d& stress );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \varepsilon^{vol}_{\ominus}}{\partial \varepsilon_I} \f$ of
+     * the volumetric compressive strain \f$ \varepsilon^{vol}_{\ominus} \f$ with respect to the principal strains
+     * \f$ \varepsilon_I \f$.
+     *
+     * @param strain Principal/total strain provided in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$), 6
+     * components.
+     * @return A 3-component vector (\f$ \partial \varepsilon^{vol}_{\ominus} / \partial \varepsilon_I \f$), where
+     * each entry is the partial derivative of the corresponding volumetric-compressive component with respect to the
+     * principal strains \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$.
+     */
+    Eigen::Vector3d dStrainVolumetricNegative_dStrainPrincipal( const Marmot::Vector6d& strain );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_2}\f$ of
-       * the Lode angle in strain space \f$ \theta^{(\varepsilon)} \f$ with respect to the second deviatoric invariant
-       * \f$ J^{(\varepsilon)}_2 \f$.
-       *
-       * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
-       * @return Value of the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_2} \f$.
-       */
-      double dThetaStrain_dJ2Strain( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \boldsymbol{\varepsilon}^{p}}{\partial
+     * \boldsymbol{\varepsilon}} \f$ of the Voigt-notated plastic strain vector \f$ \boldsymbol{\varepsilon}^{p} \f$
+     * with respect to the Voigt-notated total strain vector \f$ \boldsymbol{\varepsilon} \f$.
+     *
+     * @details The relation used is
+     * \f[
+     *   \frac{\partial \boldsymbol{\varepsilon}^{p}}{\partial \boldsymbol{\varepsilon}}
+     *   \;=\; \boldsymbol{I} \;-\; \mathbb{C}^{-1}\,\mathbb{C}^{(ep)}
+     * \f]
+     * where \f$ \mathbb{C}^{-1} \f$ is the elastic compliance (6×6) and \f$ \mathbb{C}^{(ep)} \f$ the elastoplastic
+     * stiffness (6×6).
+     * @param CelInv Elastic compliance tensor \f$ \mathbb{C}^{-1} \f$ (6×6 matrix).
+     * @param Cep Elastoplastic stiffness tensor \f$ \mathbb{C}^{(ep)} \f$ (6×6 matrix).
+     * @return 6×6 matrix \f$ \partial \boldsymbol{\varepsilon}^{p} / \partial \boldsymbol{\varepsilon} \f$ in Voigt
+     * form.
+     */
+    Matrix6d dEp_dE( const Matrix6d& CelInv, const Matrix6d& Cep );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_3}\f$ of
-       * the Lode angle in strain space \f$ \theta^{(\varepsilon)} \f$ with respect to the third deviatoric invariant
-       * \f$ J^{(\varepsilon)}_3 \f$.
-       *
-       * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
-       * @return Value of the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial J^{(\varepsilon)}_3} \f$.
-       */
-      double dThetaStrain_dJ3Strain( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \Delta \varepsilon^{p,vol}}{\partial
+     * \boldsymbol{\varepsilon}} \f$ of the volumetric plastic strain increment \f$ \Delta \varepsilon^{p,vol} \f$
+     * with respect to the Voigt-notated total strain vector \f$ \boldsymbol{\varepsilon} \f$.
+     *
+     * @param CelInv Elastic compliance tensor \f$ \mathbb{C}^{-1} \f$ (6×6 matrix).
+     * @param Cep Elastoplastic stiffness tensor \f$ \mathbb{C}^{(ep)} \f$ (6×6 matrix).
+     * @return Row vector (1×6) containing \f$ \partial \Delta \varepsilon^{p,vol} / \partial \boldsymbol{\varepsilon}
+     * \f$ in Voigt notation.
+     */
+    RowVector6d dDeltaEpv_dE( const Matrix6d& CelInv, const Matrix6d& Cep );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial J_2}{\partial \boldsymbol{\sigma}}\f$ of the second
-       * deviatoric invariant \f$ J_2 \f$ with respect to the stress vector in Voigt notation.
-       *
-       * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
-       * @return Vector of partial derivatives \f$ \frac{\partial J_2}{\partial \boldsymbol{\sigma}} \f$ in Voigt
-       * notation.
-       */
-      Marmot::Vector6d dJ2_dStress( const Marmot::Vector6d& stress );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \varepsilon_I}{\partial \boldsymbol{\varepsilon}} \f$ of the
+     * principal strains \f$ \varepsilon_I \f$ with respect to the Voigt-notated strain vector \f$
+     * \boldsymbol{\varepsilon} \f$.
+     *
+     * @param dEp Input strain vector in Voigt notation (6 components).
+     * @return A 3×6 matrix where each row contains the partial derivatives of one principal strain
+     * \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$ with respect to the 6 Voigt strain components.
+     */
+    Marmot::Matrix36 dSortedStrainPrincipal_dStrain( const Marmot::Vector6d& dEp );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial J_3}{\partial \boldsymbol{\sigma}}\f$ of the third deviatoric
-       * invariant \f$ J_3 \f$ with respect to the stress vector in Voigt notation.
-       *
-       * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
-       * @return Vector of partial derivatives \f$ \frac{\partial J_3}{\partial \boldsymbol{\sigma}} \f$ in Voigt
-       * notation.
-       */
-      Marmot::Vector6d dJ3_dStress( const Marmot::Vector6d& stress );
+    /**
+     * @brief Computes the derivative \f$ \frac{\partial \Delta \varepsilon^{p,vol}_{\ominus}}
+     * {\partial \boldsymbol{\varepsilon}} \f$ of the volumetric plastic strain increment in compression
+     * \f$ \Delta \varepsilon^{p,vol}_{\ominus} \f$ with respect to the strain vector in Voigt notation
+     * \f$ \boldsymbol{\varepsilon} \f$.
+     *
+     * @param dEp Incremental plastic strain vector in Voigt notation (\f$\Delta\boldsymbol{\varepsilon^{p}} \f$), 6
+     * components.
+     * @param CelInv Elastic compliance tensor \f$ \mathbb{C}^{-1} \f$ (6×6 matrix).
+     * @param Cep Elastoplastic stiffness tensor \f$ \mathbb{C}^{(ep)} \f$ (6×6 matrix).
+     * @return Row vector (1×6) containing
+     * \f$ \partial \Delta \varepsilon^{p,vol}_{\ominus} / \partial \boldsymbol{\varepsilon} \f$
+     * in Voigt notation.
+     */
+    RowVector6d dDeltaEpvneg_dE( const Marmot::Vector6d& dEp, const Matrix6d& CelInv, const Matrix6d& Cep );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial J^{(\varepsilon)}_2}{\partial \boldsymbol{\varepsilon}} \f$
-       * of the second deviatoric invariant \f$ J^{(\varepsilon)}_2 \f$ with respect to the strain vector in Voigt
-       * notation.
-       *
-       * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
-       * @return Vector of partial derivatives \f$ \frac{\partial J^{(\varepsilon)}_2}{\partial
-       * \boldsymbol{\varepsilon}} \f$ in Voigt notation.
-       */
-      Marmot::Vector6d dJ2Strain_dStrain( const Marmot::Vector6d& strain );
+  } // namespace Derivatives
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial J^{(\varepsilon)}_3}{\partial \boldsymbol{\varepsilon}} \f$
-       * of the third deviatoric invariant \f$ J^{(\varepsilon)}_3 \f$ with respect to the strain vector in Voigt
-       * notation.
-       *
-       * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
-       * @return Vector of partial derivatives \f$ \frac{\partial J^{(\varepsilon)}_3}{\partial
-       * \boldsymbol{\varepsilon}} \f$ in Voigt notation.
-       */
-      Marmot::Vector6d dJ3Strain_dStrain( const Marmot::Vector6d& strain );
+  namespace Transformations {
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial \boldsymbol{\varepsilon}}
-       * \f$ of the Lode angle in strain space \f$ \theta^{(\varepsilon)} \f$ with respect to the strain vector in Voigt
-       * notation.
-       *
-       * @param strain Strain vector in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$).
-       * @return Vector of partial derivatives \f$ \frac{\partial \theta^{(\varepsilon)}}{\partial
-       * \boldsymbol{\varepsilon}} \f$ in Voigt notation.
-       */
-      Marmot::Vector6d dThetaStrain_dStrain( const Marmot::Vector6d& strain );
+    /**
+     * @brief Computes the transformation matrix \f$ T_{\varepsilon} \f$ to rotate a strain vector in Voigt notation
+     * into another Cartesian coordinate system.
+     *
+     * @details This function modifies the stress transformation matrix \f$T_{\varepsilon}\f$ to account for the
+     * engineering shear convention used for strains in Voigt notation. Specifically:
+     * - The upper-right 3×3 block is scaled by 0.5
+     * - The lower-left 3×3 block is scaled by 2
+     *
+     * This function builds the 6×6 transformation matrix from the direction cosines of the new basis:
+     * \f[
+     *   \boldsymbol{\varepsilon}'_{\text{voigt}} \;=\; T_{\varepsilon}\,\boldsymbol{\varepsilon}_{\text{voigt}}.
+     * \f]
+     * which is equivalent to the tensor transformation
+     * \f[
+     *   \boldsymbol{\varepsilon}' \;=\; \boldsymbol{Q}\,\boldsymbol{\varepsilon}\,\boldsymbol{Q}^{T}
+     * \f]
+     * @param transformedCoordinateSystem 3×3 rotation matrix \f$\boldsymbol{Q}\f$ that maps from
+     * the original to the target Cartesian basis.
+     * @return 6×6 transformation matrix \f$T_{\varepsilon}\f$ that transforms strain vectors in Voigt notation.
+     */
+    Matrix6d transformationMatrixStrainVoigt( const Matrix3d& transformedCoordinateSystem );
 
-      // derivatives of principalStess with respect to stress
+    /**
+     * @brief Computes the transformation matrix \f$ T_{\sigma} \f$ to rotate a stress vector in Voigt notation
+     * into another Cartesian coordinate system.
+     * @details This function builds the 6×6 transformation matrix from the direction cosines of the new basis:
+     * \f[
+     *   \boldsymbol{\sigma}'_{\text{voigt}} \;=\; T_{\sigma}\,\boldsymbol{\sigma}_{\text{voigt}},
+     * \f]
+     * which is equivalent to the tensor transformation
+     * \f[
+     *   \boldsymbol{\sigma}' \;=\; \boldsymbol{Q}\,\boldsymbol{\sigma}\,\boldsymbol{Q}^{T}.
+     * \f]
+     * @param transformedCoordinateSystem 3×3 rotation matrix \f$\boldsymbol{Q}\f$ that maps from
+     * the original to the target Cartesian basis.
+     * @return 6×6 transformation matrix \f$T_{\sigma}\f$ that transforms stress vectors in Voigt notation.
+     */
+    Matrix6d transformationMatrixStressVoigt( const Matrix3d& transformedCoordinateSystem );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \sigma_I}{\partial \boldsymbol{\sigma}} \f$ of the principal
-       * stresses
-       * \f$ \sigma_I \f$ with respect to the stress vector in Voigt notation.
-       *
-       * @param stress Stress vector in Voigt notation (\f$ \boldsymbol{\sigma} \f$).
-       * @return Matrix of partial derivatives \f$ \frac{\partial \sigma_I}{\partial \boldsymbol{\sigma}} \f$,
-       * where each row corresponds to the gradient of one principal stress with respect to \f$ \boldsymbol{\sigma} \f$.
-       */
-      Marmot::Matrix36 dStressPrincipals_dStress( const Marmot::Vector6d& stress );
+    /**
+     * @brief Calculates the projection matrix for mapping Voigt stress to a traction vector.
+     * @details This function returns the \f$3 \times 6\f$ projection matrix \f$\mathbf{P}^{(\mathbf{n})}\f$
+     * that maps a **Voigt-notated stress vector** \f$\boldsymbol{\sigma}_{\text{voigt}} \in \mathbb{R}^6\f$
+     * to the **traction vector** \f$\mathbf{t}^{(\mathbf{n})} \in \mathbb{R}^3\f$ on a plane with
+     * an outward unit normal vector \f$\mathbf{n}\f$.
+     * The relationship is given by:
+     * \f[
+     * \mathbf{t}^{(\mathbf{n})} = \mathbf{P}^{(\mathbf{n})} \, \boldsymbol{\sigma}_{\text{voigt}}.
+     * \f]
+     * This expression is mathematically equivalent to Cauchy's formula \f$ \boldsymbol{t}^{(n)}_i =
+     * \sigma_{ji} \, n_j \f$.
+     * @param normalVector The \f$3 \times 1\f$ **unit vector** \f$\mathbf{n}\f$ representing the **normal**
+     * of the plane.
+     * @return The \f$3 \times 6\f$ projection matrix \f$\mathbf{P}^{(\mathbf{n})}\f$.
+     */
+    Matrix36d projectVoigtStressToPlane( const Vector3d& normalVector );
 
-      // derivatives of plastic strains with respect to strains
+    /**
+     * @brief Calculates the projection matrix for mapping a Voigt strain vector to the strain on a plane.
+     * @details This function is similar to `projectVoigtStressToPlane` but for **strains** in voigt notation. For
+     * more details, see the documentation of `projectVoigtStressToPlane`.
+     * @param normalVector The \f$3 \times 1\f$ **unit vector** \f$\mathbf{n}\f$ representing the **normal**
+     * of the plane.
+     * @return The \f$3 \times 6\f$ projection matrix \f$\mathbf{P}^{(\mathbf{n})}\f$.
+     */
+    Matrix36d projectVoigtStrainToPlane( const Vector3d& normalVector );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \varepsilon^{vol}_{\ominus}}{\partial \varepsilon_I} \f$ of
-       * the volumetric compressive strain \f$ \varepsilon^{vol}_{\ominus} \f$ with respect to the principal strains
-       * \f$ \varepsilon_I \f$.
-       *
-       * @param strain Principal/total strain provided in Voigt notation (\f$ \boldsymbol{\varepsilon} \f$), 6
-       * components.
-       * @return A 3-component vector (\f$ \partial \varepsilon^{vol}_{\ominus} / \partial \varepsilon_I \f$), where
-       * each entry is the partial derivative of the corresponding volumetric-compressive component with respect to the
-       * principal strains \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$.
-       */
-      Eigen::Vector3d dStrainVolumetricNegative_dStrainPrincipal( const Marmot::Vector6d& strain );
+    /**
+     * @brief Rotates a stress tensor in Voigt notation.
+     * @details This function rotates a stress tensor \f$ \boldsymbol{\sigma} \f$ using a rotation matrix
+     * \f$ \boldsymbol{Q} \f$, while keeping the tensor in **Voigt notation**.
+     * The rotated stress \f$ \boldsymbol{\sigma}^{\prime} \f$ is computed as:
+     * \f[
+     * \boldsymbol{\sigma}^{\prime} = \boldsymbol{Q} \, \boldsymbol{\sigma} \, \boldsymbol{Q}^{T}.
+     * \f]
+     * @param Q A \f$3 \times 3\f$ rotation matrix \f$ \boldsymbol{Q} \f$.
+     * @param stress A Voigt-notated stress vector \f$ \boldsymbol{\sigma} \in \mathbb{R}^6 \f$.
+     * @return The rotated Voigt-notated stress vector \f$ \boldsymbol{\sigma}^{\prime} \in \mathbb{R}^6 \f$.
+     */
+    Marmot::Vector6d rotateVoigtStress( const Eigen::Matrix3d& Q, const Marmot::Vector6d& stress );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \boldsymbol{\varepsilon}^{p}}{\partial
-       * \boldsymbol{\varepsilon}} \f$ of the Voigt-notated plastic strain vector \f$ \boldsymbol{\varepsilon}^{p} \f$
-       * with respect to the Voigt-notated total strain vector \f$ \boldsymbol{\varepsilon} \f$.
-       *
-       * @details The relation used is
-       * \f[
-       *   \frac{\partial \boldsymbol{\varepsilon}^{p}}{\partial \boldsymbol{\varepsilon}}
-       *   \;=\; \boldsymbol{I} \;-\; \mathbb{C}^{-1}\,\mathbb{C}^{(ep)}
-       * \f]
-       * where \f$ \mathbb{C}^{-1} \f$ is the elastic compliance (6×6) and \f$ \mathbb{C}^{(ep)} \f$ the elastoplastic
-       * stiffness (6×6).
-       * @param CelInv Elastic compliance tensor \f$ \mathbb{C}^{-1} \f$ (6×6 matrix).
-       * @param Cep Elastoplastic stiffness tensor \f$ \mathbb{C}^{(ep)} \f$ (6×6 matrix).
-       * @return 6×6 matrix \f$ \partial \boldsymbol{\varepsilon}^{p} / \partial \boldsymbol{\varepsilon} \f$ in Voigt
-       * form.
-       */
-      Matrix6d dEp_dE( const Matrix6d& CelInv, const Matrix6d& Cep );
+    /**
+     * @brief Transforms a stress tensor in Voigt notation from the global to a local coordinate system.
+     * @param stress The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
+     * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
+     * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
+     * @return The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
+     * @details The transformation convention used is: \f$ \boldsymbol{\sigma}_{\text{local}} = Q^T \,
+     * \boldsymbol{\sigma}_{\text{global}} \, Q \f$, where \f$ Q \f$ is the transformation matrix.
+     */
+    Marmot::Vector6d transformStressToLocalSystem( const Marmot::Vector6d& stress,
+                                                   const Matrix3d&         transformedCoordinateSystem );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \Delta \varepsilon^{p,vol}}{\partial
-       * \boldsymbol{\varepsilon}} \f$ of the volumetric plastic strain increment \f$ \Delta \varepsilon^{p,vol} \f$
-       * with respect to the Voigt-notated total strain vector \f$ \boldsymbol{\varepsilon} \f$.
-       *
-       * @param CelInv Elastic compliance tensor \f$ \mathbb{C}^{-1} \f$ (6×6 matrix).
-       * @param Cep Elastoplastic stiffness tensor \f$ \mathbb{C}^{(ep)} \f$ (6×6 matrix).
-       * @return Row vector (1×6) containing \f$ \partial \Delta \varepsilon^{p,vol} / \partial \boldsymbol{\varepsilon}
-       * \f$ in Voigt notation.
-       */
-      RowVector6d dDeltaEpv_dE( const Matrix6d& CelInv, const Matrix6d& Cep );
+    /**
+     * @brief Transforms a strain tensor in Voigt notation from the global to a local coordinate system.
+     * @param stress The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
+     * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
+     * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
+     * @return The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
+     * @details The transformation convention used is: \f$ \boldsymbol{\varepsilon}_{\text{local}} = Q^T \,
+     * \boldsymbol{\varepsilon}_{\text{global}} \, Q \f$, where \f$ Q \f$ is the transformation matrix.
+     */
+    Marmot::Vector6d transformStrainToLocalSystem( const Marmot::Vector6d& stress,
+                                                   const Matrix3d&         transformedCoordinateSystem );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \varepsilon_I}{\partial \boldsymbol{\varepsilon}} \f$ of the
-       * principal strains \f$ \varepsilon_I \f$ with respect to the Voigt-notated strain vector \f$
-       * \boldsymbol{\varepsilon} \f$.
-       *
-       * @param dEp Input strain vector in Voigt notation (6 components).
-       * @return A 3×6 matrix where each row contains the partial derivatives of one principal strain
-       * \f$ \varepsilon_1, \varepsilon_2, \varepsilon_3 \f$ with respect to the 6 Voigt strain components.
-       */
-      Marmot::Matrix36 dSortedStrainPrincipal_dStrain( const Marmot::Vector6d& dEp );
+    /**
+     * @brief Transforms a stress tensor in Voigt notation from a local to the global coordinate system.
+     * @param stress The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
+     * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
+     * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
+     * @return The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
+     * @details The transformation convention used is: \f$ \boldsymbol{\sigma}_{\text{global}} = Q \,
+     * \boldsymbol{\sigma}_{\text{local}} \, Q^T \f$, where \f$ Q \f$ is the transformation matrix.
+     */
+    Marmot::Vector6d transformStressToGlobalSystem( const Marmot::Vector6d& stress,
+                                                    const Matrix3d&         transformedCoordinateSystem );
 
-      /**
-       * @brief Computes the derivative \f$ \frac{\partial \Delta \varepsilon^{p,vol}_{\ominus}}
-       * {\partial \boldsymbol{\varepsilon}} \f$ of the volumetric plastic strain increment in compression
-       * \f$ \Delta \varepsilon^{p,vol}_{\ominus} \f$ with respect to the strain vector in Voigt notation
-       * \f$ \boldsymbol{\varepsilon} \f$.
-       *
-       * @param dEp Incremental plastic strain vector in Voigt notation (\f$\Delta\boldsymbol{\varepsilon^{p}} \f$), 6
-       * components.
-       * @param CelInv Elastic compliance tensor \f$ \mathbb{C}^{-1} \f$ (6×6 matrix).
-       * @param Cep Elastoplastic stiffness tensor \f$ \mathbb{C}^{(ep)} \f$ (6×6 matrix).
-       * @return Row vector (1×6) containing
-       * \f$ \partial \Delta \varepsilon^{p,vol}_{\ominus} / \partial \boldsymbol{\varepsilon} \f$
-       * in Voigt notation.
-       */
-      RowVector6d dDeltaEpvneg_dE( const Marmot::Vector6d& dEp, const Matrix6d& CelInv, const Matrix6d& Cep );
+    /**
+     * @brief Transforms a strain tensor in Voigt notation from a local to the global coordinate system.
+     * @param stress The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
+     * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
+     * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
+     * @return The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
+     * @details The transformation convention used is: \f$ \boldsymbol{\varepsilon}_{\text{global}} = Q \,
+     * \boldsymbol{\varepsilon}_{\text{local}} \, Q^T \f$, where \f$ Q \f$ is the transformation matrix.
+     */
+    Marmot::Vector6d transformStrainToGlobalSystem( const Marmot::Vector6d& stress,
+                                                    const Matrix3d&         transformedCoordinateSystem );
 
-    } // namespace Derivatives
+    /**
+     * @brief Transforms a stiffness tensor in Voigt notation from a local to the global coordinate system.
+     * @param stiffness The stiffness tensor in Voigt notation (\f$ \mathbb{R}^{6 \times 6} \f$) in the local system.
+     * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
+     * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
+     * @return The stiffness tensor in Voigt notation (\f$ \mathbb{R}^{6 \times 6} \f$) in the global system.
+     * @details The transformation convention used is: \f$ \mathbf{C}_{\text{global}} = T \, \mathbf{C}_{\text{local}}
+     * \, T^T \f$, where \f$ T \f$ is the transformation matrix derived from \f$ Q \f$.
+     */
+    Marmot::Matrix6d transformStiffnessToGlobalSystem( const Marmot::Matrix6d& stiffness,
+                                                       const Matrix3d&         transformedCoordinateSystem );
 
-    namespace Transformations {
+  } // namespace Transformations
 
-      /**
-       * @brief Computes the transformation matrix \f$ T_{\varepsilon} \f$ to rotate a strain vector in Voigt notation
-       * into another Cartesian coordinate system.
-       *
-       * @details This function modifies the stress transformation matrix \f$T_{\varepsilon}\f$ to account for the
-       * engineering shear convention used for strains in Voigt notation. Specifically:
-       * - The upper-right 3×3 block is scaled by 0.5
-       * - The lower-left 3×3 block is scaled by 2
-       *
-       * This function builds the 6×6 transformation matrix from the direction cosines of the new basis:
-       * \f[
-       *   \boldsymbol{\varepsilon}'_{\text{voigt}} \;=\; T_{\varepsilon}\,\boldsymbol{\varepsilon}_{\text{voigt}}.
-       * \f]
-       * which is equivalent to the tensor transformation
-       * \f[
-       *   \boldsymbol{\varepsilon}' \;=\; \boldsymbol{Q}\,\boldsymbol{\varepsilon}\,\boldsymbol{Q}^{T}
-       * \f]
-       * @param transformedCoordinateSystem 3×3 rotation matrix \f$\boldsymbol{Q}\f$ that maps from
-       * the original to the target Cartesian basis.
-       * @return 6×6 transformation matrix \f$T_{\varepsilon}\f$ that transforms strain vectors in Voigt notation.
-       */
-      Matrix6d transformationMatrixStrainVoigt( const Matrix3d& transformedCoordinateSystem );
-
-      /**
-       * @brief Computes the transformation matrix \f$ T_{\sigma} \f$ to rotate a stress vector in Voigt notation
-       * into another Cartesian coordinate system.
-       * @details This function builds the 6×6 transformation matrix from the direction cosines of the new basis:
-       * \f[
-       *   \boldsymbol{\sigma}'_{\text{voigt}} \;=\; T_{\sigma}\,\boldsymbol{\sigma}_{\text{voigt}},
-       * \f]
-       * which is equivalent to the tensor transformation
-       * \f[
-       *   \boldsymbol{\sigma}' \;=\; \boldsymbol{Q}\,\boldsymbol{\sigma}\,\boldsymbol{Q}^{T}.
-       * \f]
-       * @param transformedCoordinateSystem 3×3 rotation matrix \f$\boldsymbol{Q}\f$ that maps from
-       * the original to the target Cartesian basis.
-       * @return 6×6 transformation matrix \f$T_{\sigma}\f$ that transforms stress vectors in Voigt notation.
-       */
-      Matrix6d transformationMatrixStressVoigt( const Matrix3d& transformedCoordinateSystem );
-
-      /**
-       * @brief Calculates the projection matrix for mapping Voigt stress to a traction vector.
-       * @details This function returns the \f$3 \times 6\f$ projection matrix \f$\mathbf{P}^{(\mathbf{n})}\f$
-       * that maps a **Voigt-notated stress vector** \f$\boldsymbol{\sigma}_{\text{voigt}} \in \mathbb{R}^6\f$
-       * to the **traction vector** \f$\mathbf{t}^{(\mathbf{n})} \in \mathbb{R}^3\f$ on a plane with
-       * an outward unit normal vector \f$\mathbf{n}\f$.
-       * The relationship is given by:
-       * \f[
-       * \mathbf{t}^{(\mathbf{n})} = \mathbf{P}^{(\mathbf{n})} \, \boldsymbol{\sigma}_{\text{voigt}}.
-       * \f]
-       * This expression is mathematically equivalent to Cauchy's formula \f$ \boldsymbol{t}^{(n)}_i =
-       * \sigma_{ji} \, n_j \f$.
-       * @param normalVector The \f$3 \times 1\f$ **unit vector** \f$\mathbf{n}\f$ representing the **normal**
-       * of the plane.
-       * @return The \f$3 \times 6\f$ projection matrix \f$\mathbf{P}^{(\mathbf{n})}\f$.
-       */
-      Matrix36d projectVoigtStressToPlane( const Vector3d& normalVector );
-
-      /**
-       * @brief Calculates the projection matrix for mapping a Voigt strain vector to the strain on a plane.
-       * @details This function is similar to `projectVoigtStressToPlane` but for **strains** in voigt notation. For
-       * more details, see the documentation of `projectVoigtStressToPlane`.
-       * @param normalVector The \f$3 \times 1\f$ **unit vector** \f$\mathbf{n}\f$ representing the **normal**
-       * of the plane.
-       * @return The \f$3 \times 6\f$ projection matrix \f$\mathbf{P}^{(\mathbf{n})}\f$.
-       */
-      Matrix36d projectVoigtStrainToPlane( const Vector3d& normalVector );
-
-      /**
-       * @brief Rotates a stress tensor in Voigt notation.
-       * @details This function rotates a stress tensor \f$ \boldsymbol{\sigma} \f$ using a rotation matrix
-       * \f$ \boldsymbol{Q} \f$, while keeping the tensor in **Voigt notation**.
-       * The rotated stress \f$ \boldsymbol{\sigma}^{\prime} \f$ is computed as:
-       * \f[
-       * \boldsymbol{\sigma}^{\prime} = \boldsymbol{Q} \, \boldsymbol{\sigma} \, \boldsymbol{Q}^{T}.
-       * \f]
-       * @param Q A \f$3 \times 3\f$ rotation matrix \f$ \boldsymbol{Q} \f$.
-       * @param stress A Voigt-notated stress vector \f$ \boldsymbol{\sigma} \in \mathbb{R}^6 \f$.
-       * @return The rotated Voigt-notated stress vector \f$ \boldsymbol{\sigma}^{\prime} \in \mathbb{R}^6 \f$.
-       */
-      Marmot::Vector6d rotateVoigtStress( const Eigen::Matrix3d& Q, const Marmot::Vector6d& stress );
-
-      /**
-       * @brief Transforms a stress tensor in Voigt notation from the global to a local coordinate system.
-       * @param stress The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
-       * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
-       * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
-       * @return The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
-       * @details The transformation convention used is: \f$ \boldsymbol{\sigma}_{\text{local}} = Q^T \,
-       * \boldsymbol{\sigma}_{\text{global}} \, Q \f$, where \f$ Q \f$ is the transformation matrix.
-       */
-      Marmot::Vector6d transformStressToLocalSystem( const Marmot::Vector6d& stress,
-                                                     const Matrix3d&         transformedCoordinateSystem );
-
-      /**
-       * @brief Transforms a strain tensor in Voigt notation from the global to a local coordinate system.
-       * @param stress The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
-       * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
-       * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
-       * @return The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
-       * @details The transformation convention used is: \f$ \boldsymbol{\varepsilon}_{\text{local}} = Q^T \,
-       * \boldsymbol{\varepsilon}_{\text{global}} \, Q \f$, where \f$ Q \f$ is the transformation matrix.
-       */
-      Marmot::Vector6d transformStrainToLocalSystem( const Marmot::Vector6d& stress,
-                                                     const Matrix3d&         transformedCoordinateSystem );
-
-      /**
-       * @brief Transforms a stress tensor in Voigt notation from a local to the global coordinate system.
-       * @param stress The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
-       * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
-       * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
-       * @return The stress tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
-       * @details The transformation convention used is: \f$ \boldsymbol{\sigma}_{\text{global}} = Q \,
-       * \boldsymbol{\sigma}_{\text{local}} \, Q^T \f$, where \f$ Q \f$ is the transformation matrix.
-       */
-      Marmot::Vector6d transformStressToGlobalSystem( const Marmot::Vector6d& stress,
-                                                      const Matrix3d&         transformedCoordinateSystem );
-
-      /**
-       * @brief Transforms a strain tensor in Voigt notation from a local to the global coordinate system.
-       * @param stress The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the local system.
-       * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
-       * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
-       * @return The strain tensor in Voigt notation (\f$ \mathbb{R}^6 \f$) in the global system.
-       * @details The transformation convention used is: \f$ \boldsymbol{\varepsilon}_{\text{global}} = Q \,
-       * \boldsymbol{\varepsilon}_{\text{local}} \, Q^T \f$, where \f$ Q \f$ is the transformation matrix.
-       */
-      Marmot::Vector6d transformStrainToGlobalSystem( const Marmot::Vector6d& stress,
-                                                      const Matrix3d&         transformedCoordinateSystem );
-
-      /**
-       * @brief Transforms a stiffness tensor in Voigt notation from a local to the global coordinate system.
-       * @param stiffness The stiffness tensor in Voigt notation (\f$ \mathbb{R}^{6 \times 6} \f$) in the local system.
-       * @param transformedCoordinateSystem A \f$3 \times 3\f$ orthonormal matrix whose columns are the axes of the
-       * local coordinate system expressed in the global system. Typically, this is a rotation matrix.
-       * @return The stiffness tensor in Voigt notation (\f$ \mathbb{R}^{6 \times 6} \f$) in the global system.
-       * @details The transformation convention used is: \f$ \mathbf{C}_{\text{global}} = T \, \mathbf{C}_{\text{local}}
-       * \, T^T \f$, where \f$ T \f$ is the transformation matrix derived from \f$ Q \f$.
-       */
-      Marmot::Matrix6d transformStiffnessToGlobalSystem( const Marmot::Matrix6d& stiffness,
-                                                         const Matrix3d&         transformedCoordinateSystem );
-
-    } // namespace Transformations
-
-  }   // namespace ContinuumMechanics::VoigtNotation
-} // namespace Marmot
+} // namespace Marmot::ContinuumMechanics::VoigtNotation

--- a/modules/core/MarmotMechanicsCore/include/Marmot/MenetreyWillam.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/MenetreyWillam.h
@@ -27,28 +27,27 @@
 #include "Marmot/HaighWestergaard.h"
 #include <utility>
 
-namespace Marmot {
-  namespace ContinuumMechanics::CommonConstitutiveModels {
+namespace Marmot::ContinuumMechanics::CommonConstitutiveModels {
 
-    /**
-     * \brief Generalized failure criterion proposed by Menétrey and Willam
-     *
-     * Implementation of the generalized failure criterion proposed by Menétrey and Willam
-     *
-     * \f[
-     *  f(\xi,\rho,\theta) = \left(A_f\,\rho\right)^2+m\left(B_f\,\rho\,r(\theta,e)+C_f\,\xi\right) - 1
-     * \f]
-     *
-     * with the Haigh-Westergaard coordinates \f$\xi,\,\rho,\,\theta\f$ and the parameters \f$A_f,\,B_f,\,C_f,\,m,\,e\f$
-     * which are automatically evaluated dependent on the desired formulation (supported types see \ref
-     * MenetreyWillamType).
-     *
-     * # Example
-     *
-     * For a given pair of principal stress components in the Haigh-Westergaard stress space, evaluate the Mohr-Coulomb
-     * failure criterion:
-     */
-    // clang-format off
+  /**
+   * \brief Generalized failure criterion proposed by Menétrey and Willam
+   *
+   * Implementation of the generalized failure criterion proposed by Menétrey and Willam
+   *
+   * \f[
+   *  f(\xi,\rho,\theta) = \left(A_f\,\rho\right)^2+m\left(B_f\,\rho\,r(\theta,e)+C_f\,\xi\right) - 1
+   * \f]
+   *
+   * with the Haigh-Westergaard coordinates \f$\xi,\,\rho,\,\theta\f$ and the parameters \f$A_f,\,B_f,\,C_f,\,m,\,e\f$
+   * which are automatically evaluated dependent on the desired formulation (supported types see \ref
+   * MenetreyWillamType).
+   *
+   * # Example
+   *
+   * For a given pair of principal stress components in the Haigh-Westergaard stress space, evaluate the Mohr-Coulomb
+   * failure criterion:
+   */
+  // clang-format off
      /**
      * @code
      * #include <Marmot/MenetreyWillam.h>
@@ -69,304 +68,303 @@ namespace Marmot {
      * }
      * @endcode
      */
-    // clang-format on
-    class MenetreyWillam {
-    public:
-      /**
-       * Aggregate of the parameters for the generalized strength criterion
-       * proposed by Menétrey and Willam.
-       */
-      struct MenetreyWillamParameters {
-        double Af; /**< additional parameter to capture the influence of the
-                      deviatoric stress invariant \f$\rho\f$ */
-        double Bf; /**< addditional parameter to capture the influence of the
-                      deviatoric stress invariant \f$\rho\f$ and the lode angle */
-        double Cf; /**< addditional parameter to capture the influence of the
-                      hydrostatic stress invariant \f$\xi\f$ */
-        double m;  /**< Friction parameter \f$m\f$ */
-        double e;  /**< Eccentricity parameter \f$e\f$; to obtain a smooth and
-                      convex surface $e$ has to be in the range of \f$0.5\leq e
-                      \leq 1\f$ */
-      } param;     ///< Menetrey Willam parameters
+  // clang-format on
+  class MenetreyWillam {
+  public:
+    /**
+     * Aggregate of the parameters for the generalized strength criterion
+     * proposed by Menétrey and Willam.
+     */
+    struct MenetreyWillamParameters {
+      double Af; /**< additional parameter to capture the influence of the
+                    deviatoric stress invariant \f$\rho\f$ */
+      double Bf; /**< addditional parameter to capture the influence of the
+                    deviatoric stress invariant \f$\rho\f$ and the lode angle */
+      double Cf; /**< addditional parameter to capture the influence of the
+                    hydrostatic stress invariant \f$\xi\f$ */
+      double m;  /**< Friction parameter \f$m\f$ */
+      double e;  /**< Eccentricity parameter \f$e\f$; to obtain a smooth and
+                    convex surface $e$ has to be in the range of \f$0.5\leq e
+                    \leq 1\f$ */
+    } param;     ///< Menetrey Willam parameters
 
-      /// @brief Reduction of the generalized failure criterion to a specific type.
-      enum class MenetreyWillamType {
-        Mises,         /**< von-Mises failure criterion; only the tensile strength @ref
-                          ft has to be specified. */
-        Rankine,       /**< Rankine failure criterion; only the tensile strength @ref
-                          ft has to be specified. \note In deviatoric sections, compared to the original Rankine criterion the
-                          vertices are slightly rounded (specified by the eccentricity parameter \f$e\f$). */
-        DruckerPrager, /**< Drucker-Prager failure criterion; both the tensile
-                          strength @ref ft as well as the compressive strength
-                          @ref fc have to be specified. */
-        MohrCoulomb    /**< Drucker-Prager failure criterion; both the tensile
-                          strength @ref ft as well as the compressive strength @ref
-                          fc have to be specified. \note In deviatoric sections, compared to the original Mohr-Coulomb
-                          criterion the vertices are slightly rounded (specified by the eccentricity parameter \f$e\f$). */
-      };
-
-      /**
-       * Constructor that takes the uniaxial tensile strength \f$f_t\f$ and two
-       * optional arguments consisting of the specific type of failure criterion \ref MenetreyWillamType
-       * and the uniaxial compressive strength \f$f_c\f$. The call of the
-       * constructor automatically fills the corresponding Menetrey-Willam \c param.
-       */
-      MenetreyWillam( const double              ft,
-                      const MenetreyWillamType& type = MenetreyWillamType::Rankine,
-                      const double              fc   = 0 );
-
-      /**
-       * This function can be used to reset the type of the specified failure
-       * criterion by entering the uniaxial compressive strength \c fc, the uniaxial tensile strength \c ft
-       * and the \ref MenetreyWillamType.
-       */
-      void setParameters( const double ft, const double fc, const MenetreyWillamType& type );
-
-      /**
-       * Compute the polar radius \f$r\f$ from the Lode angle \f$\theta\f$. The
-       * eccentricity parameter will be used from the chosen Menetrey-Willam parameters \c param.
-       */
-      template < typename T >
-      T polarRadius( const double& theta ) const
-      {
-        return polarRadius( theta, param.e );
-      }
-
-      /**
-       * Static version for computing the polar radius \f$r\f$ from the Lode angle
-       * \f$\theta\f$ and a specified value for the eccentricity parameter
-       * \f$e\f$.
-       */
-      template < typename T >
-      static T polarRadius( const T& theta, const double& e )
-      {
-        // computes the deviatoric shape roundness for a given eccentricity (e) at a certain
-        // position (theta) the numerator and denominator are stored for performance reasons, as
-        // they are also needed for the derivative dRdTheta
-        if ( e >= 1.0 )
-          return 1;
-
-        const double e2        = e * e;
-        const T      cosTheta  = cos( theta );
-        const T      cos2Theta = cosTheta * cosTheta;
-
-        const T numerator   = ( 4. * ( 1. - e2 ) * cos2Theta + ( 2. * e - 1. ) * ( 2. * e - 1. ) );
-        const T denominator = ( 2. * ( 1. - e2 ) * cosTheta +
-                                ( 2. * e - 1. ) * sqrt( 4. * ( 1. - e2 ) * cos2Theta + 5. * e2 - 4. * e ) );
-
-        const T r = numerator / denominator;
-
-        return r;
-      }
-      /**
-       * Compute the polar radius \f$r\f$ and its derivative
-       * \f$\frac{dr}{d\theta}\f$ from the Lode angle \f$\theta\f$. The
-       * eccentricity parameter will be used from the \c param struct.
-       */
-      template < typename T >
-      std::pair< T, T > dPolarRadius_dTheta( const T& theta ) const
-      {
-        return dPolarRadius_dTheta( theta, param.e );
-      }
-
-      /**
-       * Static version for computing the polar radius \f$r$\f$  and its
-       * derivative \f$\frac{dr}{d\theta}\f$ from the Lode angle \f$\theta\f$
-       * and a specified value for the eccentricity parameter \f$e\f$.
-       */
-      template < typename T >
-      static std::pair< T, T > dPolarRadius_dTheta( const T& theta, const double& e )
-      {
-        //
-        // computes the deviatoric shape roundness for a given eccentricity (e) at a certain
-        // position (theta) the numerator and denominator are stored for performance reasons, as
-        // they are also needed for the derivative dRdTheta
-        T r, dRdTheta;
-
-        if ( e >= 1.0 ) {
-          r        = 1;
-          dRdTheta = 0;
-          return std::make_pair( r, dRdTheta );
-        }
-
-        const double e2        = e * e;
-        const T      cosTheta  = cos( theta );
-        const T      cos2Theta = cosTheta * cosTheta;
-
-        T numerator   = ( 4. * ( 1. - e2 ) * cos2Theta + ( 2. * e - 1. ) * ( 2. * e - 1. ) );
-        T denominator = ( 2. * ( 1. - e2 ) * cosTheta +
-                          ( 2. * e - 1. ) * sqrt( 4. * ( 1. - e2 ) * cos2Theta + 5. * e2 - 4. * e ) );
-
-        r = numerator / denominator;
-
-        // compute the derivative
-        const T sinTheta = sin( theta );
-
-        const T a          = numerator;
-        const T b          = 1. / denominator;
-        const T aux        = 4. * ( 1. - e2 ) * cos2Theta + 5. * e2 - 4. * e;
-        const T dAuxdTheta = 4. * ( 1. - e2 ) * 2. * cosTheta * -sinTheta;
-        const T dadTheta   = 2. * cosTheta * ( -sinTheta ) * 4. * ( 1. - e2 );
-        const T dbdTheta   = -pow( denominator, -2. ) * ( 2. * ( 1. - e2 ) * -sinTheta +
-                                                        ( 2. * e - 1 ) * 1. / 2 * pow( aux, -1. / 2 ) * dAuxdTheta );
-        dRdTheta           = b * dadTheta + a * dbdTheta;
-
-        return { r, dRdTheta };
-      }
-
-      /**
-       * @brief Compute the polar radius and its first and second derivative with respect to the Lode angle
-       * @tparam T scalar type
-       * @param theta Lode angle
-       * @param e eccentricity parameter
-       * @return tuple of polar radius, its first and second derivative with respect to the Lode angle
-       */
-      template < typename T >
-      static std::tuple< T, T, T > d2PolarRadius_dTheta2( const T& theta, const double& e )
-      {
-
-        const auto [r, dr_dTheta] = dPolarRadius_dTheta< T >( theta, e );
-        if ( e >= 1.0 ) {
-          return { r, dr_dTheta, 0 };
-        }
-
-        const double e2   = pow( e, 2 );
-        const double e2m1 = e2 - 1;
-        const double tem1 = 2 * e - 1;
-
-        const T cos_theta   = cos( theta );
-        const T sin_theta   = sin( theta );
-        const T cos_2_theta = cos_theta * cos_theta;
-        const T sin_2_theta = sin_theta * sin_theta;
-
-        const T x      = 5. * e2 - 4. * e - 4. * e2m1 * cos_2_theta;
-        const T sqrt_x = sqrt( x );
-
-        const T one_over_sqrt_x = 1. / sqrt_x;
-
-        const T d2r_dTheta2 = e2m1 *
-                              ( -16. * e2m1 * ( 4.0 * tem1 * one_over_sqrt_x * cos_theta + 2. ) * sin_2_theta *
-                                  cos_theta / ( tem1 * sqrt_x - 2 * e2m1 * cos_theta ) -
-                                8. * sin_2_theta + 8. * cos_2_theta +
-                                ( pow( 2. * e - 1., 2 ) - 4 * e2m1 * cos_2_theta ) *
-                                  ( 16.0 * tem1 * e2m1 * pow( x, -1.5 ) * sin_2_theta * cos_2_theta +
-                                    4.0 * tem1 * one_over_sqrt_x * sin_2_theta -
-                                    4.0 * tem1 * one_over_sqrt_x * cos_2_theta +
-                                    e2m1 * ( 4.0 * tem1 * one_over_sqrt_x * cos_theta + 2. ) *
-                                      ( 8.0 * tem1 * one_over_sqrt_x * cos_theta + 4. ) * sin_2_theta /
-                                      ( tem1 * sqrt_x - 2. * e2m1 * cos_theta ) -
-                                    2. * cos_theta ) /
-                                  ( tem1 * sqrt_x - 2. * e2m1 * cos_theta ) ) /
-                              ( tem1 * sqrt_x - 2. * e2m1 * cos_theta );
-
-        return { r, dr_dTheta, d2r_dTheta2 };
-      }
-
-      /**
-       * Evaluate the yield function \f$f\f$ depending on the Haigh-Westergaard stress
-       * coordinates @p hw. \f$f<0\f$ means no yielding while \f$f\geq0\f$ means
-       * yielding. When the optional fillet parameter @p varEps is given, a potential vertex
-       * along the hydrostatic axis is rounded and thus a smooth failure criterion is obtained.
-       *
-       * \note The yield function can be also used as plastic potential function if needed.
-       */
-      template < typename T >
-      T yieldFunction( const ContinuumMechanics::HaighWestergaard::HaighWestergaardCoordinates< T >& hw,
-                       const double varEps = 0.0 ) const
-      {
-        const T r_ = polarRadius( hw.theta, param.e );
-        if ( varEps == 0 )
-          return ( param.Af * hw.rho ) * ( param.Af * hw.rho ) +
-                 param.m * ( param.Bf * hw.rho * r_ + param.Cf * hw.xi ) - 1.;
-        else
-          return param.Af * param.Af * hw.rho * hw.rho +
-                 param.m *
-                   ( sqrt( param.Bf * hw.rho * r_ * param.Bf * hw.rho * r_ + varEps * varEps ) + param.Cf * hw.xi ) -
-                 1.;
-      }
-
-      /**
-       * Evaluate the derivatives of the yield function with respect to the
-       * Haigh-Westergaard stress coordinates, i.e.
-       * \f$df/d\xi,\,df/d\rho,\,df/d\theta\f$. When the optional fillet parameter @p varEps is given, a potential
-       * vertex along the hydrostatic axis is rounded. Thus, a smooth failure criterion is obtained, where derivatives
-       * can be calculated uniquely.
-       */
-      template < typename T >
-      std::tuple< T, T, T > dYieldFunction_dHaighWestergaard(
-        const ContinuumMechanics::HaighWestergaard::HaighWestergaardCoordinates< T >& hw,
-        const double                                                                  varEps = 0.0 ) const
-      {
-        const auto [r_, dRdTheta_] = dPolarRadius_dTheta( hw.theta, param.e );
-
-        T dFdXi, dFdRho, dFdTheta;
-        dFdXi = param.m * param.Cf;
-
-        if ( varEps == 0.0 ) {
-          dFdRho   = 2. * param.Af * hw.rho * param.Af + param.m * param.Bf * r_;
-          dFdTheta = param.m * param.Bf * hw.rho * dRdTheta_;
-        }
-        else {
-          const T auxTerm1 = param.m * 0.5 *
-                             pow( param.Bf * param.Bf * hw.rho * hw.rho * r_ * r_ + varEps * varEps, -0.5 ) * 2 *
-                             param.Bf * hw.rho * r_ * param.Bf;
-
-          dFdRho   = param.Af * param.Af * 2. * hw.rho + auxTerm1 * r_;
-          dFdTheta = auxTerm1 * hw.rho * dRdTheta_;
-        }
-
-        return { dFdXi, dFdRho, dFdTheta };
-      }
-
-      /**
-       * Compute a fillet parameter for the vertex of the yield surface along the hydrostatic axis in the same way as
-       * Abaqus does. This parameter is only relevant in the case of the Drucker-Prager or the Mohr-Coulomb criterion.
-       * The calculated smoothing value can then be used as the optional input argument @p varEps in \ref
-       * yieldFunction and \ref dYieldFunction_dHaighWestergaard.
-       */
-      static inline double abaqusMohrCoulombPotentialVarEpsToMenetreyWillam( const double varEps, const double psi )
-      {
-        return varEps * 2 * std::sin( psi );
-      }
-
-      /**
-       * Compute the eccentricity parameter based on a given compressive strength \c fc and
-       * tensile strength \c ft.
-       */
-      static inline double e( const double fc, const double ft ) { return ( fc + 2 * ft ) / ( 2 * fc + ft ); }
-
-      /**
-       * Compute the cohesion based on a given compressive strength \c fc and
-       * tensile strength \c ft.
-       */
-      static inline double c( const double fc, const double ft )
-      {
-        const double phi_ = phi( fc, ft );
-        return ft / 2. * ( 1 + std::sin( phi_ ) ) / ( std::cos( phi_ ) );
-      }
-
-      /**
-       * Compute the friction angle in radian based on a given compressive strength \c fc and
-       * tensile strength \c ft.
-       */
-      static inline double phi( const double fc, const double ft ) { return std::asin( ( fc - ft ) / ( fc + ft ) ); }
-
-      /**
-       * Compute the tensile strength based on a given cohesion \c c and a friction angle \c phi.
-       */
-      static inline double ft( const double c, const double phi )
-      {
-        return 2 * c * std::cos( phi ) / ( 1 + std::sin( phi ) );
-      }
-
-      /**
-       * Compute the compressive strength based on a given cohesion \c c and a friction angle \c phi.
-       */
-      static inline double fc( const double c, const double phi )
-      {
-        return 2 * c * std::cos( phi ) / ( 1 - std::sin( phi ) );
-      }
+    /// @brief Reduction of the generalized failure criterion to a specific type.
+    enum class MenetreyWillamType {
+      Mises,         /**< von-Mises failure criterion; only the tensile strength @ref
+                        ft has to be specified. */
+      Rankine,       /**< Rankine failure criterion; only the tensile strength @ref
+                        ft has to be specified. \note In deviatoric sections, compared to the original Rankine criterion the
+                        vertices are slightly rounded (specified by the eccentricity parameter \f$e\f$). */
+      DruckerPrager, /**< Drucker-Prager failure criterion; both the tensile
+                        strength @ref ft as well as the compressive strength
+                        @ref fc have to be specified. */
+      MohrCoulomb    /**< Drucker-Prager failure criterion; both the tensile
+                        strength @ref ft as well as the compressive strength @ref
+                        fc have to be specified. \note In deviatoric sections, compared to the original Mohr-Coulomb
+                        criterion the vertices are slightly rounded (specified by the eccentricity parameter \f$e\f$). */
     };
 
-  } // namespace ContinuumMechanics::CommonConstitutiveModels
-} // namespace Marmot
+    /**
+     * Constructor that takes the uniaxial tensile strength \f$f_t\f$ and two
+     * optional arguments consisting of the specific type of failure criterion \ref MenetreyWillamType
+     * and the uniaxial compressive strength \f$f_c\f$. The call of the
+     * constructor automatically fills the corresponding Menetrey-Willam \c param.
+     */
+    MenetreyWillam( const double              ft,
+                    const MenetreyWillamType& type = MenetreyWillamType::Rankine,
+                    const double              fc   = 0 );
+
+    /**
+     * This function can be used to reset the type of the specified failure
+     * criterion by entering the uniaxial compressive strength \c fc, the uniaxial tensile strength \c ft
+     * and the \ref MenetreyWillamType.
+     */
+    void setParameters( const double ft, const double fc, const MenetreyWillamType& type );
+
+    /**
+     * Compute the polar radius \f$r\f$ from the Lode angle \f$\theta\f$. The
+     * eccentricity parameter will be used from the chosen Menetrey-Willam parameters \c param.
+     */
+    template < typename T >
+    T polarRadius( const double& theta ) const
+    {
+      return polarRadius( theta, param.e );
+    }
+
+    /**
+     * Static version for computing the polar radius \f$r\f$ from the Lode angle
+     * \f$\theta\f$ and a specified value for the eccentricity parameter
+     * \f$e\f$.
+     */
+    template < typename T >
+    static T polarRadius( const T& theta, const double& e )
+    {
+      // computes the deviatoric shape roundness for a given eccentricity (e) at a certain
+      // position (theta) the numerator and denominator are stored for performance reasons, as
+      // they are also needed for the derivative dRdTheta
+      if ( e >= 1.0 )
+        return 1;
+
+      const double e2        = e * e;
+      const T      cosTheta  = cos( theta );
+      const T      cos2Theta = cosTheta * cosTheta;
+
+      const T numerator   = ( 4. * ( 1. - e2 ) * cos2Theta + ( 2. * e - 1. ) * ( 2. * e - 1. ) );
+      const T denominator = ( 2. * ( 1. - e2 ) * cosTheta +
+                              ( 2. * e - 1. ) * sqrt( 4. * ( 1. - e2 ) * cos2Theta + 5. * e2 - 4. * e ) );
+
+      const T r = numerator / denominator;
+
+      return r;
+    }
+    /**
+     * Compute the polar radius \f$r\f$ and its derivative
+     * \f$\frac{dr}{d\theta}\f$ from the Lode angle \f$\theta\f$. The
+     * eccentricity parameter will be used from the \c param struct.
+     */
+    template < typename T >
+    std::pair< T, T > dPolarRadius_dTheta( const T& theta ) const
+    {
+      return dPolarRadius_dTheta( theta, param.e );
+    }
+
+    /**
+     * Static version for computing the polar radius \f$r$\f$  and its
+     * derivative \f$\frac{dr}{d\theta}\f$ from the Lode angle \f$\theta\f$
+     * and a specified value for the eccentricity parameter \f$e\f$.
+     */
+    template < typename T >
+    static std::pair< T, T > dPolarRadius_dTheta( const T& theta, const double& e )
+    {
+      //
+      // computes the deviatoric shape roundness for a given eccentricity (e) at a certain
+      // position (theta) the numerator and denominator are stored for performance reasons, as
+      // they are also needed for the derivative dRdTheta
+      T r, dRdTheta;
+
+      if ( e >= 1.0 ) {
+        r        = 1;
+        dRdTheta = 0;
+        return std::make_pair( r, dRdTheta );
+      }
+
+      const double e2        = e * e;
+      const T      cosTheta  = cos( theta );
+      const T      cos2Theta = cosTheta * cosTheta;
+
+      T numerator   = ( 4. * ( 1. - e2 ) * cos2Theta + ( 2. * e - 1. ) * ( 2. * e - 1. ) );
+      T denominator = ( 2. * ( 1. - e2 ) * cosTheta +
+                        ( 2. * e - 1. ) * sqrt( 4. * ( 1. - e2 ) * cos2Theta + 5. * e2 - 4. * e ) );
+
+      r = numerator / denominator;
+
+      // compute the derivative
+      const T sinTheta = sin( theta );
+
+      const T a          = numerator;
+      const T b          = 1. / denominator;
+      const T aux        = 4. * ( 1. - e2 ) * cos2Theta + 5. * e2 - 4. * e;
+      const T dAuxdTheta = 4. * ( 1. - e2 ) * 2. * cosTheta * -sinTheta;
+      const T dadTheta   = 2. * cosTheta * ( -sinTheta ) * 4. * ( 1. - e2 );
+      const T dbdTheta   = -pow( denominator, -2. ) *
+                         ( 2. * ( 1. - e2 ) * -sinTheta + ( 2. * e - 1 ) * 1. / 2 * pow( aux, -1. / 2 ) * dAuxdTheta );
+      dRdTheta = b * dadTheta + a * dbdTheta;
+
+      return { r, dRdTheta };
+    }
+
+    /**
+     * @brief Compute the polar radius and its first and second derivative with respect to the Lode angle
+     * @tparam T scalar type
+     * @param theta Lode angle
+     * @param e eccentricity parameter
+     * @return tuple of polar radius, its first and second derivative with respect to the Lode angle
+     */
+    template < typename T >
+    static std::tuple< T, T, T > d2PolarRadius_dTheta2( const T& theta, const double& e )
+    {
+
+      const auto [r, dr_dTheta] = dPolarRadius_dTheta< T >( theta, e );
+      if ( e >= 1.0 ) {
+        return { r, dr_dTheta, 0 };
+      }
+
+      const double e2   = pow( e, 2 );
+      const double e2m1 = e2 - 1;
+      const double tem1 = 2 * e - 1;
+
+      const T cos_theta   = cos( theta );
+      const T sin_theta   = sin( theta );
+      const T cos_2_theta = cos_theta * cos_theta;
+      const T sin_2_theta = sin_theta * sin_theta;
+
+      const T x      = 5. * e2 - 4. * e - 4. * e2m1 * cos_2_theta;
+      const T sqrt_x = sqrt( x );
+
+      const T one_over_sqrt_x = 1. / sqrt_x;
+
+      const T d2r_dTheta2 = e2m1 *
+                            ( -16. * e2m1 * ( 4.0 * tem1 * one_over_sqrt_x * cos_theta + 2. ) * sin_2_theta *
+                                cos_theta / ( tem1 * sqrt_x - 2 * e2m1 * cos_theta ) -
+                              8. * sin_2_theta + 8. * cos_2_theta +
+                              ( pow( 2. * e - 1., 2 ) - 4 * e2m1 * cos_2_theta ) *
+                                ( 16.0 * tem1 * e2m1 * pow( x, -1.5 ) * sin_2_theta * cos_2_theta +
+                                  4.0 * tem1 * one_over_sqrt_x * sin_2_theta -
+                                  4.0 * tem1 * one_over_sqrt_x * cos_2_theta +
+                                  e2m1 * ( 4.0 * tem1 * one_over_sqrt_x * cos_theta + 2. ) *
+                                    ( 8.0 * tem1 * one_over_sqrt_x * cos_theta + 4. ) * sin_2_theta /
+                                    ( tem1 * sqrt_x - 2. * e2m1 * cos_theta ) -
+                                  2. * cos_theta ) /
+                                ( tem1 * sqrt_x - 2. * e2m1 * cos_theta ) ) /
+                            ( tem1 * sqrt_x - 2. * e2m1 * cos_theta );
+
+      return { r, dr_dTheta, d2r_dTheta2 };
+    }
+
+    /**
+     * Evaluate the yield function \f$f\f$ depending on the Haigh-Westergaard stress
+     * coordinates @p hw. \f$f<0\f$ means no yielding while \f$f\geq0\f$ means
+     * yielding. When the optional fillet parameter @p varEps is given, a potential vertex
+     * along the hydrostatic axis is rounded and thus a smooth failure criterion is obtained.
+     *
+     * \note The yield function can be also used as plastic potential function if needed.
+     */
+    template < typename T >
+    T yieldFunction( const ContinuumMechanics::HaighWestergaard::HaighWestergaardCoordinates< T >& hw,
+                     const double                                                                  varEps = 0.0 ) const
+    {
+      const T r_ = polarRadius( hw.theta, param.e );
+      if ( varEps == 0 )
+        return ( param.Af * hw.rho ) * ( param.Af * hw.rho ) + param.m * ( param.Bf * hw.rho * r_ + param.Cf * hw.xi ) -
+               1.;
+      else
+        return param.Af * param.Af * hw.rho * hw.rho +
+               param.m *
+                 ( sqrt( param.Bf * hw.rho * r_ * param.Bf * hw.rho * r_ + varEps * varEps ) + param.Cf * hw.xi ) -
+               1.;
+    }
+
+    /**
+     * Evaluate the derivatives of the yield function with respect to the
+     * Haigh-Westergaard stress coordinates, i.e.
+     * \f$df/d\xi,\,df/d\rho,\,df/d\theta\f$. When the optional fillet parameter @p varEps is given, a potential
+     * vertex along the hydrostatic axis is rounded. Thus, a smooth failure criterion is obtained, where derivatives
+     * can be calculated uniquely.
+     */
+    template < typename T >
+    std::tuple< T, T, T > dYieldFunction_dHaighWestergaard(
+      const ContinuumMechanics::HaighWestergaard::HaighWestergaardCoordinates< T >& hw,
+      const double                                                                  varEps = 0.0 ) const
+    {
+      const auto [r_, dRdTheta_] = dPolarRadius_dTheta( hw.theta, param.e );
+
+      T dFdXi, dFdRho, dFdTheta;
+      dFdXi = param.m * param.Cf;
+
+      if ( varEps == 0.0 ) {
+        dFdRho   = 2. * param.Af * hw.rho * param.Af + param.m * param.Bf * r_;
+        dFdTheta = param.m * param.Bf * hw.rho * dRdTheta_;
+      }
+      else {
+        const T auxTerm1 = param.m * 0.5 *
+                           pow( param.Bf * param.Bf * hw.rho * hw.rho * r_ * r_ + varEps * varEps, -0.5 ) * 2 *
+                           param.Bf * hw.rho * r_ * param.Bf;
+
+        dFdRho   = param.Af * param.Af * 2. * hw.rho + auxTerm1 * r_;
+        dFdTheta = auxTerm1 * hw.rho * dRdTheta_;
+      }
+
+      return { dFdXi, dFdRho, dFdTheta };
+    }
+
+    /**
+     * Compute a fillet parameter for the vertex of the yield surface along the hydrostatic axis in the same way as
+     * Abaqus does. This parameter is only relevant in the case of the Drucker-Prager or the Mohr-Coulomb criterion.
+     * The calculated smoothing value can then be used as the optional input argument @p varEps in \ref
+     * yieldFunction and \ref dYieldFunction_dHaighWestergaard.
+     */
+    static inline double abaqusMohrCoulombPotentialVarEpsToMenetreyWillam( const double varEps, const double psi )
+    {
+      return varEps * 2 * std::sin( psi );
+    }
+
+    /**
+     * Compute the eccentricity parameter based on a given compressive strength \c fc and
+     * tensile strength \c ft.
+     */
+    static inline double e( const double fc, const double ft ) { return ( fc + 2 * ft ) / ( 2 * fc + ft ); }
+
+    /**
+     * Compute the cohesion based on a given compressive strength \c fc and
+     * tensile strength \c ft.
+     */
+    static inline double c( const double fc, const double ft )
+    {
+      const double phi_ = phi( fc, ft );
+      return ft / 2. * ( 1 + std::sin( phi_ ) ) / ( std::cos( phi_ ) );
+    }
+
+    /**
+     * Compute the friction angle in radian based on a given compressive strength \c fc and
+     * tensile strength \c ft.
+     */
+    static inline double phi( const double fc, const double ft ) { return std::asin( ( fc - ft ) / ( fc + ft ) ); }
+
+    /**
+     * Compute the tensile strength based on a given cohesion \c c and a friction angle \c phi.
+     */
+    static inline double ft( const double c, const double phi )
+    {
+      return 2 * c * std::cos( phi ) / ( 1 + std::sin( phi ) );
+    }
+
+    /**
+     * Compute the compressive strength based on a given cohesion \c c and a friction angle \c phi.
+     */
+    static inline double fc( const double c, const double phi )
+    {
+      return 2 * c * std::cos( phi ) / ( 1 - std::sin( phi ) );
+    }
+  };
+
+} // namespace Marmot::ContinuumMechanics::CommonConstitutiveModels

--- a/modules/core/MarmotMechanicsCore/include/Marmot/YieldSurfaceCombinationManager.h
+++ b/modules/core/MarmotMechanicsCore/include/Marmot/YieldSurfaceCombinationManager.h
@@ -31,82 +31,78 @@
  * @brief Manager for multi-surface yield-surface combinations in multi-surface plasticity.
  */
 
-namespace Marmot {
-  namespace NumericalAlgorithms {
-    /**
-     * @brief Tracks and iterates over yield-surface activity combinations for multi-surface plasticity.
-     *
-     * Maintains a table of all \f$2^n - 1\f$ non-empty subsets of @p nYieldSurfaces yield
-     * surfaces and provides an interface to iterate over them during the return-mapping
-     * algorithm, marking already-tried combinations as used.
-     *
-     * @tparam nYieldSurfaces  Number of yield surfaces.
-     */
-    template < int nYieldSurfaces >
-    class YieldSurfaceCombinationManager {
-      /// Column in the YieldSurfFlagArr for marking a combination as used
-      const int idxUsedFlag;
+namespace Marmot::NumericalAlgorithms {
+  /**
+   * @brief Tracks and iterates over yield-surface activity combinations for multi-surface plasticity.
+   *
+   * Maintains a table of all \f$2^n - 1\f$ non-empty subsets of @p nYieldSurfaces yield
+   * surfaces and provides an interface to iterate over them during the return-mapping
+   * algorithm, marking already-tried combinations as used.
+   *
+   * @tparam nYieldSurfaces  Number of yield surfaces.
+   */
+  template < int nYieldSurfaces >
+  class YieldSurfaceCombinationManager {
+    /// Column in the YieldSurfFlagArr for marking a combination as used
+    const int idxUsedFlag;
 
-    public:
-      /// An array which contains every possible (reasonable) combination of yield surfaces
-      Eigen::Array< bool, ( 1 << nYieldSurfaces ) - 1, ( nYieldSurfaces + 1 ) > yieldSurfaceCombinations;
-      /// An array to carry active/nonactive states of yield surfaces
-      typedef Eigen::Array< bool, 1, nYieldSurfaces > YieldSurfFlagArr;
-      /// An array to carry values of yield functions
-      typedef Eigen::Array< double, 1, nYieldSurfaces > YieldSurfResArr;
+  public:
+    /// An array which contains every possible (reasonable) combination of yield surfaces
+    Eigen::Array< bool, ( 1 << nYieldSurfaces ) - 1, ( nYieldSurfaces + 1 ) > yieldSurfaceCombinations;
+    /// An array to carry active/nonactive states of yield surfaces
+    typedef Eigen::Array< bool, 1, nYieldSurfaces > YieldSurfFlagArr;
+    /// An array to carry values of yield functions
+    typedef Eigen::Array< double, 1, nYieldSurfaces > YieldSurfResArr;
 
-      YieldSurfaceCombinationManager();
-      /// get another unused combination of yield surfaces
-      bool getAnotherYieldFlagCombination( YieldSurfFlagArr& activeSurfaces );
-      /// set the current combination as used
-      void markYieldFlagCombinationAsUsed( const YieldSurfFlagArr& activeSurfaces );
-      /// reset all yieldsurfaces as unused
-      void resetUsedYieldFlagCombinations();
-    };
-  } // namespace NumericalAlgorithms
-} // namespace Marmot
+    YieldSurfaceCombinationManager();
+    /// get another unused combination of yield surfaces
+    bool getAnotherYieldFlagCombination( YieldSurfFlagArr& activeSurfaces );
+    /// set the current combination as used
+    void markYieldFlagCombinationAsUsed( const YieldSurfFlagArr& activeSurfaces );
+    /// reset all yieldsurfaces as unused
+    void resetUsedYieldFlagCombinations();
+  };
+} // namespace Marmot::NumericalAlgorithms
 
-namespace Marmot {
-  namespace NumericalAlgorithms {
-    template < int n >
-    YieldSurfaceCombinationManager< n >::YieldSurfaceCombinationManager() : idxUsedFlag( n )
-    {
-      yieldSurfaceCombinations.setZero();
-      const int numRows = ( 1 << n ) - 1;
-      const int numCols = n;
+namespace Marmot::NumericalAlgorithms {
+  template < int n >
+  YieldSurfaceCombinationManager< n >::YieldSurfaceCombinationManager() : idxUsedFlag( n )
+  {
+    yieldSurfaceCombinations.setZero();
+    const int numRows = ( 1 << n ) - 1;
+    const int numCols = n;
 
-      for ( int row = 0; row < numRows; row++ )
-        for ( int col = 0; col < numCols; col++ )
-          yieldSurfaceCombinations( row, col ) = ( row + 1 ) & 1 << ( col );
-      return;
-    }
+    for ( int row = 0; row < numRows; row++ )
+      for ( int col = 0; col < numCols; col++ )
+        yieldSurfaceCombinations( row, col ) = ( row + 1 ) & 1 << ( col );
+    return;
+  }
 
-    template < int n >
-    bool YieldSurfaceCombinationManager< n >::getAnotherYieldFlagCombination( YieldSurfFlagArr& activeSurfaces )
-    {
-      for ( int i = 0; i < yieldSurfaceCombinations.rows(); i++ ) {
-        bool             alreadyUsed          = yieldSurfaceCombinations.row( i )( idxUsedFlag );
-        YieldSurfFlagArr combinationCandidate = yieldSurfaceCombinations.row( i ).head( n );
-        if ( !alreadyUsed && ( combinationCandidate == true ).any() ) {
-          activeSurfaces = combinationCandidate;
-          return true;
-        }
+  template < int n >
+  bool YieldSurfaceCombinationManager< n >::getAnotherYieldFlagCombination( YieldSurfFlagArr& activeSurfaces )
+  {
+    for ( int i = 0; i < yieldSurfaceCombinations.rows(); i++ ) {
+      bool             alreadyUsed          = yieldSurfaceCombinations.row( i )( idxUsedFlag );
+      YieldSurfFlagArr combinationCandidate = yieldSurfaceCombinations.row( i ).head( n );
+      if ( !alreadyUsed && ( combinationCandidate == true ).any() ) {
+        activeSurfaces = combinationCandidate;
+        return true;
       }
-      return false;
     }
+    return false;
+  }
 
-    template < int n >
-    void YieldSurfaceCombinationManager< n >::resetUsedYieldFlagCombinations()
-    {
-      yieldSurfaceCombinations.col( idxUsedFlag ).setConstant( false );
-    }
+  template < int n >
+  void YieldSurfaceCombinationManager< n >::resetUsedYieldFlagCombinations()
+  {
+    yieldSurfaceCombinations.col( idxUsedFlag ).setConstant( false );
+  }
 
-    template < int n >
-    void YieldSurfaceCombinationManager< n >::markYieldFlagCombinationAsUsed( const YieldSurfFlagArr& activeSurfaces )
-    {
-      for ( int i = 0; i < yieldSurfaceCombinations.rows(); i++ )
-        if ( ( yieldSurfaceCombinations.row( i ).head( n ) == activeSurfaces ).all() )
-          yieldSurfaceCombinations.row( i )( idxUsedFlag ) = true;
-    }
-  } // namespace NumericalAlgorithms
-} // namespace Marmot
+  template < int n >
+  void YieldSurfaceCombinationManager< n >::markYieldFlagCombinationAsUsed( const YieldSurfFlagArr& activeSurfaces )
+  {
+    for ( int i = 0; i < yieldSurfaceCombinations.rows(); i++ )
+      if ( ( yieldSurfaceCombinations.row( i ).head( n ) == activeSurfaces ).all() )
+        yieldSurfaceCombinations.row( i )( idxUsedFlag ) = true;
+  }
+} // namespace Marmot::NumericalAlgorithms

--- a/modules/core/MarmotMechanicsCore/src/HaighWestergaard.cpp
+++ b/modules/core/MarmotMechanicsCore/src/HaighWestergaard.cpp
@@ -7,38 +7,36 @@
 
 using namespace Eigen;
 
-namespace Marmot {
-  namespace ContinuumMechanics::HaighWestergaard {
+namespace Marmot::ContinuumMechanics::HaighWestergaard {
 
-    using namespace Constants;
-    using namespace ContinuumMechanics::VoigtNotation;
-    using namespace ContinuumMechanics::VoigtNotation::Invariants;
+  using namespace Constants;
+  using namespace ContinuumMechanics::VoigtNotation;
+  using namespace ContinuumMechanics::VoigtNotation::Invariants;
 
-    HaighWestergaardCoordinates< double > haighWestergaardFromStrain( const Vector6d& strain )
-    {
-      HaighWestergaardCoordinates< double > hw;
-      const double                          J2_ = J2Strain( strain );
+  HaighWestergaardCoordinates< double > haighWestergaardFromStrain( const Vector6d& strain )
+  {
+    HaighWestergaardCoordinates< double > hw;
+    const double                          J2_ = J2Strain( strain );
 
-      hw.xi  = I1( strain ) / sqrt3; // will be changed to eM if used
-      hw.rho = sqrt( 2. * J2_ );
+    hw.xi  = I1( strain ) / sqrt3; // will be changed to eM if used
+    hw.rho = sqrt( 2. * J2_ );
 
-      if ( hw.rho != 0 ) {
-        const double J3_ = J3Strain( strain );
-        const double x   = 3. * ( sqrt3 / 2. ) * J3_ / ( pow( J2_, 3. / 2 ) );
-        if ( x <= -1 )
-          hw.theta = 1. / 3 * Constants::Pi;
-        else if ( x >= 1 )
-          hw.theta = 0;
-        else if ( x != x )
-          hw.theta = 1. / 3 * Constants::Pi;
-        else
-          hw.theta = 1. / 3 * acos( x );
-      }
-      else
+    if ( hw.rho != 0 ) {
+      const double J3_ = J3Strain( strain );
+      const double x   = 3. * ( sqrt3 / 2. ) * J3_ / ( pow( J2_, 3. / 2 ) );
+      if ( x <= -1 )
+        hw.theta = 1. / 3 * Constants::Pi;
+      else if ( x >= 1 )
         hw.theta = 0;
-
-      return hw;
+      else if ( x != x )
+        hw.theta = 1. / 3 * Constants::Pi;
+      else
+        hw.theta = 1. / 3 * acos( x );
     }
+    else
+      hw.theta = 0;
 
-  } // namespace ContinuumMechanics::HaighWestergaard
-} // namespace Marmot
+    return hw;
+  }
+
+} // namespace Marmot::ContinuumMechanics::HaighWestergaard

--- a/modules/core/MarmotMechanicsCore/src/MarmotElasticity.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotElasticity.cpp
@@ -2,147 +2,141 @@
 
 using namespace Eigen;
 
-namespace Marmot {
-  namespace ContinuumMechanics {
-    namespace Elasticity::Isotropic {
+namespace Marmot::ContinuumMechanics {
+  namespace Elasticity::Isotropic {
 
-      Matrix6d stiffnessTensor( const double E, const double nu )
-      {
-        Matrix6d C;
-        // clang-format off
+    Matrix6d stiffnessTensor( const double E, const double nu )
+    {
+      Matrix6d C;
+      // clang-format off
             	C <<  (1-nu),     nu,     nu,          0,          0,          0,
             	          nu, (1-nu),     nu,          0,          0,          0,
             	          nu,     nu, (1-nu),          0,          0,          0,
             	          0,       0,      0, (1-2*nu)/2,          0,          0,
             	          0,       0,      0,          0, (1-2*nu)/2,          0,
             	          0,       0,      0,          0,          0, (1-2*nu)/2;
-        // clang-format on
-        C *= E / ( ( 1 + nu ) * ( 1 - 2 * nu ) );
-        return C;
-      }
+      // clang-format on
+      C *= E / ( ( 1 + nu ) * ( 1 - 2 * nu ) );
+      return C;
+    }
 
-      Matrix6d stiffnessTensorKG( const double K, const double G )
-      {
-        const double E_  = E( K, G );
-        const double nu_ = nu( K, G );
-        return stiffnessTensor( E_, nu_ );
-      }
+    Matrix6d stiffnessTensorKG( const double K, const double G )
+    {
+      const double E_  = E( K, G );
+      const double nu_ = nu( K, G );
+      return stiffnessTensor( E_, nu_ );
+    }
 
-      Matrix6d complianceTensor( const double E, const double nu )
-      {
-        Matrix6d     CInv;
-        const double G = E / ( 2 * ( 1 + nu ) );
-        // clang-format off
+    Matrix6d complianceTensor( const double E, const double nu )
+    {
+      Matrix6d     CInv;
+      const double G = E / ( 2 * ( 1 + nu ) );
+      // clang-format off
             	  CInv <<   1./E,  -nu/E, -nu/E,     0,    0,    0,
             	           -nu/E,   1./E, -nu/E,     0,    0,    0,
             	           -nu/E,  -nu/E,  1./E,     0,    0,    0,
             	               0,      0,     0,  1./G,    0,    0,
             	               0,      0,     0,     0, 1./G,    0,
             	               0,      0,     0,     0,    0, 1./G;
-        // clang-format on
-        return CInv;
-      }
-    } // namespace Elasticity::Isotropic
+      // clang-format on
+      return CInv;
+    }
+  } // namespace Elasticity::Isotropic
 
-    namespace Elasticity::TransverseIsotropic {
+  namespace Elasticity::TransverseIsotropic {
 
-      Matrix6d complianceTensor( const double E1,
-                                 const double E2,
-                                 const double nu12,
-                                 const double nu23,
-                                 const double G12 )
-      {
-        Matrix6d     CInv;
-        const double G23 = E2 / ( 2 * ( 1 + nu23 ) );
-        // clang-format off
+    Matrix6d complianceTensor( const double E1,
+                               const double E2,
+                               const double nu12,
+                               const double nu23,
+                               const double G12 )
+    {
+      Matrix6d     CInv;
+      const double G23 = E2 / ( 2 * ( 1 + nu23 ) );
+      // clang-format off
             	  CInv <<   1./E1, -nu12/E1, -nu12/E1,      0,      0,      0,
                        -nu12/E1,    1./E2, -nu23/E2,      0,      0,      0,
                        -nu12/E1, -nu23/E2,    1./E2,      0,      0,      0,
                               0,        0,        0, 1./G12,      0,      0,
                               0,        0,        0,      0, 1./G12,      0,
                               0,        0,        0,      0,      0, 1./G23;
-        // clang-format on
-        return CInv;
-      }
+      // clang-format on
+      return CInv;
+    }
 
-      Matrix6d stiffnessTensor( const double E1,
-                                const double E2,
-                                const double nu12,
-                                const double nu23,
-                                const double G12 )
-      {
+    Matrix6d stiffnessTensor( const double E1, const double E2, const double nu12, const double nu23, const double G12 )
+    {
 
-        Matrix3d CInvTopLeft;
+      Matrix3d CInvTopLeft;
 
-        // clang-format off
+      // clang-format off
         CInvTopLeft <<   1./E1, -nu12/E1, -nu12/E1,
                       -nu12/E1,    1./E2, -nu23/E2,
                       -nu12/E1, -nu23/E2,    1./E2;
-        // clang-format on
+      // clang-format on
 
-        Matrix6d     C          = Matrix6d::Zero();
-        const double G23        = E2 / ( 2 * ( 1 + nu23 ) );
-        C.block< 3, 3 >( 0, 0 ) = CInvTopLeft.inverse();
-        C( 3, 3 )               = G12;
-        C( 4, 4 )               = G12;
-        C( 5, 5 )               = G23;
+      Matrix6d     C          = Matrix6d::Zero();
+      const double G23        = E2 / ( 2 * ( 1 + nu23 ) );
+      C.block< 3, 3 >( 0, 0 ) = CInvTopLeft.inverse();
+      C( 3, 3 )               = G12;
+      C( 4, 4 )               = G12;
+      C( 5, 5 )               = G23;
 
-        return C;
-      }
+      return C;
+    }
 
-    } // namespace Elasticity::TransverseIsotropic
+  } // namespace Elasticity::TransverseIsotropic
 
-    namespace Elasticity::Orthotropic {
+  namespace Elasticity::Orthotropic {
 
-      Matrix6d complianceTensor( const double E1,
-                                 const double E2,
-                                 const double E3,
-                                 const double nu12,
-                                 const double nu23,
-                                 const double nu13,
-                                 const double G12,
-                                 const double G23,
-                                 const double G31 )
-      {
-        Matrix6d CInv;
-        // clang-format off
+    Matrix6d complianceTensor( const double E1,
+                               const double E2,
+                               const double E3,
+                               const double nu12,
+                               const double nu23,
+                               const double nu13,
+                               const double G12,
+                               const double G23,
+                               const double G31 )
+    {
+      Matrix6d CInv;
+      // clang-format off
            	    CInv <<   1./E1, -nu12/E1, -nu13/E1,      0,      0,      0,
            	           -nu12/E1,    1./E2, -nu23/E2,      0,      0,      0,
            	           -nu13/E1, -nu23/E2,    1./E3,      0,      0,      0,
            	                  0,        0,        0, 1./G12,      0,      0,
            	              	  0,        0,        0,      0, 1./G31,      0,
            	              	  0,        0,        0,      0,      0, 1./G23;
-        // clang-format on
-        return CInv;
-      }
+      // clang-format on
+      return CInv;
+    }
 
-      Matrix6d stiffnessTensor( const double E1,
-                                const double E2,
-                                const double E3,
-                                const double nu12,
-                                const double nu23,
-                                const double nu13,
-                                const double G12,
-                                const double G23,
-                                const double G31 )
-      {
+    Matrix6d stiffnessTensor( const double E1,
+                              const double E2,
+                              const double E3,
+                              const double nu12,
+                              const double nu23,
+                              const double nu13,
+                              const double G12,
+                              const double G23,
+                              const double G31 )
+    {
 
-        Matrix3d CInvTopLeft;
+      Matrix3d CInvTopLeft;
 
-        // clang-format off
+      // clang-format off
         CInvTopLeft <<    1./E1, -nu12/E1, -nu13/E1,
            	           -nu12/E1,    1./E2, -nu23/E2,
            	           -nu13/E1, -nu23/E2,    1./E3;
-        // clang-format on
+      // clang-format on
 
-        Matrix6d C              = Matrix6d::Zero();
-        C.block< 3, 3 >( 0, 0 ) = CInvTopLeft.inverse();
-        C( 3, 3 )               = G12;
-        C( 4, 4 )               = G31;
-        C( 5, 5 )               = G23;
+      Matrix6d C              = Matrix6d::Zero();
+      C.block< 3, 3 >( 0, 0 ) = CInvTopLeft.inverse();
+      C( 3, 3 )               = G12;
+      C( 4, 4 )               = G31;
+      C( 5, 5 )               = G23;
 
-        return C;
-      }
-    } // namespace Elasticity::Orthotropic
-  }   // namespace ContinuumMechanics
-} // namespace Marmot
+      return C;
+    }
+  } // namespace Elasticity::Orthotropic
+} // namespace Marmot::ContinuumMechanics

--- a/modules/core/MarmotMechanicsCore/src/MarmotKinematics.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotKinematics.cpp
@@ -3,96 +3,93 @@
 
 using namespace Eigen;
 
-namespace Marmot {
-  namespace ContinuumMechanics::Kinematics {
+namespace Marmot::ContinuumMechanics::Kinematics {
 
-    namespace VelocityGradient {
+  namespace VelocityGradient {
 
-      EigenTensors::Tensor3333d initializeDOmega_dVelocityGradient()
-      {
-        EigenTensors::Tensor3333d dwdl;
+    EigenTensors::Tensor3333d initializeDOmega_dVelocityGradient()
+    {
+      EigenTensors::Tensor3333d dwdl;
 
-        for ( int i = 0; i < 3; i++ )
-          for ( int j = 0; j < 3; j++ )
-            for ( int k = 0; k < 3; k++ )
-              for ( int l = 0; l < 3; l++ ) {
-                dwdl( i, j, k, l ) = 0.5 * ( ( i == k ? 1 : 0 ) * ( j == l ? 1 : 0 ) -
-                                             ( k == j ? 1 : 0 ) * ( i == l ? 1 : 0 ) );
-              }
-        return dwdl;
-      }
-      const EigenTensors::Tensor3333d dOmega_dVelocityGradient = initializeDOmega_dVelocityGradient();
-
-      EigenTensors::Tensor633d initializeDStretchingRate_dVelocityGradient()
-      {
-        EigenTensors::Tensor633d dddl;
-
-        for ( int i = 0; i < 3; i++ )
-          for ( int j = 0; j < 3; j++ )
-            for ( int k = 0; k < 3; k++ )
-              for ( int l = 0; l < 3; l++ ) {
-                dddl( ContinuumMechanics::TensorUtility::IndexNotation::toVoigt< 3 >( i, j ),
-                      k,
-                      l ) = 0.5 *
-                            ( ( i == k ? 1 : 0 ) * ( j == l ? 1 : 0 ) + ( j == k ? 1 : 0 ) * ( i == l ? 1 : 0 ) ) *
-                            ( i == j ? 1 : 2 ); // strain-engineering-notation correction
-              }
-        return dddl;
-      }
-
-      const EigenTensors::Tensor633d dStretchingRate_dVelocityGradient = initializeDStretchingRate_dVelocityGradient();
-
-    } // namespace VelocityGradient
-
-    namespace Strain {
-
-      Marmot::Vector6d GreenLagrange( const Eigen::Matrix3d& F )
-      {
-        Eigen::Matrix3d H = F - Eigen::Matrix3d::Identity();
-        return Marmot::ContinuumMechanics::VoigtNotation::voigtFromStrainMatrix< 3 >(
-          0.5 * ( H + H.transpose() + H.transpose() * H ) );
-      }
-
-      Marmot::EigenTensors::Tensor633d dGreenLagrangedDeformationGradient( const Eigen::Matrix3d& F )
-      {
-        EigenTensors::Tensor633d dEdF;
-        auto                     kron = Matrix3d::Identity();
-
-        for ( int IJ = 0; IJ < 6; IJ++ ) {
-          auto [I, J] = Marmot::ContinuumMechanics::TensorUtility::IndexNotation::fromVoigt< 3 >( IJ );
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ )
           for ( int k = 0; k < 3; k++ )
-            for ( int L = 0; L < 3; L++ )
+            for ( int l = 0; l < 3; l++ ) {
+              dwdl( i, j, k, l ) = 0.5 * ( ( i == k ? 1 : 0 ) * ( j == l ? 1 : 0 ) -
+                                           ( k == j ? 1 : 0 ) * ( i == l ? 1 : 0 ) );
+            }
+      return dwdl;
+    }
+    const EigenTensors::Tensor3333d dOmega_dVelocityGradient = initializeDOmega_dVelocityGradient();
 
-              dEdF( IJ, k, L ) = 0.5 * ( kron( I, L ) * F( k, J ) + kron( J, L ) * F( k, I ) ) * ( I == J ? 1 : 2 );
-        }
+    EigenTensors::Tensor633d initializeDStretchingRate_dVelocityGradient()
+    {
+      EigenTensors::Tensor633d dddl;
 
-        return dEdF;
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ )
+          for ( int k = 0; k < 3; k++ )
+            for ( int l = 0; l < 3; l++ ) {
+              dddl( ContinuumMechanics::TensorUtility::IndexNotation::toVoigt< 3 >( i, j ),
+                    k,
+                    l ) = 0.5 * ( ( i == k ? 1 : 0 ) * ( j == l ? 1 : 0 ) + ( j == k ? 1 : 0 ) * ( i == l ? 1 : 0 ) ) *
+                          ( i == j ? 1 : 2 ); // strain-engineering-notation correction
+            }
+      return dddl;
+    }
+
+    const EigenTensors::Tensor633d dStretchingRate_dVelocityGradient = initializeDStretchingRate_dVelocityGradient();
+
+  } // namespace VelocityGradient
+
+  namespace Strain {
+
+    Marmot::Vector6d GreenLagrange( const Eigen::Matrix3d& F )
+    {
+      Eigen::Matrix3d H = F - Eigen::Matrix3d::Identity();
+      return Marmot::ContinuumMechanics::VoigtNotation::voigtFromStrainMatrix< 3 >(
+        0.5 * ( H + H.transpose() + H.transpose() * H ) );
+    }
+
+    Marmot::EigenTensors::Tensor633d dGreenLagrangedDeformationGradient( const Eigen::Matrix3d& F )
+    {
+      EigenTensors::Tensor633d dEdF;
+      auto                     kron = Matrix3d::Identity();
+
+      for ( int IJ = 0; IJ < 6; IJ++ ) {
+        auto [I, J] = Marmot::ContinuumMechanics::TensorUtility::IndexNotation::fromVoigt< 3 >( IJ );
+        for ( int k = 0; k < 3; k++ )
+          for ( int L = 0; L < 3; L++ )
+
+            dEdF( IJ, k, L ) = 0.5 * ( kron( I, L ) * F( k, J ) + kron( J, L ) * F( k, I ) ) * ( I == J ? 1 : 2 );
       }
 
-    } // namespace Strain
-    namespace DeformationGradient {
-      template <>
-      Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, 1, 1 > >& tensor )
-      {
-        Matrix3d tensor3D = Matrix3d::Identity();
-        tensor3D( 0, 0 )  = tensor( 0, 0 );
-        return tensor3D;
-      }
+      return dEdF;
+    }
 
-      template <>
-      Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, 2, 2 > >& tensor )
-      {
-        Matrix3d tensor3D              = Matrix3d::Identity();
-        tensor3D.topLeftCorner( 2, 2 ) = tensor;
-        return tensor3D;
-      }
+  } // namespace Strain
+  namespace DeformationGradient {
+    template <>
+    Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, 1, 1 > >& tensor )
+    {
+      Matrix3d tensor3D = Matrix3d::Identity();
+      tensor3D( 0, 0 )  = tensor( 0, 0 );
+      return tensor3D;
+    }
 
-      template <>
-      Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, 3, 3 > >& tensor )
-      {
-        return tensor;
-      }
-    } // namespace DeformationGradient
+    template <>
+    Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, 2, 2 > >& tensor )
+    {
+      Matrix3d tensor3D              = Matrix3d::Identity();
+      tensor3D.topLeftCorner( 2, 2 ) = tensor;
+      return tensor3D;
+    }
 
-  }   // namespace ContinuumMechanics::Kinematics
-} // namespace Marmot
+    template <>
+    Eigen::Matrix3d make3D( const Eigen::Ref< const Eigen::Matrix< double, 3, 3 > >& tensor )
+    {
+      return tensor;
+    }
+  } // namespace DeformationGradient
+
+} // namespace Marmot::ContinuumMechanics::Kinematics

--- a/modules/core/MarmotMechanicsCore/src/MarmotLocalization.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotLocalization.cpp
@@ -4,69 +4,67 @@
 #include <cmath>
 #include <iostream>
 
-namespace Marmot {
-  namespace ContinuumMechanics::LocalizationAnalysis {
+namespace Marmot::ContinuumMechanics::LocalizationAnalysis {
 
-    Marmot::Matrix3d computeAcousticTensor( const Marmot::Matrix6d& materialTangent,
-                                            const Marmot::Vector3d& normalVector )
-    {
-      Marmot::Matrix3d acousticTensor;
-      int              indexRow, indexCol;
+  Marmot::Matrix3d computeAcousticTensor( const Marmot::Matrix6d& materialTangent,
+                                          const Marmot::Vector3d& normalVector )
+  {
+    Marmot::Matrix3d acousticTensor;
+    int              indexRow, indexCol;
 
-      acousticTensor.setZero();
+    acousticTensor.setZero();
 
-      for ( int i = 0; i < 3; i++ ) {
-        for ( int j = 0; j < 3; j++ ) {
-          indexRow = Marmot::ContinuumMechanics::TensorUtility::IndexNotation::toVoigt< 3 >( i, j );
-          for ( int k = 0; k < 3; k++ ) {
-            for ( int l = 0; l < 3; l++ ) {
-              indexCol = Marmot::ContinuumMechanics::TensorUtility::IndexNotation::toVoigt< 3 >( k, l );
+    for ( int i = 0; i < 3; i++ ) {
+      for ( int j = 0; j < 3; j++ ) {
+        indexRow = Marmot::ContinuumMechanics::TensorUtility::IndexNotation::toVoigt< 3 >( i, j );
+        for ( int k = 0; k < 3; k++ ) {
+          for ( int l = 0; l < 3; l++ ) {
+            indexCol = Marmot::ContinuumMechanics::TensorUtility::IndexNotation::toVoigt< 3 >( k, l );
 
-              acousticTensor( j, k ) += normalVector( i ) * materialTangent( indexRow, indexCol ) * normalVector( l );
-            }
+            acousticTensor( j, k ) += normalVector( i ) * materialTangent( indexRow, indexCol ) * normalVector( l );
           }
         }
       }
-
-      return acousticTensor;
     }
 
-    bool localizationChecker( const Marmot::Matrix3d& acousticTensor )
-    {
-      double Tol = 1e-12;
-      return acousticTensor.determinant() <= Tol ? true : false;
-    }
+    return acousticTensor;
+  }
 
-    Marmot::Vector3d computeNormalVector( double alpha, double beta )
-    {
-      double           alphaRad = Marmot::Math::degToRad( alpha );
-      double           betaRad  = Marmot::Math::degToRad( beta );
-      Marmot::Vector3d nVec;
+  bool localizationChecker( const Marmot::Matrix3d& acousticTensor )
+  {
+    double Tol = 1e-12;
+    return acousticTensor.determinant() <= Tol ? true : false;
+  }
 
-      nVec << cos( betaRad ) * cos( alphaRad ), cos( betaRad ) * sin( alphaRad ), sin( betaRad );
-      return nVec;
-    }
+  Marmot::Vector3d computeNormalVector( double alpha, double beta )
+  {
+    double           alphaRad = Marmot::Math::degToRad( alpha );
+    double           betaRad  = Marmot::Math::degToRad( beta );
+    Marmot::Vector3d nVec;
 
-    double minimumDeterminantAcousticTensor( const Marmot::Matrix6d& materialTangent )
-    {
-      Marmot::Matrix3d acousticTensor;
-      Marmot::Vector3d nVec;
-      double           detQ;
-      double           detQNew;
+    nVec << cos( betaRad ) * cos( alphaRad ), cos( betaRad ) * sin( alphaRad ), sin( betaRad );
+    return nVec;
+  }
 
-      detQ = 1e300;
-      for ( double alpha = 0.; alpha <= 360.; alpha += 10. ) {
-        for ( double beta = 0.; beta <= 90.; beta += 10. ) {
-          nVec           = computeNormalVector( alpha, beta );
-          acousticTensor = computeAcousticTensor( materialTangent, nVec );
-          detQNew        = acousticTensor.determinant();
+  double minimumDeterminantAcousticTensor( const Marmot::Matrix6d& materialTangent )
+  {
+    Marmot::Matrix3d acousticTensor;
+    Marmot::Vector3d nVec;
+    double           detQ;
+    double           detQNew;
 
-          if ( detQNew <= detQ )
-            detQ = detQNew;
-        }
+    detQ = 1e300;
+    for ( double alpha = 0.; alpha <= 360.; alpha += 10. ) {
+      for ( double beta = 0.; beta <= 90.; beta += 10. ) {
+        nVec           = computeNormalVector( alpha, beta );
+        acousticTensor = computeAcousticTensor( materialTangent, nVec );
+        detQNew        = acousticTensor.determinant();
+
+        if ( detQNew <= detQ )
+          detQ = detQNew;
       }
-
-      return detQ;
     }
-  } // namespace ContinuumMechanics::LocalizationAnalysis
-} // namespace Marmot
+
+    return detQ;
+  }
+} // namespace Marmot::ContinuumMechanics::LocalizationAnalysis

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElastic.cpp
@@ -5,156 +5,160 @@
 #include "Marmot/MarmotMath.h"
 #include "Marmot/MarmotVoigt.h"
 
-using namespace Eigen;
+namespace Marmot {
 
-void MarmotMaterialHypoElastic::setCharacteristicElementLength( double length )
-{
-  characteristicElementLength = length;
-}
+  using namespace Eigen;
 
-void MarmotMaterialHypoElastic::computePlaneStress( state2D&                state2D_,
-                                                    Marmot::Matrix3d&       dStress_dStrain2D_,
-                                                    const Marmot::Vector3d& dStrain2D_,
-                                                    const timeInfo&         timeInfo ) const
-{
-  using namespace Marmot;
-  using namespace ContinuumMechanics::VoigtNotation;
-
-  Map< const Matrix< double, 3, 1 > > dStrain2D( dStrain2D_.data() );
-  Map< Matrix< double, 3, 1 > >       stress2D( state2D_.stress.data() );
-  Map< Matrix< double, 3, 3 > >       dStress_dStrain2D( dStress_dStrain2D_.data() );
-  Map< VectorXd >                     stateVars( state2D_.stateVars, this->getNumberOfRequiredStateVars() );
-
-  Matrix6d dStress_dStrain3D;
-
-  VectorXd stateVarsOld  = stateVars;
-  Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( dStrain2D );
-
-  // assumption of isochoric deformation for initial guess
-  dStrain3DTemp( 2 ) = ( -dStrain2D( 0 ) - dStrain2D( 1 ) );
-
-  state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D ),
-                 state2D_.elasticEnergyDensity,
-                 state2D_.dissipation,
-                 stateVars.data() );
-
-  int planeStressCount = 1;
-  while ( true ) {
-
-    stateVars = stateVarsOld;
-
-    state.stress               = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D );
-    state.elasticEnergyDensity = state2D_.elasticEnergyDensity;
-    state.dissipation          = state2D_.dissipation;
-
-    computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
-
-    double residual = state.stress.array().abs()[2];
-
-    if ( residual < 1.e-10 || ( planeStressCount > 7 && residual < 1e-8 ) ) {
-      break;
-    }
-
-    double tangentCompliance = 1. / dStress_dStrain3D( 2, 2 );
-    if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 )
-      tangentCompliance = 1e10;
-
-    dStrain3DTemp( 2 ) -= tangentCompliance * state.stress( 2 );
-
-    planeStressCount += 1;
-    if ( planeStressCount > 13 ) {
-      MarmotJournal::warningToMSG( "PlaneStressWrapper requires cutback" );
-      throw Marmot::StressUpdateFailed( "Plane stress iteration did not converge" );
-    }
+  void MarmotMaterialHypoElastic::setCharacteristicElementLength( double length )
+  {
+    characteristicElementLength = length;
   }
 
-  state2D_.stress               = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::TwoD >( state.stress );
-  state2D_.elasticEnergyDensity = state.elasticEnergyDensity;
-  state2D_.dissipation          = state.dissipation;
-  state2D_.stateVars            = stateVars.data();
+  void MarmotMaterialHypoElastic::computePlaneStress( state2D&                state2D_,
+                                                      Marmot::Matrix3d&       dStress_dStrain2D_,
+                                                      const Marmot::Vector3d& dStrain2D_,
+                                                      const timeInfo&         timeInfo ) const
+  {
+    using namespace Marmot;
+    using namespace ContinuumMechanics::VoigtNotation;
 
-  dStress_dStrain2D_ = ContinuumMechanics::PlaneStress::getPlaneStressTangent( dStress_dStrain3D );
-}
+    Map< const Matrix< double, 3, 1 > > dStrain2D( dStrain2D_.data() );
+    Map< Matrix< double, 3, 1 > >       stress2D( state2D_.stress.data() );
+    Map< Matrix< double, 3, 3 > >       dStress_dStrain2D( dStress_dStrain2D_.data() );
+    Map< VectorXd >                     stateVars( state2D_.stateVars, this->getNumberOfRequiredStateVars() );
 
-void MarmotMaterialHypoElastic::computeUniaxialStress( state1D&        state1D_,
-                                                       double&         dStress_dStrain1D_,
-                                                       const double    dStrain1D_,
-                                                       const timeInfo& timeInfo ) const
-{
-  using namespace Marmot;
-  using namespace ContinuumMechanics::VoigtNotation;
+    Matrix6d dStress_dStrain3D;
 
-  Map< const Matrix< double, 1, 1 > > dStrain1D( &dStrain1D_ );
-  Map< Matrix< double, 1, 1 > >       stress1D( &state1D_.stress );
-  Map< VectorXd >                     stateVars( state1D_.stateVars, stateLayout.totalSize() );
+    VectorXd stateVarsOld  = stateVars;
+    Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( dStrain2D );
 
-  Matrix6d dStress_dStrain3D;
+    // assumption of isochoric deformation for initial guess
+    dStrain3DTemp( 2 ) = ( -dStrain2D( 0 ) - dStrain2D( 1 ) );
 
-  VectorXd stateVarsOld  = stateVars;
-  Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( dStrain1D );
+    state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D ),
+                   state2D_.elasticEnergyDensity,
+                   state2D_.dissipation,
+                   stateVars.data() );
 
-  state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D ),
-                 state1D_.elasticEnergyDensity,
-                 state1D_.dissipation,
-                 stateVars.data() );
+    int planeStressCount = 1;
+    while ( true ) {
 
-  int count = 1;
-  while ( true ) {
-    stateVars = stateVarsOld;
+      stateVars = stateVarsOld;
 
-    state.stress               = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D );
-    state.elasticEnergyDensity = state1D_.elasticEnergyDensity;
-    state.dissipation          = state1D_.dissipation;
+      state.stress = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::TwoD >( stress2D );
+      state.elasticEnergyDensity = state2D_.elasticEnergyDensity;
+      state.dissipation          = state2D_.dissipation;
 
-    computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
+      computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
 
-    const double residual = state.stress.array().abs().segment( 1, 2 ).sum();
+      double residual = state.stress.array().abs()[2];
 
-    if ( residual < 1.e-13 || ( count > 7 && residual < 1e-10 ) ) {
-      break;
+      if ( residual < 1.e-10 || ( planeStressCount > 7 && residual < 1e-8 ) ) {
+        break;
+      }
+
+      double tangentCompliance = 1. / dStress_dStrain3D( 2, 2 );
+      if ( Math::isNaN( tangentCompliance ) || std::abs( tangentCompliance ) > 1e10 )
+        tangentCompliance = 1e10;
+
+      dStrain3DTemp( 2 ) -= tangentCompliance * state.stress( 2 );
+
+      planeStressCount += 1;
+      if ( planeStressCount > 13 ) {
+        MarmotJournal::warningToMSG( "PlaneStressWrapper requires cutback" );
+        throw Marmot::StressUpdateFailed( "Plane stress iteration did not converge" );
+      }
     }
 
-    dStrain3DTemp.segment< 2 >( 1 ) -= dStress_dStrain3D.block< 2, 2 >( 1, 1 ).colPivHouseholderQr().solve(
-      state.stress.segment< 2 >( 1 ) );
+    state2D_.stress               = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::TwoD >( state.stress );
+    state2D_.elasticEnergyDensity = state.elasticEnergyDensity;
+    state2D_.dissipation          = state.dissipation;
+    state2D_.stateVars            = stateVars.data();
 
-    count += 1;
-    if ( count > 13 ) {
-      MarmotJournal::warningToMSG( "UniaxialStressWrapper requires cutback" );
-      throw Marmot::StressUpdateFailed( "uniaxial stress iteration did not converge" );
+    dStress_dStrain2D_ = ContinuumMechanics::PlaneStress::getPlaneStressTangent( dStress_dStrain3D );
+  }
+
+  void MarmotMaterialHypoElastic::computeUniaxialStress( state1D&        state1D_,
+                                                         double&         dStress_dStrain1D_,
+                                                         const double    dStrain1D_,
+                                                         const timeInfo& timeInfo ) const
+  {
+    using namespace Marmot;
+    using namespace ContinuumMechanics::VoigtNotation;
+
+    Map< const Matrix< double, 1, 1 > > dStrain1D( &dStrain1D_ );
+    Map< Matrix< double, 1, 1 > >       stress1D( &state1D_.stress );
+    Map< VectorXd >                     stateVars( state1D_.stateVars, stateLayout.totalSize() );
+
+    Matrix6d dStress_dStrain3D;
+
+    VectorXd stateVarsOld  = stateVars;
+    Vector6d dStrain3DTemp = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( dStrain1D );
+
+    state3D state( Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D ),
+                   state1D_.elasticEnergyDensity,
+                   state1D_.dissipation,
+                   stateVars.data() );
+
+    int count = 1;
+    while ( true ) {
+      stateVars = stateVarsOld;
+
+      state.stress = Marmot::ContinuumMechanics::VoigtNotation::make3DVoigt< VoigtSize::OneD >( stress1D );
+      state.elasticEnergyDensity = state1D_.elasticEnergyDensity;
+      state.dissipation          = state1D_.dissipation;
+
+      computeStress( state, dStress_dStrain3D, dStrain3DTemp, timeInfo );
+
+      const double residual = state.stress.array().abs().segment( 1, 2 ).sum();
+
+      if ( residual < 1.e-13 || ( count > 7 && residual < 1e-10 ) ) {
+        break;
+      }
+
+      dStrain3DTemp.segment< 2 >( 1 ) -= dStress_dStrain3D.block< 2, 2 >( 1, 1 ).colPivHouseholderQr().solve(
+        state.stress.segment< 2 >( 1 ) );
+
+      count += 1;
+      if ( count > 13 ) {
+        MarmotJournal::warningToMSG( "UniaxialStressWrapper requires cutback" );
+        throw Marmot::StressUpdateFailed( "uniaxial stress iteration did not converge" );
+      }
     }
+
+    state1D_.stress = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::OneD >( state.stress )[0];
+    state1D_.elasticEnergyDensity = state.elasticEnergyDensity;
+    state1D_.dissipation          = state.dissipation;
+    state1D_.stateVars            = stateVars.data();
+
+    dStress_dStrain1D_ = ContinuumMechanics::UniaxialStress::getUniaxialStressTangent( dStress_dStrain3D );
+  }
+  double MarmotMaterialHypoElastic::getMaximumWaveSpeed( const state3D& state ) const
+  {
+    const int nStateVars = getNumberOfRequiredStateVars();
+
+    std::vector< double > stateVarsCopy( nStateVars, 0.0 );
+    if ( state.stateVars != nullptr && nStateVars > 0 ) {
+      std::copy_n( state.stateVars, nStateVars, stateVarsCopy.begin() );
+    }
+
+    state3D stateCopy( state.stress, state.elasticEnergyDensity, state.dissipation, stateVarsCopy.data() );
+
+    Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
+    const auto       dStrain         = Marmot::Vector6d::Zero();
+    const timeInfo   timeInfo{ 0.0, 1.0 };
+
+    computeStress( stateCopy, dStress_dStrain, dStrain, timeInfo );
+
+    const double maxStiffnessDiagonal = std::max( { dStress_dStrain( 0, 0 ),
+                                                    dStress_dStrain( 1, 1 ),
+                                                    dStress_dStrain( 2, 2 ),
+                                                    dStress_dStrain( 3, 3 ),
+                                                    dStress_dStrain( 4, 4 ),
+                                                    dStress_dStrain( 5, 5 ) } );
+    const double density              = getDensity( stateCopy.stateVars );
+
+    return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
   }
 
-  state1D_.stress = ContinuumMechanics::VoigtNotation::reduce3DVoigt< VoigtSize::OneD >( state.stress )[0];
-  state1D_.elasticEnergyDensity = state.elasticEnergyDensity;
-  state1D_.dissipation          = state.dissipation;
-  state1D_.stateVars            = stateVars.data();
-
-  dStress_dStrain1D_ = ContinuumMechanics::UniaxialStress::getUniaxialStressTangent( dStress_dStrain3D );
-}
-double MarmotMaterialHypoElastic::getMaximumWaveSpeed( const state3D& state ) const
-{
-  const int nStateVars = getNumberOfRequiredStateVars();
-
-  std::vector< double > stateVarsCopy( nStateVars, 0.0 );
-  if ( state.stateVars != nullptr && nStateVars > 0 ) {
-    std::copy_n( state.stateVars, nStateVars, stateVarsCopy.begin() );
-  }
-
-  state3D stateCopy( state.stress, state.elasticEnergyDensity, state.dissipation, stateVarsCopy.data() );
-
-  Marmot::Matrix6d dStress_dStrain = Marmot::Matrix6d::Zero();
-  const auto       dStrain         = Marmot::Vector6d::Zero();
-  const timeInfo   timeInfo{ 0.0, 1.0 };
-
-  computeStress( stateCopy, dStress_dStrain, dStrain, timeInfo );
-
-  const double maxStiffnessDiagonal = std::max( { dStress_dStrain( 0, 0 ),
-                                                  dStress_dStrain( 1, 1 ),
-                                                  dStress_dStrain( 2, 2 ),
-                                                  dStress_dStrain( 3, 3 ),
-                                                  dStress_dStrain( 4, 4 ),
-                                                  dStress_dStrain( 5, 5 ) } );
-  const double density              = getDensity( stateCopy.stateVars );
-
-  return density > 0.0 ? std::sqrt( std::max( 0.0, maxStiffnessDiagonal ) / density ) : 0.0;
-}
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticAD.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticAD.cpp
@@ -3,46 +3,50 @@
 #include "Marmot/MarmotTypedefs.h"
 #include <autodiff/forward/dual/eigen.hpp>
 
-using namespace Eigen;
-using namespace autodiff;
+namespace Marmot {
 
-void MarmotMaterialHypoElasticAD::computeStress( state3D&                state,
-                                                 Marmot::Matrix6d&       dStressDDStrain,
-                                                 const Marmot::Vector6d& dStrain,
-                                                 const timeInfo&         timeInfo
+  using namespace Eigen;
+  using namespace autodiff;
 
-) const
-{
+  void MarmotMaterialHypoElasticAD::computeStress( state3D&                state,
+                                                   Marmot::Matrix6d&       dStressDDStrain,
+                                                   const Marmot::Vector6d& dStrain,
+                                                   const timeInfo&         timeInfo
 
-  using namespace Marmot;
-  mVector6d       S( state.stress.data() );
-  const Vector6d  dEps = Map< const Vector6d >( dStrain.data() );
-  Map< VectorXd > stateVars( state.stateVars, this->getNumberOfRequiredStateVars() );
+  ) const
+  {
 
-  // remember old state
-  const VectorXd stateVarsOld = stateVars;
-  const Vector6d SOld         = S;
+    using namespace Marmot;
+    mVector6d       S( state.stress.data() );
+    const Vector6d  dEps = Map< const Vector6d >( dStrain.data() );
+    Map< VectorXd > stateVars( state.stateVars, this->getNumberOfRequiredStateVars() );
 
-  mMatrix6d C( dStressDDStrain.data() );
-  // ----------------------------------------
-  // autodiff part
-  // ----------------------------------------
-  // compute stress and tangent with autodiff
-  std::tie( S, C ) = Marmot::AutomaticDifferentiation::dF_dX(
-    [&]( const Marmot::Vector6dual dE_ ) {
-      // reset stateVars to old state
-      stateVars = stateVarsOld;
+    // remember old state
+    const VectorXd stateVarsOld = stateVars;
+    const Vector6d SOld         = S;
 
-      Marmot::Vector6dual s( SOld );
+    mMatrix6d C( dStressDDStrain.data() );
+    // ----------------------------------------
+    // autodiff part
+    // ----------------------------------------
+    // compute stress and tangent with autodiff
+    std::tie( S, C ) = Marmot::AutomaticDifferentiation::dF_dX(
+      [&]( const Marmot::Vector6dual dE_ ) {
+        // reset stateVars to old state
+        stateVars = stateVarsOld;
 
-      // construct AD state
-      state3DAD stateAD = state3DAD( state );
-      // compute stress
-      computeStressAD( stateAD, dE_, timeInfo );
+        Marmot::Vector6dual s( SOld );
 
-      Marmot::Vector6dual res = stateAD.stress;
-      return res;
-    },
-    dEps );
-  // ----------------------------------------
-}
+        // construct AD state
+        state3DAD stateAD = state3DAD( state );
+        // compute stress
+        computeStressAD( stateAD, dE_, timeInfo );
+
+        Marmot::Vector6dual res = stateAD.stress;
+        return res;
+      },
+      dEps );
+    // ----------------------------------------
+  }
+
+} // namespace Marmot

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
@@ -1,7 +1,7 @@
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 #include "Marmot/MarmotJournal.h"
 
-using namespace MarmotLibrary;
+using namespace Marmot::Registration;
 
 Marmot::MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( const std::string& materialName,
                                                                                      const double* materialProperties,

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialHypoElasticFactory.cpp
@@ -3,10 +3,10 @@
 
 using namespace MarmotLibrary;
 
-MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( const std::string& materialName,
-                                                                             const double*      materialProperties,
-                                                                             int                nMaterialProperties,
-                                                                             int                materialNumber )
+Marmot::MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( const std::string& materialName,
+                                                                                     const double* materialProperties,
+                                                                                     int           nMaterialProperties,
+                                                                                     int           materialNumber )
 {
   auto& map = materialFactoryFunctionByName();
   auto  it  = map.find( materialName );
@@ -15,7 +15,7 @@ MarmotMaterialHypoElastic* MarmotMaterialHypoElasticFactory::createMaterial( con
     for ( const auto& pair : map ) {
       reg += pair.first + ", ";
     }
-    throw std::invalid_argument( MakeString()
+    throw std::invalid_argument( Marmot::MakeString()
                                  << __PRETTY_FUNCTION__ << " Material " + materialName + " not registered!" + reg );
   }
 

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialPointSolverHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialPointSolverHypoElastic.cpp
@@ -11,7 +11,7 @@ MarmotMaterialPointSolverHypoElastic::MarmotMaterialPointSolverHypoElastic( std:
                                                                             const SolverOptions& options )
   : options( options )
 {
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration;
 
   // create material instance
   material = std::unique_ptr< MarmotMaterialHypoElastic >( dynamic_cast< MarmotMaterialHypoElastic* >(

--- a/modules/core/MarmotMechanicsCore/src/MarmotPronySeries.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotPronySeries.cpp
@@ -2,61 +2,24 @@
 #include "Marmot/MarmotTypedefs.h"
 #include <iostream>
 
-namespace Marmot::ContinuumMechanics::Viscoelasticity {
-  namespace PronySeries {
+namespace Marmot::ContinuumMechanics::Viscoelasticity::PronySeries {
 
-    using namespace Marmot;
+  using namespace Marmot;
 
-    void evaluatePronySeries( const Properties&               props,
-                              Vector6d&                       stress,
-                              Matrix6d&                       stiffness,
-                              Eigen::Ref< mapStateVarMatrix > stateVars,
-                              const Vector6d&                 dStrain,
-                              const double                    dT,
-                              const bool                      updateStateVars )
-    {
-      // ultimate stiffness contribution
-      stress += props.ultimateStiffnessMatrix * dStrain;
-      stiffness = props.ultimateStiffnessMatrix;
+  void evaluatePronySeries( const Properties&               props,
+                            Vector6d&                       stress,
+                            Matrix6d&                       stiffness,
+                            Eigen::Ref< mapStateVarMatrix > stateVars,
+                            const Vector6d&                 dStrain,
+                            const double                    dT,
+                            const bool                      updateStateVars )
+  {
+    // ultimate stiffness contribution
+    stress += props.ultimateStiffnessMatrix * dStrain;
+    stiffness = props.ultimateStiffnessMatrix;
 
-      // prony series terms
-      if ( dT > 0.0 ) {
-        for ( size_t k = 0; k < props.nPronyTerms; k++ ) {
-          const auto& tau       = props.pronyRelaxationTimes.block< 6, 6 >( 0, k * 6 );
-          const auto& C         = props.pronyStiffnesses.block< 6, 6 >( 0, k * 6 );
-          const auto& currState = stateVars.block< 6, 6 >( 0, k * 6 );
-
-          const Matrix6d eta = tau.cwiseProduct( C );
-
-          const Matrix6d exp_dt_tau = tau.unaryExpr( [dT]( const double& x ) {
-            if ( x != 0.0 )
-              return std::exp( -dT / x );
-            else
-              return 0.0;
-          } );
-
-          // due to strain increment
-          stress += ( eta - eta.cwiseProduct( exp_dt_tau ) ) * dStrain / dT;
-          stiffness += ( eta - eta.cwiseProduct( exp_dt_tau ) ) / dT;
-
-          // due to history
-          stress -= Matrix6d( currState - exp_dt_tau.cwiseProduct( currState ) ).colwise().sum();
-
-          // update state variables only if it is requested
-          if ( updateStateVars )
-            stateVars.block< 6, 6 >( 0, 6 * k ) = exp_dt_tau.cwiseProduct( currState ) +
-                                                  Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT ) -
-                                                  Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT )
-                                                    .cwiseProduct( exp_dt_tau );
-        }
-      }
-    }
-
-    void updateStateVars( const Properties&               props,
-                          Eigen::Ref< mapStateVarMatrix > stateVars,
-                          const Vector6d&                 dStrain,
-                          const double                    dT )
-    {
+    // prony series terms
+    if ( dT > 0.0 ) {
       for ( size_t k = 0; k < props.nPronyTerms; k++ ) {
         const auto& tau       = props.pronyRelaxationTimes.block< 6, 6 >( 0, k * 6 );
         const auto& C         = props.pronyStiffnesses.block< 6, 6 >( 0, k * 6 );
@@ -71,12 +34,47 @@ namespace Marmot::ContinuumMechanics::Viscoelasticity {
             return 0.0;
         } );
 
-        stateVars.block< 6, 6 >( 0, 6 * k ) = exp_dt_tau.cwiseProduct( currState ) +
-                                              Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT ) -
-                                              Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT )
-                                                .cwiseProduct( exp_dt_tau );
+        // due to strain increment
+        stress += ( eta - eta.cwiseProduct( exp_dt_tau ) ) * dStrain / dT;
+        stiffness += ( eta - eta.cwiseProduct( exp_dt_tau ) ) / dT;
+
+        // due to history
+        stress -= Matrix6d( currState - exp_dt_tau.cwiseProduct( currState ) ).colwise().sum();
+
+        // update state variables only if it is requested
+        if ( updateStateVars )
+          stateVars.block< 6, 6 >( 0, 6 * k ) = exp_dt_tau.cwiseProduct( currState ) +
+                                                Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT ) -
+                                                Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT )
+                                                  .cwiseProduct( exp_dt_tau );
       }
     }
+  }
 
-  } // namespace PronySeries
-} // namespace Marmot::ContinuumMechanics::Viscoelasticity
+  void updateStateVars( const Properties&               props,
+                        Eigen::Ref< mapStateVarMatrix > stateVars,
+                        const Vector6d&                 dStrain,
+                        const double                    dT )
+  {
+    for ( size_t k = 0; k < props.nPronyTerms; k++ ) {
+      const auto& tau       = props.pronyRelaxationTimes.block< 6, 6 >( 0, k * 6 );
+      const auto& C         = props.pronyStiffnesses.block< 6, 6 >( 0, k * 6 );
+      const auto& currState = stateVars.block< 6, 6 >( 0, k * 6 );
+
+      const Matrix6d eta = tau.cwiseProduct( C );
+
+      const Matrix6d exp_dt_tau = tau.unaryExpr( [dT]( const double& x ) {
+        if ( x != 0.0 )
+          return std::exp( -dT / x );
+        else
+          return 0.0;
+      } );
+
+      stateVars.block< 6, 6 >( 0, 6 * k ) = exp_dt_tau.cwiseProduct( currState ) +
+                                            Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT ) -
+                                            Matrix6d( eta.array().rowwise() * dStrain.transpose().array() / dT )
+                                              .cwiseProduct( exp_dt_tau );
+    }
+  }
+
+} // namespace Marmot::ContinuumMechanics::Viscoelasticity::PronySeries

--- a/modules/core/MarmotMechanicsCore/src/MarmotVoigt.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotVoigt.cpp
@@ -7,575 +7,574 @@
 
 using namespace Eigen;
 
-namespace Marmot {
-  namespace ContinuumMechanics::VoigtNotation {
-    using namespace Constants;
-    using namespace ContinuumMechanics::HaighWestergaard;
+namespace Marmot::ContinuumMechanics::VoigtNotation {
+  using namespace Constants;
+  using namespace ContinuumMechanics::HaighWestergaard;
 
-    const Vector6d P    = ( Vector6d() << 1, 1, 1, 2, 2, 2 ).finished();
-    const Vector6d PInv = ( Vector6d() << 1, 1, 1, .5, .5, .5 ).finished();
+  const Vector6d P    = ( Vector6d() << 1, 1, 1, 2, 2, 2 ).finished();
+  const Vector6d PInv = ( Vector6d() << 1, 1, 1, .5, .5, .5 ).finished();
 
-    const Vector6d I    = ( Vector6d() << 1, 1, 1, 0, 0, 0 ).finished();
-    const Vector6d IHyd = ( Vector6d() << 1. / 3, 1. / 3, 1. / 3, 0, 0, 0 ).finished();
+  const Vector6d I    = ( Vector6d() << 1, 1, 1, 0, 0, 0 ).finished();
+  const Vector6d IHyd = ( Vector6d() << 1. / 3, 1. / 3, 1. / 3, 0, 0, 0 ).finished();
 
-    const Matrix6d IDev = ( Matrix6d() <<
-                              // clang-format off
+  const Matrix6d IDev = ( Matrix6d() <<
+                            // clang-format off
         2./3,    -1./3,   -1./3,    0,  0,  0,
         -1./3,   2./3,    -1./3,    0,  0,  0,
         -1./3,   -1./3,   2./3,     0,  0,  0,
         0,          0,      0,      1,  0,  0,
         0,          0,      0,      0,  1,  0,
         0,          0,      0,      0,  0,  1).finished();
-    // clang-format on
+  // clang-format on
 
-    Vector6d strainToVoigt( const Matrix3d& strainTensor )
-    {
-      Vector6d strain;
-      // clang-format off
+  Vector6d strainToVoigt( const Matrix3d& strainTensor )
+  {
+    Vector6d strain;
+    // clang-format off
             strain << strainTensor( 0, 0 ),
                       strainTensor( 1, 1 ),
                       strainTensor( 2, 2 ),
                   2 * strainTensor( 0, 1 ),
                   2 * strainTensor( 0, 2 ),
                   2 * strainTensor( 1, 2 );
-      // clang-format on
-      return strain;
-    }
+    // clang-format on
+    return strain;
+  }
 
-    Eigen::Matrix< double, 6, 6 > stiffnessToVoigt( const EigenTensors::Tensor3333d& C )
-    {
-      // Ordering for Voigt notation (0->xx, 1->yy, 2->zz, 3->xy, 4->xz, 5->yz)
-      std::array< std::pair< int, int >, 6 > ordering = {
-        { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 0, 1 }, { 2, 0 }, { 1, 2 } } };
+  Eigen::Matrix< double, 6, 6 > stiffnessToVoigt( const EigenTensors::Tensor3333d& C )
+  {
+    // Ordering for Voigt notation (0->xx, 1->yy, 2->zz, 3->xy, 4->xz, 5->yz)
+    std::array< std::pair< int, int >, 6 > ordering = {
+      { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 0, 1 }, { 2, 0 }, { 1, 2 } } };
 
-      Eigen::Matrix< double, 6, 6 > voigtStiffness;
-      voigtStiffness.setZero(); // Initialize with zeros
+    Eigen::Matrix< double, 6, 6 > voigtStiffness;
+    voigtStiffness.setZero(); // Initialize with zeros
 
-      for ( int a = 0; a < 6; ++a ) {
-        int i = ordering[a].first;
-        int j = ordering[a].second;
-        for ( int b = 0; b < 6; ++b ) {
-          int k = ordering[b].first;
-          int l = ordering[b].second;
+    for ( int a = 0; a < 6; ++a ) {
+      int i = ordering[a].first;
+      int j = ordering[a].second;
+      for ( int b = 0; b < 6; ++b ) {
+        int k = ordering[b].first;
+        int l = ordering[b].second;
 
-          // Populate the Voigt stiffness matrix
-          voigtStiffness( a, b ) = C( i, j, k, l );
-          voigtStiffness( a, b ) += C( j, i, k, l );
-          voigtStiffness( a, b ) += C( j, i, l, k );
-          voigtStiffness( a, b ) += C( i, j, l, k );
-          voigtStiffness( a, b ) /= 4.0;
-        }
+        // Populate the Voigt stiffness matrix
+        voigtStiffness( a, b ) = C( i, j, k, l );
+        voigtStiffness( a, b ) += C( j, i, k, l );
+        voigtStiffness( a, b ) += C( j, i, l, k );
+        voigtStiffness( a, b ) += C( i, j, l, k );
+        voigtStiffness( a, b ) /= 4.0;
       }
-
-      return voigtStiffness;
     }
 
-    EigenTensors::Tensor3333d voigtToStiffness( const Eigen::Matrix< double, 6, 6 >& voigtStiffness )
-    {
-      using namespace TensorUtility::IndexNotation;
+    return voigtStiffness;
+  }
 
-      EigenTensors::Tensor3333d stiffness;
-      stiffness.setZero(); // Initialize with zeros
+  EigenTensors::Tensor3333d voigtToStiffness( const Eigen::Matrix< double, 6, 6 >& voigtStiffness )
+  {
+    using namespace TensorUtility::IndexNotation;
 
-      int row;
-      int col;
-      for ( int i = 0; i < 3; i++ ) {
-        for ( int j = 0; j < 3; j++ ) {
-          row = toVoigt< 3 >( i, j );
-          for ( int k = 0; k < 3; k++ ) {
-            for ( int l = 0; l < 3; l++ ) {
-              col = toVoigt< 3 >( k, l );
-              stiffness( i, j, k, l ) += voigtStiffness( row, col );
-            };
+    EigenTensors::Tensor3333d stiffness;
+    stiffness.setZero(); // Initialize with zeros
+
+    int row;
+    int col;
+    for ( int i = 0; i < 3; i++ ) {
+      for ( int j = 0; j < 3; j++ ) {
+        row = toVoigt< 3 >( i, j );
+        for ( int k = 0; k < 3; k++ ) {
+          for ( int l = 0; l < 3; l++ ) {
+            col = toVoigt< 3 >( k, l );
+            stiffness( i, j, k, l ) += voigtStiffness( row, col );
           };
         };
       };
-
-      return stiffness;
-    }
-
-    FastorStandardTensors::Tensor3333d voigtToStiffnessFastor( const Marmot::Matrix6d& voigtStiffness )
-    {
-      FastorStandardTensors::Tensor3333d stiffness( 0. );
-      int                                row;
-      int                                col;
-      using namespace TensorUtility::IndexNotation;
-      for ( int i = 0; i < 3; i++ ) {
-        for ( int j = 0; j < 3; j++ ) {
-          row = toVoigt< 3 >( i, j );
-          for ( int k = 0; k < 3; k++ ) {
-            for ( int l = 0; l < 3; l++ ) {
-              col = toVoigt< 3 >( k, l );
-              stiffness( i, j, k, l ) += voigtStiffness( row, col );
-            };
-          };
-        };
-      };
-      return stiffness;
     };
 
-    Vector3d voigtToPlaneVoigt( const Vector6d& voigt )
+    return stiffness;
+  }
+
+  FastorStandardTensors::Tensor3333d voigtToStiffnessFastor( const Marmot::Matrix6d& voigtStiffness )
+  {
+    FastorStandardTensors::Tensor3333d stiffness( 0. );
+    int                                row;
+    int                                col;
+    using namespace TensorUtility::IndexNotation;
+    for ( int i = 0; i < 3; i++ ) {
+      for ( int j = 0; j < 3; j++ ) {
+        row = toVoigt< 3 >( i, j );
+        for ( int k = 0; k < 3; k++ ) {
+          for ( int l = 0; l < 3; l++ ) {
+            col = toVoigt< 3 >( k, l );
+            stiffness( i, j, k, l ) += voigtStiffness( row, col );
+          };
+        };
+      };
+    };
+    return stiffness;
+  };
+
+  Vector3d voigtToPlaneVoigt( const Vector6d& voigt )
+  {
+    /* converts a 6d voigt Vector with Abaqus notation
+       S11, S22, S33, S12, S13, S23
+       to a 3d Vector S11, S22, S12 */
+    Vector3d voigtPlane;
+    voigtPlane << voigt[0], voigt[1], voigt[3];
+    return voigtPlane;
+  }
+
+  Vector4d voigtToAxisymmetricVoigt( const Vector6d& voigt )
+  {
+    // Converts full 3D Voigt vector to axisymmetric Voigt vector
+    /* Assumes Voigt order:
+       [0] ε_rr
+       [1] ε_zz
+       [2] ε_θθ
+       [3] γ_rz
+       [4] γ_rθ (ignored)
+       [5] γ_zθ (ignored)
+
+       Axisymmetric Voigt order:
+       [0] ε_rr
+       [1] ε_zz
+       [2] ε_θθ
+       [3] γ_rz
+    */
+    Vector4d voigtAxisym;
+    voigtAxisym << voigt[0], voigt[1], voigt[2], voigt[3];
+    return voigtAxisym;
+  }
+
+  Vector6d planeVoigtToVoigt( const Vector3d& voigtPlane )
+  {
+    /* converts a 3d voigt Vector with notation
+       S11, S22, S12 to a Vector6d with
+       S11, S22, S33, S12, S13, S23
+       !!! Don't use if 3rd component is NOT ZERO !!!*/
+    Vector6d voigt;
+    voigt << voigtPlane[0], voigtPlane[1], 0, voigtPlane[2], 0, 0;
+    return voigt;
+  }
+
+  Vector6d axisymmetricVoigtToVoigt( const Vector4d& voigtAxisymmetric )
+  {
+    // Input: ε_rr, ε_zz, ε_tt (θθ), γ_rz
+    // Output: ε_rr, ε_zz, ε_tt, γ_rz, 0, 0
+    Vector6d voigt;
+    voigt << voigtAxisymmetric[0], // ε_rr
+      voigtAxisymmetric[1],        // ε_zz
+      voigtAxisymmetric[2],        // ε_θθ
+      voigtAxisymmetric[3],        // γ_rz
+      0.0,                         // γ_rθ
+      0.0;                         // γ_zθ
+    return voigt;
+  }
+
+  namespace Invariants {
+
+    Vector3d principalStrains( const Vector6d& voigtStrain )
     {
-      /* converts a 6d voigt Vector with Abaqus notation
-         S11, S22, S33, S12, S13, S23
-         to a 3d Vector S11, S22, S12 */
-      Vector3d voigtPlane;
-      voigtPlane << voigt[0], voigt[1], voigt[3];
-      return voigtPlane;
+      SelfAdjointEigenSolver< Matrix3d > es( voigtToStrain( voigtStrain ) );
+      return es.eigenvalues();
     }
 
-    Vector4d voigtToAxisymmetricVoigt( const Vector6d& voigt )
+    Vector3d principalStresses( const Vector6d& voigtStress )
     {
-      // Converts full 3D Voigt vector to axisymmetric Voigt vector
-      /* Assumes Voigt order:
-         [0] ε_rr
-         [1] ε_zz
-         [2] ε_θθ
-         [3] γ_rz
-         [4] γ_rθ (ignored)
-         [5] γ_zθ (ignored)
-
-         Axisymmetric Voigt order:
-         [0] ε_rr
-         [1] ε_zz
-         [2] ε_θθ
-         [3] γ_rz
-      */
-      Vector4d voigtAxisym;
-      voigtAxisym << voigt[0], voigt[1], voigt[2], voigt[3];
-      return voigtAxisym;
+      SelfAdjointEigenSolver< Matrix3d > es( voigtToStress( voigtStress ) );
+      return es.eigenvalues();
     }
 
-    Vector6d planeVoigtToVoigt( const Vector3d& voigtPlane )
+    Vector3d sortedPrincipalStrains( const Vector6d& voigtStrain )
     {
-      /* converts a 3d voigt Vector with notation
-         S11, S22, S12 to a Vector6d with
-         S11, S22, S33, S12, S13, S23
-         !!! Don't use if 3rd component is NOT ZERO !!!*/
-      Vector6d voigt;
-      voigt << voigtPlane[0], voigtPlane[1], 0, voigtPlane[2], 0, 0;
-      return voigt;
+      HaighWestergaardCoordinates hw = haighWestergaardFromStrain( voigtStrain );
+      Vector3d                    strainPrinc;
+
+      strainPrinc << hw.xi / sqrt3 + sqrt2_3 * hw.rho * std::cos( hw.theta ),
+        hw.xi / sqrt3 + sqrt2_3 * hw.rho * ( -std::sin( Constants::Pi / 6. - hw.theta ) ),
+        hw.xi / sqrt3 + sqrt2_3 * hw.rho * ( -std::sin( Constants::Pi / 6. + hw.theta ) );
+
+      return strainPrinc;
     }
 
-    Vector6d axisymmetricVoigtToVoigt( const Vector4d& voigtAxisymmetric )
+    Eigen::Matrix3d principalStressesDirections( const Marmot::Vector6d& voigtStress )
     {
-      // Input: ε_rr, ε_zz, ε_tt (θθ), γ_rz
-      // Output: ε_rr, ε_zz, ε_tt, γ_rz, 0, 0
-      Vector6d voigt;
-      voigt << voigtAxisymmetric[0], // ε_rr
-        voigtAxisymmetric[1],        // ε_zz
-        voigtAxisymmetric[2],        // ε_θθ
-        voigtAxisymmetric[3],        // γ_rz
-        0.0,                         // γ_rθ
-        0.0;                         // γ_zθ
-      return voigt;
+      SelfAdjointEigenSolver< Matrix3d > es( voigtToStress( voigtStress ) );
+      Matrix3d                           Q = es.eigenvectors();
+      Q.col( 2 )                           = Q.col( 0 ).cross( Q.col( 1 ) ); // for a clockwise coordinate system
+      return Q;
     }
 
-    namespace Invariants {
+    std::pair< Eigen::Vector3d, Eigen::Matrix< double, 3, 6 > > principalValuesAndDerivatives(
+      const Eigen::Matrix< double, 6, 1 >& S )
+    {
+      // This is a fast implementation of the classical algorithm for determining
+      // the principal components of a symmetric 3x3 Matrix in Voigt notation (off
+      // diagonals expected with factor 1) as well as its respective derivatives
 
-      Vector3d principalStrains( const Vector6d& voigtStrain )
-      {
-        SelfAdjointEigenSolver< Matrix3d > es( voigtToStrain( voigtStrain ) );
-        return es.eigenvalues();
-      }
+      using namespace Eigen;
 
-      Vector3d principalStresses( const Vector6d& voigtStress )
-      {
-        SelfAdjointEigenSolver< Matrix3d > es( voigtToStress( voigtStress ) );
-        return es.eigenvalues();
-      }
+      using Vector6d = Matrix< double, 6, 1 >;
+      using Matrix36 = Matrix< double, 3, 6 >;
+      using Matrix66 = Matrix< double, 6, 6 >;
 
-      Vector3d sortedPrincipalStrains( const Vector6d& voigtStrain )
-      {
-        HaighWestergaardCoordinates hw = haighWestergaardFromStrain( voigtStrain );
-        Vector3d                    strainPrinc;
+      const static auto dS0_dS = ( Vector6d() << 1, 0, 0, 0, 0, 0 ).finished();
+      const static auto dS1_dS = ( Vector6d() << 0, 1, 0, 0, 0, 0 ).finished();
+      const static auto dS2_dS = ( Vector6d() << 0, 0, 1, 0, 0, 0 ).finished();
 
-        strainPrinc << hw.xi / sqrt3 + sqrt2_3 * hw.rho * std::cos( hw.theta ),
-          hw.xi / sqrt3 + sqrt2_3 * hw.rho * ( -std::sin( Constants::Pi / 6. - hw.theta ) ),
-          hw.xi / sqrt3 + sqrt2_3 * hw.rho * ( -std::sin( Constants::Pi / 6. + hw.theta ) );
+      const double p1 = S( 3 ) * S( 3 ) + S( 4 ) * S( 4 ) + S( 5 ) * S( 5 );
 
-        return strainPrinc;
-      }
-
-      Eigen::Matrix3d principalStressesDirections( const Marmot::Vector6d& voigtStress )
-      {
-        SelfAdjointEigenSolver< Matrix3d > es( voigtToStress( voigtStress ) );
-        Matrix3d                           Q = es.eigenvectors();
-        Q.col( 2 )                           = Q.col( 0 ).cross( Q.col( 1 ) ); // for a clockwise coordinate system
-        return Q;
-      }
-
-      std::pair< Eigen::Vector3d, Eigen::Matrix< double, 3, 6 > > principalValuesAndDerivatives(
-        const Eigen::Matrix< double, 6, 1 >& S )
-      {
-        // This is a fast implementation of the classical algorithm for determining
-        // the principal components of a symmetric 3x3 Matrix in Voigt notation (off
-        // diagonals expected with factor 1) as well as its respective derivatives
-
-        using namespace Eigen;
-
-        using Vector6d = Matrix< double, 6, 1 >;
-        using Matrix36 = Matrix< double, 3, 6 >;
-        using Matrix66 = Matrix< double, 6, 6 >;
-
-        const static auto dS0_dS = ( Vector6d() << 1, 0, 0, 0, 0, 0 ).finished();
-        const static auto dS1_dS = ( Vector6d() << 0, 1, 0, 0, 0, 0 ).finished();
-        const static auto dS2_dS = ( Vector6d() << 0, 0, 1, 0, 0, 0 ).finished();
-
-        const double p1 = S( 3 ) * S( 3 ) + S( 4 ) * S( 4 ) + S( 5 ) * S( 5 );
-
-        if ( p1 <= 1e-16 ) { // matrix is already diagonal
-                             // clang-format off
+      if ( p1 <= 1e-16 ) { // matrix is already diagonal
+                           // clang-format off
                     const static auto dE_dS = ( Matrix36() << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0 ).finished();
                     return { S.head( 3 ), dE_dS };
-                             // clang-format on
-        }
-
-        const Vector6d dP1_dS = { 0, 0, 0, 2 * S( 3 ), 2 * S( 4 ), 2 * S( 5 ) };
-
-        const double   q     = S.head( 3 ).sum() / 3;
-        const Vector6d dQ_dS = Marmot::ContinuumMechanics::VoigtNotation::I / 3;
-
-        const double   p2 = std::pow( S( 0 ) - q, 2 ) + std::pow( S( 1 ) - q, 2 ) + std::pow( S( 2 ) - q, 2 ) + 2 * p1;
-        const Vector6d dP2_dS = 2 * ( S( 0 ) - q ) * ( dS0_dS - dQ_dS ) + 2 * ( S( 1 ) - q ) * ( dS1_dS - dQ_dS ) +
-                                2 * ( S( 2 ) - q ) * ( dS2_dS - dQ_dS ) + 2 * dP1_dS;
-
-        const double   p     = std::sqrt( p2 / 6 );
-        const Vector6d dP_dS = 1. / 12 * 1. / p * dP2_dS;
-
-        const Vector6d B     = 1. / p * ( S - q * Marmot::ContinuumMechanics::VoigtNotation::I );
-        const Matrix66 dB_dS = -B * 1. / p * dP_dS.transpose() +
-                               1. / p *
-                                 ( Matrix66::Identity() -
-                                   Marmot::ContinuumMechanics::VoigtNotation::I * dQ_dS.transpose() );
-
-        const double detB = B( 0 ) * B( 1 ) * B( 2 ) + B( 3 ) * B( 4 ) * B( 5 ) * 2 - B( 2 ) * B( 3 ) * B( 3 ) -
-                            B( 1 ) * B( 4 ) * B( 4 ) - B( 0 ) * B( 5 ) * B( 5 );
-
-        Vector6d dDetB_dB;
-        dDetB_dB( 0 ) = B( 1 ) * B( 2 ) - B( 5 ) * B( 5 );
-        dDetB_dB( 1 ) = B( 0 ) * B( 2 ) - B( 4 ) * B( 4 );
-        dDetB_dB( 2 ) = B( 0 ) * B( 1 ) - B( 3 ) * B( 3 );
-        dDetB_dB( 3 ) = B( 4 ) * B( 5 ) * 2 - B( 2 ) * B( 3 ) * 2;
-        dDetB_dB( 4 ) = B( 3 ) * B( 5 ) * 2 - B( 1 ) * B( 4 ) * 2;
-        dDetB_dB( 5 ) = B( 3 ) * B( 4 ) * 2 - B( 0 ) * B( 5 ) * 2;
-
-        const double   r     = detB * 1. / 2;
-        const Vector6d dR_dS = 1. / 2 * dDetB_dB.transpose() * dB_dS;
-
-        double phi;
-        double dPhi_dR;
-        if ( r <= -1 ) {
-          phi     = Constants::Pi / 3;
-          dPhi_dR = 0.0;
-        }
-        else if ( r >= 1 ) {
-          phi     = 1.0;
-          dPhi_dR = 0.0;
-        }
-        else {
-          phi     = std::acos( r ) / 3;
-          dPhi_dR = 1. / 3 * -1. / ( std::sqrt( 1 - r * r ) );
-        }
-        const Vector6d dPhi_dS = dPhi_dR * dR_dS;
-
-        Vector3d e;
-        Matrix36 dE_dS;
-
-        e( 0 )         = q + 2 * p * std::cos( phi );
-        dE_dS.row( 0 ) = dQ_dS + 2 * ( dP_dS * std::cos( phi ) - p * std::sin( phi ) * dPhi_dS );
-
-        const double phiShifted = phi + ( 2. / 3 * Constants::Pi );
-        e( 2 )                  = q + 2 * p * std::cos( phiShifted );
-        dE_dS.row( 2 )          = dQ_dS + 2 * ( dP_dS * std::cos( phiShifted ) - p * std::sin( phiShifted ) * dPhi_dS );
-
-        e( 1 )         = 3 * q - e( 0 ) - e( 2 );
-        dE_dS.row( 1 ) = 3 * dQ_dS - dE_dS.row( 0 ).transpose() - dE_dS.row( 2 ).transpose();
-
-        return { e, dE_dS };
+                           // clang-format on
       }
 
-      double vonMisesEquivalentStress( const Vector6d& stress )
-      {
-        return sqrt( 3. * J2( stress ) );
+      const Vector6d dP1_dS = { 0, 0, 0, 2 * S( 3 ), 2 * S( 4 ), 2 * S( 5 ) };
+
+      const double   q     = S.head( 3 ).sum() / 3;
+      const Vector6d dQ_dS = Marmot::ContinuumMechanics::VoigtNotation::I / 3;
+
+      const double   p2 = std::pow( S( 0 ) - q, 2 ) + std::pow( S( 1 ) - q, 2 ) + std::pow( S( 2 ) - q, 2 ) + 2 * p1;
+      const Vector6d dP2_dS = 2 * ( S( 0 ) - q ) * ( dS0_dS - dQ_dS ) + 2 * ( S( 1 ) - q ) * ( dS1_dS - dQ_dS ) +
+                              2 * ( S( 2 ) - q ) * ( dS2_dS - dQ_dS ) + 2 * dP1_dS;
+
+      const double   p     = std::sqrt( p2 / 6 );
+      const Vector6d dP_dS = 1. / 12 * 1. / p * dP2_dS;
+
+      const Vector6d B     = 1. / p * ( S - q * Marmot::ContinuumMechanics::VoigtNotation::I );
+      const Matrix66 dB_dS = -B * 1. / p * dP_dS.transpose() +
+                             1. / p *
+                               ( Matrix66::Identity() -
+                                 Marmot::ContinuumMechanics::VoigtNotation::I * dQ_dS.transpose() );
+
+      const double detB = B( 0 ) * B( 1 ) * B( 2 ) + B( 3 ) * B( 4 ) * B( 5 ) * 2 - B( 2 ) * B( 3 ) * B( 3 ) -
+                          B( 1 ) * B( 4 ) * B( 4 ) - B( 0 ) * B( 5 ) * B( 5 );
+
+      Vector6d dDetB_dB;
+      dDetB_dB( 0 ) = B( 1 ) * B( 2 ) - B( 5 ) * B( 5 );
+      dDetB_dB( 1 ) = B( 0 ) * B( 2 ) - B( 4 ) * B( 4 );
+      dDetB_dB( 2 ) = B( 0 ) * B( 1 ) - B( 3 ) * B( 3 );
+      dDetB_dB( 3 ) = B( 4 ) * B( 5 ) * 2 - B( 2 ) * B( 3 ) * 2;
+      dDetB_dB( 4 ) = B( 3 ) * B( 5 ) * 2 - B( 1 ) * B( 4 ) * 2;
+      dDetB_dB( 5 ) = B( 3 ) * B( 4 ) * 2 - B( 0 ) * B( 5 ) * 2;
+
+      const double   r     = detB * 1. / 2;
+      const Vector6d dR_dS = 1. / 2 * dDetB_dB.transpose() * dB_dS;
+
+      double phi;
+      double dPhi_dR;
+      if ( r <= -1 ) {
+        phi     = Constants::Pi / 3;
+        dPhi_dR = 0.0;
+      }
+      else if ( r >= 1 ) {
+        phi     = 1.0;
+        dPhi_dR = 0.0;
+      }
+      else {
+        phi     = std::acos( r ) / 3;
+        dPhi_dR = 1. / 3 * -1. / ( std::sqrt( 1 - r * r ) );
+      }
+      const Vector6d dPhi_dS = dPhi_dR * dR_dS;
+
+      Vector3d e;
+      Matrix36 dE_dS;
+
+      e( 0 )         = q + 2 * p * std::cos( phi );
+      dE_dS.row( 0 ) = dQ_dS + 2 * ( dP_dS * std::cos( phi ) - p * std::sin( phi ) * dPhi_dS );
+
+      const double phiShifted = phi + ( 2. / 3 * Constants::Pi );
+      e( 2 )                  = q + 2 * p * std::cos( phiShifted );
+      dE_dS.row( 2 )          = dQ_dS + 2 * ( dP_dS * std::cos( phiShifted ) - p * std::sin( phiShifted ) * dPhi_dS );
+
+      e( 1 )         = 3 * q - e( 0 ) - e( 2 );
+      dE_dS.row( 1 ) = 3 * dQ_dS - dE_dS.row( 0 ).transpose() - dE_dS.row( 2 ).transpose();
+
+      return { e, dE_dS };
+    }
+
+    double vonMisesEquivalentStress( const Vector6d& stress )
+    {
+      return sqrt( 3. * J2( stress ) );
+    }
+
+    double vonMisesEquivalentStrain( const Vector6d& strain )
+    {
+      // e_eq = sqrt( 2/3 * e_ij * e_ij )
+      const Vector6d& e = strain;
+      return std::sqrt( 2. / 3. * ( e( 0 ) * e( 0 ) + e( 1 ) * e( 1 ) + e( 2 ) * e( 2 ) ) +
+                        1. / 3. * ( e( 3 ) * e( 3 ) + e( 4 ) * e( 4 ) + e( 5 ) * e( 5 ) ) );
+    }
+
+    double normStress( const Vector6d& stress )
+    {
+      return ContinuumMechanics::VoigtNotation::voigtToStress( stress ).norm();
+    }
+
+    double StrainVolumetricNegative( const Vector6d& strain )
+    {
+      Vector3d dEpPrincipal = principalStrains( strain );
+
+      return Math::macauly( -dEpPrincipal( 0 ) ) + Math::macauly( -dEpPrincipal( 1 ) ) +
+             Math::macauly( -dEpPrincipal( 2 ) );
+    }
+
+    double I1Strain( const Vector6d& strain )
+    {
+      return strain.head( 3 ).sum();
+    }
+
+    double I2Strain( const Vector6d& strain ) // you could also use normal I2, but
+                                              // with epsilon12 instead of 2*epsilon12
+    {
+      const Vector6d& e = strain;
+
+      return e( 0 ) * e( 1 ) + e( 1 ) * e( 2 ) + e( 2 ) * e( 0 ) - e( 3 ) / 2. * e( 3 ) / 2. -
+             e( 4 ) / 2. * e( 4 ) / 2. - e( 5 ) / 2. * e( 5 ) / 2.;
+    }
+
+    double I3Strain( const Vector6d& strain ) // you could also use normal I3, but
+                                              // with epsilon12 instead of 2*epsilon12
+    {
+      return voigtToStrain( strain ).determinant();
+    }
+
+    double J2Strain( const Vector6d& strain )
+    {
+      const double res = 1. / 3. * std::pow( I1( strain ), 2. ) - I2Strain( strain );
+      return res > 0 ? res : 0;
+    }
+
+    double J3Strain( const Vector6d& strain ) // determinant of the deviatoric strain tensor
+    {
+      return voigtToStrain< double >( IDev * strain ).determinant();
+    }
+
+  } // namespace Invariants
+
+  namespace Derivatives {
+    using namespace Invariants;
+
+    Vector6d dStressMean_dStress()
+    {
+      return 1. / 3 * I;
+    }
+
+    Vector6d dTheta_dStress( double theta, const Vector6d& stress )
+    {
+      if ( theta <= 1e-15 || theta >= Pi / 3 - 1e-15 )
+        return Vector6d::Zero();
+
+      // const double J2_ = J2(stress);
+      // const double J3_ = J3(stress);
+
+      const double dThetadJ2 = dTheta_dJ2( stress );
+      const double dThetadJ3 = dTheta_dJ3( stress );
+
+      if ( Math::isNaN( dThetadJ2 ) || Math::isNaN( dThetadJ3 ) )
+        return Vector6d::Zero();
+
+      return dThetadJ2 * dJ2_dStress( stress ) + dThetadJ3 * dJ3_dStress( stress );
+    }
+
+    double dTheta_dJ2( const Vector6d& stress )
+    {
+      const HaighWestergaardCoordinates hw    = haighWestergaard( stress );
+      const double&                     theta = hw.theta;
+
+      if ( theta <= 1e-14 || theta >= Pi / 3 - 1e-14 )
+        return 1e16;
+
+      const double J2_ = J2( stress );
+      const double J3_ = J3( stress );
+
+      const double cos2_3theta = std::cos( 3 * theta ) * std::cos( 3 * theta );
+      const double dThetadJ2   = 3 * sqrt3 / 4 * J3_ / ( std::pow( J2_, 2.5 ) * std::sqrt( 1.0 - cos2_3theta ) );
+      return dThetadJ2;
+    }
+
+    double dTheta_dJ3( const Vector6d& stress )
+    {
+      const HaighWestergaardCoordinates hw    = haighWestergaard( stress );
+      const double&                     theta = hw.theta;
+
+      if ( theta <= 1e-14 || theta >= Pi / 3 - 1e-14 )
+        return -1e16;
+
+      const double J2_ = J2( stress );
+      // const double J3_ = J3(stress);
+
+      const double cos2_3theta = std::cos( 3 * theta ) * std::cos( 3 * theta );
+      const double dThetadJ3   = -sqrt3 / 2. * 1. / ( std::pow( J2_, 1.5 ) * std::sqrt( 1.0 - cos2_3theta ) );
+      return dThetadJ3;
+    }
+
+    double dThetaStrain_dJ2Strain( const Vector6d& strain )
+    {
+      const HaighWestergaardCoordinates hw    = haighWestergaardFromStrain( strain );
+      const double                      theta = hw.theta;
+
+      if ( theta <= 1e-15 || theta >= Pi / 3 - 1e-15 )
+        return 1e16;
+      else
+        return 3. * std::sqrt( 3. ) / 4. * J3Strain( strain ) /
+               ( std::pow( J2Strain( strain ), 5. / 2 ) * std::sqrt( 1. - std::pow( std::cos( 3. * theta ), 2. ) ) );
+    }
+
+    double dThetaStrain_dJ3Strain( const Vector6d& strain )
+    {
+      const HaighWestergaardCoordinates hw    = haighWestergaardFromStrain( strain );
+      const double&                     theta = hw.theta;
+
+      if ( theta <= 1e-15 || theta >= Pi / 3 - 1e-15 )
+        return -1e16;
+      else
+        return -std::sqrt( 3. ) / 2. * 1. /
+               ( std::pow( J2Strain( strain ), 3. / 2 ) * std::sqrt( 1. - std::pow( std::cos( 3. * theta ), 2. ) ) );
+    }
+
+    Vector6d dJ2_dStress( const Vector6d& stress )
+    {
+      return P.array() * ( IDev * stress ).array();
+    }
+
+    Vector6d dJ3_dStress( const Vector6d& stress )
+    {
+      Vector6d s = IDev * stress;
+      return ( P.array() * stressToVoigt< double >( voigtToStress( s ) * voigtToStress( s ) ).array() ).matrix() -
+             2. / 3. * J2( stress ) * I;
+    }
+
+    Vector6d dJ2Strain_dStrain( const Vector6d& strain )
+    {
+      return PInv.array() * ( IDev * strain ).array();
+    }
+
+    Vector6d dJ3Strain_dStrain( const Vector6d& strain )
+    {
+      Vector6d e = IDev * strain;
+      return ( PInv.array() * strainToVoigt( voigtToStrain( e ) * voigtToStrain( e ) ).array() ).matrix() -
+             2. / 3. * J2Strain( strain ) * I;
+    }
+
+    Vector6d dThetaStrain_dStrain( const Vector6d& strain )
+
+    {
+      return dThetaStrain_dJ2Strain( strain ) * dJ2Strain_dStrain( strain ) +
+             dThetaStrain_dJ3Strain( strain ) * dJ3Strain_dStrain( strain );
+    }
+
+    Matrix36 dStressPrincipals_dStress( const Vector6d& stress ) // derivative when principal stresses are
+                                                                 // computed from solving Eigenvalue-Problem
+    {
+      MatrixXd J( 3, 6 );
+
+      Vector6d leftX;
+      Vector6d rightX;
+
+      for ( size_t i = 0; i < 6; i++ ) {
+        double volatile h = std::max( 1.0, std::abs( stress( i ) ) ) * Constants::cubicRootEps();
+        leftX             = stress;
+        leftX( i ) -= h;
+        rightX = stress;
+        rightX( i ) += h;
+
+        J.col( i ) = 1. / ( 2 * h ) * ( principalStresses( rightX ) - principalStresses( leftX ) );
+      }
+      return J;
+    }
+
+    Vector3d dStrainVolumetricNegative_dStrainPrincipal( const Vector6d& strain )
+    {
+      Vector3d       dEvdEpPrinc  = Vector3d::Zero();
+      const Vector3d deltaEpPrinc = Invariants::sortedPrincipalStrains( strain );
+
+      for ( int i = 0; i < dEvdEpPrinc.size(); i++ )
+        dEvdEpPrinc( i ) = -Math::heaviside( -deltaEpPrinc( i ) );
+
+      return dEvdEpPrinc;
+    }
+
+    Matrix6d dEp_dE( const Matrix6d& CelInv, const Matrix6d& Cep )
+    {
+      return Matrix6d::Identity() - CelInv * Cep;
+    }
+
+    RowVector6d dDeltaEpv_dE( const Matrix6d& CelInv, const Matrix6d& Cep )
+    {
+      return I.transpose() * ( Matrix6d::Identity() - CelInv * Cep );
+    }
+
+    Matrix36 dSortedStrainPrincipal_dStrain(
+      const Vector6d& dEp ) // equations from page 218-219 PhD Thesis David Unteregger
+    {
+      Vector3d dEpPrinc_dEpvol   = Vector3d::Zero();
+      Vector3d dEpPrinc_dEprho   = Vector3d::Zero();
+      Vector3d dEPprinc_dEptheta = Vector3d::Zero();
+
+      const double                      sqrt2_3 = std::sqrt( 2. / 3. );
+      const HaighWestergaardCoordinates hw      = haighWestergaardFromStrain( dEp );
+      // const double& epsM =		hw(0);
+      const double& rhoE = hw.rho;
+      // const double& thetaE =		hw(2);
+
+      dEpPrinc_dEpvol = 1. / 3. * Vector3d::Ones();
+      dEpPrinc_dEprho << sqrt2_3 * std::cos( hw.theta ), sqrt2_3 * std::cos( hw.theta - 2. * Constants::Pi / 3. ),
+        sqrt2_3 * std::cos( hw.theta + 2. * Constants::Pi / 3. );
+
+      dEPprinc_dEptheta << -sqrt2_3 * hw.rho * std::sin( hw.theta ),
+        -sqrt2_3 * hw.rho * std::sin( hw.theta - 2. * Constants::Pi / 3. ),
+        -sqrt2_3 * hw.rho * std::sin( hw.theta + 2. * Constants::Pi / 3. );
+
+      RowVector6d dEpvol_dEp   = RowVector6d::Zero();
+      dEpvol_dEp               = I;
+      RowVector6d dEprho_dEp   = RowVector6d::Zero();
+      RowVector6d dEptheta_dEp = RowVector6d::Zero();
+
+      if ( std::abs( rhoE ) > 1e-16 ) {
+        dEprho_dEp   = 1. / rhoE * dJ2Strain_dStrain( dEp ).transpose();
+        dEptheta_dEp = ( dThetaStrain_dJ2Strain( dEp ) * dJ2Strain_dStrain( dEp ).transpose() ) +
+                       ( dThetaStrain_dJ3Strain( dEp ) * dJ3Strain_dStrain( dEp ).transpose() );
+      }
+      else {
+        dEprho_dEp << 1.e16, 1.e16, 1.e16, 1.e16, 1.e16,
+          1.e16; // 1e16 from Code David (Line 67,
+                 // D_2_Umatsub_damage3_derivatives)
+        dEptheta_dEp << 0., 0., 0., 0., 0., 0.;
       }
 
-      double vonMisesEquivalentStrain( const Vector6d& strain )
-      {
-        // e_eq = sqrt( 2/3 * e_ij * e_ij )
-        const Vector6d& e = strain;
-        return std::sqrt( 2. / 3. * ( e( 0 ) * e( 0 ) + e( 1 ) * e( 1 ) + e( 2 ) * e( 2 ) ) +
-                          1. / 3. * ( e( 3 ) * e( 3 ) + e( 4 ) * e( 4 ) + e( 5 ) * e( 5 ) ) );
-      }
+      Matrix36 dEpPrincdEpAna;
+      dEpPrincdEpAna = ( dEpPrinc_dEpvol * dEpvol_dEp ) + ( dEpPrinc_dEprho * dEprho_dEp ) +
+                       ( dEPprinc_dEptheta * dEptheta_dEp );
 
-      double normStress( const Vector6d& stress )
-      {
-        return ContinuumMechanics::VoigtNotation::voigtToStress( stress ).norm();
-      }
+      return dEpPrincdEpAna;
+    }
 
-      double StrainVolumetricNegative( const Vector6d& strain )
-      {
-        Vector3d dEpPrincipal = principalStrains( strain );
+    RowVector6d dDeltaEpvneg_dE( const Vector6d& dEp, const Matrix6d& CelInv, const Matrix6d& Cep )
+    {
+      return dStrainVolumetricNegative_dStrainPrincipal( dEp ).transpose() * dSortedStrainPrincipal_dStrain( dEp ) *
+             dEp_dE( CelInv, Cep );
+    }
 
-        return Math::macauly( -dEpPrincipal( 0 ) ) + Math::macauly( -dEpPrincipal( 1 ) ) +
-               Math::macauly( -dEpPrincipal( 2 ) );
-      }
+  } // namespace Derivatives
+  namespace Transformations {
+    Matrix6d transformationMatrixStrainVoigt( const Matrix3d& transformedCoordinateSystem )
+    {
+      Matrix6d transformationMatrix = transformationMatrixStressVoigt( transformedCoordinateSystem );
+      transformationMatrix.topRightCorner( 3, 3 ) *= 0.5;
+      transformationMatrix.bottomLeftCorner( 3, 3 ) *= 2;
 
-      double I1Strain( const Vector6d& strain )
-      {
-        return strain.head( 3 ).sum();
-      }
+      return transformationMatrix;
+    }
 
-      double I2Strain( const Vector6d& strain ) // you could also use normal I2, but
-                                                // with epsilon12 instead of 2*epsilon12
-      {
-        const Vector6d& e = strain;
+    Matrix6d transformationMatrixStressVoigt( const Matrix3d& transformedCoordinateSystem )
+    {
+      const Matrix3d N = Math::directionCosines( transformedCoordinateSystem );
 
-        return e( 0 ) * e( 1 ) + e( 1 ) * e( 2 ) + e( 2 ) * e( 0 ) - e( 3 ) / 2. * e( 3 ) / 2. -
-               e( 4 ) / 2. * e( 4 ) / 2. - e( 5 ) / 2. * e( 5 ) / 2.;
-      }
+      Matrix6d transformationMatrix;
 
-      double I3Strain( const Vector6d& strain ) // you could also use normal I3, but
-                                                // with epsilon12 instead of 2*epsilon12
-      {
-        return voigtToStrain( strain ).determinant();
-      }
-
-      double J2Strain( const Vector6d& strain )
-      {
-        const double res = 1. / 3. * std::pow( I1( strain ), 2. ) - I2Strain( strain );
-        return res > 0 ? res : 0;
-      }
-
-      double J3Strain( const Vector6d& strain ) // determinant of the deviatoric strain tensor
-      {
-        return voigtToStrain< double >( IDev * strain ).determinant();
-      }
-
-    } // namespace Invariants
-
-    namespace Derivatives {
-      using namespace Invariants;
-
-      Vector6d dStressMean_dStress()
-      {
-        return 1. / 3 * I;
-      }
-
-      Vector6d dTheta_dStress( double theta, const Vector6d& stress )
-      {
-        if ( theta <= 1e-15 || theta >= Pi / 3 - 1e-15 )
-          return Vector6d::Zero();
-
-        // const double J2_ = J2(stress);
-        // const double J3_ = J3(stress);
-
-        const double dThetadJ2 = dTheta_dJ2( stress );
-        const double dThetadJ3 = dTheta_dJ3( stress );
-
-        if ( Math::isNaN( dThetadJ2 ) || Math::isNaN( dThetadJ3 ) )
-          return Vector6d::Zero();
-
-        return dThetadJ2 * dJ2_dStress( stress ) + dThetadJ3 * dJ3_dStress( stress );
-      }
-
-      double dTheta_dJ2( const Vector6d& stress )
-      {
-        const HaighWestergaardCoordinates hw    = haighWestergaard( stress );
-        const double&                     theta = hw.theta;
-
-        if ( theta <= 1e-14 || theta >= Pi / 3 - 1e-14 )
-          return 1e16;
-
-        const double J2_ = J2( stress );
-        const double J3_ = J3( stress );
-
-        const double cos2_3theta = std::cos( 3 * theta ) * std::cos( 3 * theta );
-        const double dThetadJ2   = 3 * sqrt3 / 4 * J3_ / ( std::pow( J2_, 2.5 ) * std::sqrt( 1.0 - cos2_3theta ) );
-        return dThetadJ2;
-      }
-
-      double dTheta_dJ3( const Vector6d& stress )
-      {
-        const HaighWestergaardCoordinates hw    = haighWestergaard( stress );
-        const double&                     theta = hw.theta;
-
-        if ( theta <= 1e-14 || theta >= Pi / 3 - 1e-14 )
-          return -1e16;
-
-        const double J2_ = J2( stress );
-        // const double J3_ = J3(stress);
-
-        const double cos2_3theta = std::cos( 3 * theta ) * std::cos( 3 * theta );
-        const double dThetadJ3   = -sqrt3 / 2. * 1. / ( std::pow( J2_, 1.5 ) * std::sqrt( 1.0 - cos2_3theta ) );
-        return dThetadJ3;
-      }
-
-      double dThetaStrain_dJ2Strain( const Vector6d& strain )
-      {
-        const HaighWestergaardCoordinates hw    = haighWestergaardFromStrain( strain );
-        const double                      theta = hw.theta;
-
-        if ( theta <= 1e-15 || theta >= Pi / 3 - 1e-15 )
-          return 1e16;
-        else
-          return 3. * std::sqrt( 3. ) / 4. * J3Strain( strain ) /
-                 ( std::pow( J2Strain( strain ), 5. / 2 ) * std::sqrt( 1. - std::pow( std::cos( 3. * theta ), 2. ) ) );
-      }
-
-      double dThetaStrain_dJ3Strain( const Vector6d& strain )
-      {
-        const HaighWestergaardCoordinates hw    = haighWestergaardFromStrain( strain );
-        const double&                     theta = hw.theta;
-
-        if ( theta <= 1e-15 || theta >= Pi / 3 - 1e-15 )
-          return -1e16;
-        else
-          return -std::sqrt( 3. ) / 2. * 1. /
-                 ( std::pow( J2Strain( strain ), 3. / 2 ) * std::sqrt( 1. - std::pow( std::cos( 3. * theta ), 2. ) ) );
-      }
-
-      Vector6d dJ2_dStress( const Vector6d& stress )
-      {
-        return P.array() * ( IDev * stress ).array();
-      }
-
-      Vector6d dJ3_dStress( const Vector6d& stress )
-      {
-        Vector6d s = IDev * stress;
-        return ( P.array() * stressToVoigt< double >( voigtToStress( s ) * voigtToStress( s ) ).array() ).matrix() -
-               2. / 3. * J2( stress ) * I;
-      }
-
-      Vector6d dJ2Strain_dStrain( const Vector6d& strain )
-      {
-        return PInv.array() * ( IDev * strain ).array();
-      }
-
-      Vector6d dJ3Strain_dStrain( const Vector6d& strain )
-      {
-        Vector6d e = IDev * strain;
-        return ( PInv.array() * strainToVoigt( voigtToStrain( e ) * voigtToStrain( e ) ).array() ).matrix() -
-               2. / 3. * J2Strain( strain ) * I;
-      }
-
-      Vector6d dThetaStrain_dStrain( const Vector6d& strain )
-
-      {
-        return dThetaStrain_dJ2Strain( strain ) * dJ2Strain_dStrain( strain ) +
-               dThetaStrain_dJ3Strain( strain ) * dJ3Strain_dStrain( strain );
-      }
-
-      Matrix36 dStressPrincipals_dStress( const Vector6d& stress ) // derivative when principal stresses are
-                                                                   // computed from solving Eigenvalue-Problem
-      {
-        MatrixXd J( 3, 6 );
-
-        Vector6d leftX;
-        Vector6d rightX;
-
-        for ( size_t i = 0; i < 6; i++ ) {
-          double volatile h = std::max( 1.0, std::abs( stress( i ) ) ) * Constants::cubicRootEps();
-          leftX             = stress;
-          leftX( i ) -= h;
-          rightX = stress;
-          rightX( i ) += h;
-
-          J.col( i ) = 1. / ( 2 * h ) * ( principalStresses( rightX ) - principalStresses( leftX ) );
-        }
-        return J;
-      }
-
-      Vector3d dStrainVolumetricNegative_dStrainPrincipal( const Vector6d& strain )
-      {
-        Vector3d       dEvdEpPrinc  = Vector3d::Zero();
-        const Vector3d deltaEpPrinc = Invariants::sortedPrincipalStrains( strain );
-
-        for ( int i = 0; i < dEvdEpPrinc.size(); i++ )
-          dEvdEpPrinc( i ) = -Math::heaviside( -deltaEpPrinc( i ) );
-
-        return dEvdEpPrinc;
-      }
-
-      Matrix6d dEp_dE( const Matrix6d& CelInv, const Matrix6d& Cep )
-      {
-        return Matrix6d::Identity() - CelInv * Cep;
-      }
-
-      RowVector6d dDeltaEpv_dE( const Matrix6d& CelInv, const Matrix6d& Cep )
-      {
-        return I.transpose() * ( Matrix6d::Identity() - CelInv * Cep );
-      }
-
-      Matrix36 dSortedStrainPrincipal_dStrain(
-        const Vector6d& dEp ) // equations from page 218-219 PhD Thesis David Unteregger
-      {
-        Vector3d dEpPrinc_dEpvol   = Vector3d::Zero();
-        Vector3d dEpPrinc_dEprho   = Vector3d::Zero();
-        Vector3d dEPprinc_dEptheta = Vector3d::Zero();
-
-        const double                      sqrt2_3 = std::sqrt( 2. / 3. );
-        const HaighWestergaardCoordinates hw      = haighWestergaardFromStrain( dEp );
-        // const double& epsM =		hw(0);
-        const double& rhoE = hw.rho;
-        // const double& thetaE =		hw(2);
-
-        dEpPrinc_dEpvol = 1. / 3. * Vector3d::Ones();
-        dEpPrinc_dEprho << sqrt2_3 * std::cos( hw.theta ), sqrt2_3 * std::cos( hw.theta - 2. * Constants::Pi / 3. ),
-          sqrt2_3 * std::cos( hw.theta + 2. * Constants::Pi / 3. );
-
-        dEPprinc_dEptheta << -sqrt2_3 * hw.rho * std::sin( hw.theta ),
-          -sqrt2_3 * hw.rho * std::sin( hw.theta - 2. * Constants::Pi / 3. ),
-          -sqrt2_3 * hw.rho * std::sin( hw.theta + 2. * Constants::Pi / 3. );
-
-        RowVector6d dEpvol_dEp   = RowVector6d::Zero();
-        dEpvol_dEp               = I;
-        RowVector6d dEprho_dEp   = RowVector6d::Zero();
-        RowVector6d dEptheta_dEp = RowVector6d::Zero();
-
-        if ( std::abs( rhoE ) > 1e-16 ) {
-          dEprho_dEp   = 1. / rhoE * dJ2Strain_dStrain( dEp ).transpose();
-          dEptheta_dEp = ( dThetaStrain_dJ2Strain( dEp ) * dJ2Strain_dStrain( dEp ).transpose() ) +
-                         ( dThetaStrain_dJ3Strain( dEp ) * dJ3Strain_dStrain( dEp ).transpose() );
-        }
-        else {
-          dEprho_dEp << 1.e16, 1.e16, 1.e16, 1.e16, 1.e16,
-            1.e16; // 1e16 from Code David (Line 67,
-                   // D_2_Umatsub_damage3_derivatives)
-          dEptheta_dEp << 0., 0., 0., 0., 0., 0.;
-        }
-
-        Matrix36 dEpPrincdEpAna;
-        dEpPrincdEpAna = ( dEpPrinc_dEpvol * dEpvol_dEp ) + ( dEpPrinc_dEprho * dEprho_dEp ) +
-                         ( dEPprinc_dEptheta * dEptheta_dEp );
-
-        return dEpPrincdEpAna;
-      }
-
-      RowVector6d dDeltaEpvneg_dE( const Vector6d& dEp, const Matrix6d& CelInv, const Matrix6d& Cep )
-      {
-        return dStrainVolumetricNegative_dStrainPrincipal( dEp ).transpose() * dSortedStrainPrincipal_dStrain( dEp ) *
-               dEp_dE( CelInv, Cep );
-      }
-
-    } // namespace Derivatives
-    namespace Transformations {
-      Matrix6d transformationMatrixStrainVoigt( const Matrix3d& transformedCoordinateSystem )
-      {
-        Matrix6d transformationMatrix = transformationMatrixStressVoigt( transformedCoordinateSystem );
-        transformationMatrix.topRightCorner( 3, 3 ) *= 0.5;
-        transformationMatrix.bottomLeftCorner( 3, 3 ) *= 2;
-
-        return transformationMatrix;
-      }
-
-      Matrix6d transformationMatrixStressVoigt( const Matrix3d& transformedCoordinateSystem )
-      {
-        const Matrix3d N = Math::directionCosines( transformedCoordinateSystem );
-
-        Matrix6d transformationMatrix;
-
-        // clang-format off
+      // clang-format off
         transformationMatrix <<
                     pow(N(0,0),2), pow(N(0,1),2), pow(N(0,2),2), 2*N(0,0)*N(0,1), 2*N(0,0)*N(0,2), 2*N(0,2)*N(0,1),
                     pow(N(1,0),2), pow(N(1,1),2), pow(N(1,2),2), 2*N(1,0)*N(1,1), 2*N(1,0)*N(1,2), 2*N(1,2)*N(1,1),
@@ -583,93 +582,92 @@ namespace Marmot {
                     N(0,0)*N(1,0), N(0,1)*N(1,1), N(0,2)*N(1,2), N(0,0)*N(1,1)+N(0,1)*N(1,0), N(0,0)*N(1,2)+N(0,2)*N(1,0), N(0,1)*N(1,2)+N(0,2)*N(1,1),
                     N(2,0)*N(0,0), N(2,1)*N(0,1), N(2,2)*N(0,2), N(2,0)*N(0,1)+N(2,1)*N(0,0), N(2,0)*N(0,2)+N(2,2)*N(0,0), N(2,1)*N(0,2)+N(2,2)*N(0,1),
                     N(1,0)*N(2,0), N(1,1)*N(2,1), N(1,2)*N(2,2), N(1,0)*N(2,1)+N(1,1)*N(2,0), N(1,0)*N(2,2)+N(1,2)*N(2,0), N(1,1)*N(2,2)+N(1,2)*N(2,1);
-        // clang-format on
+      // clang-format on
 
-        return transformationMatrix;
-      }
+      return transformationMatrix;
+    }
 
-      Matrix36d projectVoigtStressToPlane( const Vector3d& normalVector )
-      {
-        const Vector3d& n = normalVector;
+    Matrix36d projectVoigtStressToPlane( const Vector3d& normalVector )
+    {
+      const Vector3d& n = normalVector;
 
-        // clang-format off
+      // clang-format off
                 Matrix36d projectMatrix;
                 projectMatrix << n( 0 ),      0,      0, n( 1 ), 0,      n( 2 ),
                                       0, n( 1 ),      0, n( 0 ), n( 2 ),      0,
                                       0,      0, n( 2 ),      0, n( 1 ), n( 0 );
-        // clang-format on
-        return projectMatrix;
-      }
+      // clang-format on
+      return projectMatrix;
+    }
 
-      Matrix36d projectVoigtStrainToPlane( const Vector3d& normalVector )
-      {
-        Matrix36d projectMatrix = projectVoigtStressToPlane( normalVector );
-        projectMatrix.topRightCorner( 3, 3 ) *= 0.5;
+    Matrix36d projectVoigtStrainToPlane( const Vector3d& normalVector )
+    {
+      Matrix36d projectMatrix = projectVoigtStressToPlane( normalVector );
+      projectMatrix.topRightCorner( 3, 3 ) *= 0.5;
 
-        return projectMatrix;
-      }
+      return projectMatrix;
+    }
 
-      Marmot::Vector6d rotateVoigtStress( const Eigen::Matrix3d& Q, const Marmot::Vector6d& voigtStress )
-      {
-        const Matrix3d& T  = voigtToStress( voigtStress );
-        const Matrix3d& TR = Q * T * Q.transpose();
-        return stressToVoigt( TR );
-      }
+    Marmot::Vector6d rotateVoigtStress( const Eigen::Matrix3d& Q, const Marmot::Vector6d& voigtStress )
+    {
+      const Matrix3d& T  = voigtToStress( voigtStress );
+      const Matrix3d& TR = Q * T * Q.transpose();
+      return stressToVoigt( TR );
+    }
 
-      Marmot::Vector6d transformStressToLocalSystem( const Marmot::Vector6d& stress,
-                                                     const Matrix3d&         transformedCoordinateSystem )
-      {
-        const Matrix3d s_prime = Math::transformToLocalSystem( voigtToStress( stress ), transformedCoordinateSystem );
+    Marmot::Vector6d transformStressToLocalSystem( const Marmot::Vector6d& stress,
+                                                   const Matrix3d&         transformedCoordinateSystem )
+    {
+      const Matrix3d s_prime = Math::transformToLocalSystem( voigtToStress( stress ), transformedCoordinateSystem );
 
-        return stressToVoigt( s_prime );
-      }
+      return stressToVoigt( s_prime );
+    }
 
-      Marmot::Vector6d transformStrainToLocalSystem( const Marmot::Vector6d& strain,
-                                                     const Matrix3d&         transformedCoordinateSystem )
-      {
-        const Matrix3d e_prime = Math::transformToLocalSystem( voigtToStrain( strain ), transformedCoordinateSystem );
+    Marmot::Vector6d transformStrainToLocalSystem( const Marmot::Vector6d& strain,
+                                                   const Matrix3d&         transformedCoordinateSystem )
+    {
+      const Matrix3d e_prime = Math::transformToLocalSystem( voigtToStrain( strain ), transformedCoordinateSystem );
 
-        return strainToVoigt( e_prime );
-      }
+      return strainToVoigt( e_prime );
+    }
 
-      Marmot::Vector6d transformStressToGlobalSystem( const Marmot::Vector6d& stress,
-                                                      const Matrix3d&         transformedCoordinateSystem )
-      {
-        const Matrix3d s_prime = Math::transformToGlobalSystem( voigtToStress( stress ), transformedCoordinateSystem );
+    Marmot::Vector6d transformStressToGlobalSystem( const Marmot::Vector6d& stress,
+                                                    const Matrix3d&         transformedCoordinateSystem )
+    {
+      const Matrix3d s_prime = Math::transformToGlobalSystem( voigtToStress( stress ), transformedCoordinateSystem );
 
-        return stressToVoigt( s_prime );
-      }
-      Marmot::Vector6d transformStrainToGlobalSystem( const Marmot::Vector6d& strain,
-                                                      const Matrix3d&         transformedCoordinateSystem )
-      {
-        const Matrix3d e_prime = Math::transformToGlobalSystem( voigtToStrain( strain ), transformedCoordinateSystem );
+      return stressToVoigt( s_prime );
+    }
+    Marmot::Vector6d transformStrainToGlobalSystem( const Marmot::Vector6d& strain,
+                                                    const Matrix3d&         transformedCoordinateSystem )
+    {
+      const Matrix3d e_prime = Math::transformToGlobalSystem( voigtToStrain( strain ), transformedCoordinateSystem );
 
-        return strainToVoigt( e_prime );
-      }
+      return strainToVoigt( e_prime );
+    }
 
-      Matrix6d transformStiffnessToGlobalSystem( const Marmot::Matrix6d& stiffness,
-                                                 const Matrix3d&         transformedCoordinateSystem )
-      {
-        const EigenTensors::Tensor3333d stiffnessTensorLocal = voigtToStiffness( stiffness );
-        EigenTensors::Tensor3333d       stiffnessTensorGlobal;
-        stiffnessTensorGlobal.setZero();
-        Matrix3d N = transformedCoordinateSystem.transpose();
+    Matrix6d transformStiffnessToGlobalSystem( const Marmot::Matrix6d& stiffness,
+                                               const Matrix3d&         transformedCoordinateSystem )
+    {
+      const EigenTensors::Tensor3333d stiffnessTensorLocal = voigtToStiffness( stiffness );
+      EigenTensors::Tensor3333d       stiffnessTensorGlobal;
+      stiffnessTensorGlobal.setZero();
+      Matrix3d N = transformedCoordinateSystem.transpose();
 
-        for ( size_t i = 0; i < 3; i++ )
-          for ( size_t j = 0; j < 3; j++ )
-            for ( size_t k = 0; k < 3; k++ )
-              for ( size_t l = 0; l < 3; l++ )
-                for ( size_t m = 0; m < 3; m++ )
-                  for ( size_t n = 0; n < 3; n++ )
-                    for ( size_t o = 0; o < 3; o++ )
-                      for ( size_t p = 0; p < 3; p++ )
-                        stiffnessTensorGlobal( i, j, k, l ) += N( i, m ) * N( j, n ) * N( k, o ) * N( l, p ) *
-                                                               stiffnessTensorLocal( m, n, o, p );
+      for ( size_t i = 0; i < 3; i++ )
+        for ( size_t j = 0; j < 3; j++ )
+          for ( size_t k = 0; k < 3; k++ )
+            for ( size_t l = 0; l < 3; l++ )
+              for ( size_t m = 0; m < 3; m++ )
+                for ( size_t n = 0; n < 3; n++ )
+                  for ( size_t o = 0; o < 3; o++ )
+                    for ( size_t p = 0; p < 3; p++ )
+                      stiffnessTensorGlobal( i, j, k, l ) += N( i, m ) * N( j, n ) * N( k, o ) * N( l, p ) *
+                                                             stiffnessTensorLocal( m, n, o, p );
 
-        Matrix6d res = stiffnessToVoigt( stiffnessTensorGlobal );
-        return res;
-      }
+      Matrix6d res = stiffnessToVoigt( stiffnessTensorGlobal );
+      return res;
+    }
 
-    } // namespace Transformations
-  }   // namespace ContinuumMechanics::VoigtNotation
-} // namespace Marmot
+  } // namespace Transformations
+} // namespace Marmot::ContinuumMechanics::VoigtNotation

--- a/modules/core/MarmotMechanicsCore/src/MenetreyWillam.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MenetreyWillam.cpp
@@ -3,50 +3,48 @@
 #include <cmath>
 #include <sstream>
 
-namespace Marmot {
-  namespace ContinuumMechanics::CommonConstitutiveModels {
-    using namespace Constants;
-    using namespace ContinuumMechanics::HaighWestergaard;
+namespace Marmot::ContinuumMechanics::CommonConstitutiveModels {
+  using namespace Constants;
+  using namespace ContinuumMechanics::HaighWestergaard;
 
-    MenetreyWillam::MenetreyWillam( const double ft, const MenetreyWillamType& type, const double fc )
-    {
-      setParameters( ft, fc, type );
+  MenetreyWillam::MenetreyWillam( const double ft, const MenetreyWillamType& type, const double fc )
+  {
+    setParameters( ft, fc, type );
+  }
+
+  void MenetreyWillam::setParameters( const double ft, const double fc, const MenetreyWillamType& type )
+  {
+    switch ( type ) {
+    case MenetreyWillamType::Mises:
+      param.Af = 0;
+      param.Bf = sqrt3_2 / ft;
+      param.Cf = 0;
+      param.m  = 1;
+      param.e  = 1;
+      break;
+    case MenetreyWillamType::Rankine:
+      param.Af = 0;
+      param.Bf = 1. / ( sqrt6 * ft );
+      param.Cf = 1. / ( sqrt3 * ft );
+      param.m  = 1;
+      param.e  = 0.51;
+      break;
+    case MenetreyWillamType::DruckerPrager:
+      param.Af = 0;
+      param.Bf = sqrt3_8 * ( fc + ft ) / ( fc * ft );
+      param.Cf = 3. / 2 * ( fc - ft ) / ( fc * ft );
+      param.m  = 1;
+      param.e  = 1;
+      break;
+    case MenetreyWillamType::MohrCoulomb:
+      param.Af = 0;
+      param.Bf = 1. / sqrt6 * ( fc + 2. * ft ) / ( fc * ft );
+      param.Cf = 1. / sqrt3 * ( fc - ft ) / ( fc * ft );
+      param.m  = 1.;
+      param.e  = ( fc + 2 * ft ) / ( 2 * fc + ft );
+      break;
+    default: throw std::invalid_argument( "Requested MenetreyWillamType not found." );
     }
+  }
 
-    void MenetreyWillam::setParameters( const double ft, const double fc, const MenetreyWillamType& type )
-    {
-      switch ( type ) {
-      case MenetreyWillamType::Mises:
-        param.Af = 0;
-        param.Bf = sqrt3_2 / ft;
-        param.Cf = 0;
-        param.m  = 1;
-        param.e  = 1;
-        break;
-      case MenetreyWillamType::Rankine:
-        param.Af = 0;
-        param.Bf = 1. / ( sqrt6 * ft );
-        param.Cf = 1. / ( sqrt3 * ft );
-        param.m  = 1;
-        param.e  = 0.51;
-        break;
-      case MenetreyWillamType::DruckerPrager:
-        param.Af = 0;
-        param.Bf = sqrt3_8 * ( fc + ft ) / ( fc * ft );
-        param.Cf = 3. / 2 * ( fc - ft ) / ( fc * ft );
-        param.m  = 1;
-        param.e  = 1;
-        break;
-      case MenetreyWillamType::MohrCoulomb:
-        param.Af = 0;
-        param.Bf = 1. / sqrt6 * ( fc + 2. * ft ) / ( fc * ft );
-        param.Cf = 1. / sqrt3 * ( fc - ft ) / ( fc * ft );
-        param.m  = 1.;
-        param.e  = ( fc + 2 * ft ) / ( 2 * fc + ft );
-        break;
-      default: throw std::invalid_argument( "Requested MenetreyWillamType not found." );
-      }
-    }
-
-  } // namespace ContinuumMechanics::CommonConstitutiveModels
-} // namespace Marmot
+} // namespace Marmot::ContinuumMechanics::CommonConstitutiveModels

--- a/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestHaighWestergaard.cpp
@@ -1,6 +1,7 @@
 #include "Marmot/HaighWestergaard.h"
 #include "Marmot/MarmotTesting.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::ContinuumMechanics::HaighWestergaard;
 using namespace Marmot::ContinuumMechanics::VoigtNotation::Invariants;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotElasticity.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotElasticity.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotTesting.h"
 #include <Eigen/Dense>
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::ContinuumMechanics::Elasticity::Isotropic;
 using namespace Marmot::ContinuumMechanics::Elasticity::TransverseIsotropic;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotKinematics.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotKinematics.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotTesting.h"
 
 using namespace Eigen;
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::ContinuumMechanics::Kinematics::VelocityGradient;
 using namespace Marmot::ContinuumMechanics::Kinematics::Strain;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotLocalization.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotLocalization.cpp
@@ -4,6 +4,7 @@
 #include "Marmot/VonMises.h"
 
 using namespace Marmot::Testing;
+using Marmot::MarmotMaterialHypoElastic;
 
 void testMarmotLocalization()
 {

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotLowerDimensionalStress.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotLowerDimensionalStress.cpp
@@ -10,6 +10,7 @@
  */
 
 using namespace Eigen;
+using Marmot::MakeString;
 using namespace Marmot::ContinuumMechanics::Elasticity::Isotropic;
 using namespace Marmot::ContinuumMechanics::PlaneStrain;
 using namespace Marmot::ContinuumMechanics::PlaneStress;

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotPronySeries.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotPronySeries.cpp
@@ -2,6 +2,7 @@
 #include "Marmot/MarmotPronySeries.h"
 #include "Marmot/MarmotTesting.h"
 
+using namespace Marmot;
 using namespace Marmot::Testing;
 
 void testPronySeriesWithZeroMaxwellElements()

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotStateVarVectorManager.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotStateVarVectorManager.cpp
@@ -3,7 +3,7 @@
 
 using namespace Marmot::Testing;
 
-class DummyMaterialStateVarManager : public MarmotStateVarVectorManager {
+class DummyMaterialStateVarManager : public Marmot::MarmotStateVarVectorManager {
   /*
    * DummyMaterialStateVarManager is a derived class of MarmotStateVarVectorManager
    * for testing purposes. It defines a static layout with two state variables:
@@ -14,7 +14,7 @@ public:
   inline const static auto layout = makeLayout( { { .name = "var1", .length = 3 }, { .name = "var2", .length = 2 } } );
 
   // Constructor initializes the parent class
-  DummyMaterialStateVarManager( double* stateVars ) : MarmotStateVarVectorManager( stateVars, layout ){};
+  DummyMaterialStateVarManager( double* stateVars ) : Marmot::MarmotStateVarVectorManager( stateVars, layout ){};
 
   // Expose nRequiredStateVars for testing layout calculation
   static int getRequiredSize() { return layout.nRequiredStateVars; }

--- a/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotJournal.h
+++ b/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotJournal.h
@@ -27,69 +27,73 @@
 #include <sstream>
 #include <string>
 
-/** @class MakeString
- * @brief Utility class for constructing strings with stream-like syntax.
- *
- * This class allows for easy string construction using the stream insertion operator.
- * It can be used to build complex strings in a readable manner.
- */
-class MakeString {
-public:
-  std::stringstream stream; ///< Internal string stream used for building the output string.
+namespace Marmot {
 
-  /// Convert the accumulated stream content to a `std::string`.
-  operator std::string() const { return stream.str(); }
+  /** @class MakeString
+   * @brief Utility class for constructing strings with stream-like syntax.
+   *
+   * This class allows for easy string construction using the stream insertion operator.
+   * It can be used to build complex strings in a readable manner.
+   */
+  class MakeString {
+  public:
+    std::stringstream stream; ///< Internal string stream used for building the output string.
+
+    /// Convert the accumulated stream content to a `std::string`.
+    operator std::string() const { return stream.str(); }
+
+    /**
+     * @brief Append a value to the internal stream.
+     * @tparam T   Type of the value to append.
+     * @param VAR  Value to insert into the stream.
+     * @return     Reference to `*this` for chaining.
+     */
+    template < class T >
+    MakeString& operator<<( T const& VAR )
+    {
+      stream << VAR;
+      return *this;
+    }
+  };
 
   /**
-   * @brief Append a value to the internal stream.
-   * @tparam T   Type of the value to append.
-   * @param VAR  Value to insert into the stream.
-   * @return     Reference to `*this` for chaining.
+   * @class MarmotJournal
+   * @brief Singleton class for managing output messages in the Marmot framework.
+   *
+   * This class provides a centralized way to handle warning and notification messages,
+   * allowing them to be directed to a specified output stream (e.g., console, file).
    */
-  template < class T >
-  MakeString& operator<<( T const& VAR )
-  {
-    stream << VAR;
-    return *this;
-  }
-};
+  class MarmotJournal {
+  private:
+    static MarmotJournal& getInstance();
 
-/**
- * @class MarmotJournal
- * @brief Singleton class for managing output messages in the Marmot framework.
- *
- * This class provides a centralized way to handle warning and notification messages,
- * allowing them to be directed to a specified output stream (e.g., console, file).
- */
-class MarmotJournal {
-private:
-  static MarmotJournal& getInstance();
+    std::ostream output;
 
-  std::ostream output;
+    MarmotJournal();
 
-  MarmotJournal();
+  public:
+    MarmotJournal( MarmotJournal const& )  = delete;
+    void operator=( MarmotJournal const& ) = delete;
 
-public:
-  MarmotJournal( MarmotJournal const& )  = delete;
-  void operator=( MarmotJournal const& ) = delete;
+    /**
+     * @brief Redirect all subsequent journal output to @p newOutputStream.
+     * @param newOutputStream  The output stream that warnings and notifications are written to.
+     */
+    static void setMSGOutputDirection( std::ostream& newOutputStream );
 
-  /**
-   * @brief Redirect all subsequent journal output to @p newOutputStream.
-   * @param newOutputStream  The output stream that warnings and notifications are written to.
-   */
-  static void setMSGOutputDirection( std::ostream& newOutputStream );
+    /**
+     * @brief Write a warning message to the journal output stream.
+     * @param message  The warning text to emit.
+     * @return `true` after the message has been written.
+     */
+    static bool warningToMSG( const std::string& message );
 
-  /**
-   * @brief Write a warning message to the journal output stream.
-   * @param message  The warning text to emit.
-   * @return `true` after the message has been written.
-   */
-  static bool warningToMSG( const std::string& message );
+    /**
+     * @brief Write a notification message to the journal output stream.
+     * @param message  The notification text to emit.
+     * @return `true` after the message has been written.
+     */
+    static bool notificationToMSG( const std::string& message );
+  };
 
-  /**
-   * @brief Write a notification message to the journal output stream.
-   * @param message  The notification text to emit.
-   * @return `true` after the message has been written.
-   */
-  static bool notificationToMSG( const std::string& message );
-};
+} // namespace Marmot

--- a/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotStateHelpers.h
+++ b/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotStateHelpers.h
@@ -34,292 +34,296 @@
 #include <unordered_map>
 #include <vector>
 
-/**
- * @struct StateMapper
- * @brief Template struct to map raw double pointers and sizes to specific views.
- * Specializations of this struct should provide a static `map` method that
- * takes a `double*` and a `std::size_t` size, returning the desired view type.
- */
-template < class View, int... Args >
-struct StateMapper;
+namespace Marmot {
 
-/// \cond DOXYGEN_SKIP
-// Template specialisations of StateMapper are hidden from Doxygen because
-// Sphinx's C++ domain parser cannot handle deeply nested template arguments
-// (e.g. StateMapper< Eigen::Map< Eigen::MatrixXd > >) and would emit
-// "Invalid C++ declaration" warnings for every specialisation.
-
-/**
- * @struct StateMapper<double>
- * @brief Specialization of StateMapper for single double values.
- * This allows mapping a raw double pointer and size to a single double reference.
- */
-template <>
-struct StateMapper< double& > {
-  static double& map( double* ptr, std::size_t n )
-  {
-    if ( n != 1 )
-      throw std::runtime_error( "Size mismatch for double." );
-    return *ptr;
-  }
-};
-
-/**
- * @struct StateMapper<const double>
- * @brief Specialization of StateMapper for single const double values.
- * This allows mapping a raw const double pointer and size to a single const double reference.
- */
-template <>
-struct StateMapper< const double& > {
-  static const double& map( const double* ptr, std::size_t n )
-  {
-    if ( n != 1 )
-      throw std::runtime_error( "Size mismatch for double." );
-    return *ptr;
-  }
-};
-/**
- * @struct StateMapper<Fastor::Tensor<double,3,3>>
- * @brief Specialization of StateMapper for Fastor::Tensor<double,3,3>.
- * This allows mapping a raw double pointer and size to a Fastor 3x3 tensor.
- */
-template <>
-struct StateMapper< Fastor::TensorMap< double, 3, 3 > > {
-  static Fastor::TensorMap< double, 3, 3 > map( double* ptr, std::size_t n )
-  {
-    if ( n != 9 )
-      throw std::runtime_error( "Size mismatch for Fastor::Tensor<double,3,3>." );
-    return Fastor::TensorMap< double, 3, 3 >( ptr );
-  }
-};
-
-/**
- * @struct StateMapper<Eigen::Map<Eigen::MatrixXd>>
- * @brief Specialization of StateMapper for Eigen::Map<Eigen::MatrixXd>.
- * This allows mapping a raw double pointer and size to an Eigen dynamic matrix map.
- */
-template <>
-struct StateMapper< Eigen::Map< Eigen::MatrixXd > > {
-  template < class... Args >
-  static Eigen::Map< Eigen::MatrixXd > map( double* ptr, std::size_t n, int Rows, int Cols )
-  {
-    // read size form Args
-    if ( int( n ) != Rows * Cols )
-      throw std::runtime_error( "Size mismatch for Eigen::Map." );
-    return Eigen::Map< Eigen::MatrixXd >( ptr, Rows, n / Rows );
-  }
-};
-
-/**
- * @struct StateMapper<Eigen::Map<Eigen::Matrix<Scalar, Rows, Cols>>>
- * @brief Specialization of StateMapper for fixed-size Eigen::Map types.
- */
-template < typename Scalar, int Rows, int Cols >
-struct StateMapper< Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > > {
-  template < class... Args >
-  static Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > map( double* ptr, std::size_t n, Args&&... )
-  {
-    // Check if the expected total size matches the provided size 'n'
-    if ( int( n ) != Rows * Cols )
-      throw std::runtime_error( "Size mismatch for fixed-size Eigen::Map." );
-
-    // Map the raw pointer to the Eigen fixed-size matrix map
-    return Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > >( ptr, Rows, Cols );
-  }
-};
-/// \endcond
-
-/**
- * @class MarmotStateLayoutDynamic
- * @brief Runtime-defined layout for a flat array of named `double` state variables.
- *
- * Variables are registered by name and size via add(), then the layout is locked
- * with finalize(), which assigns contiguous offsets. After finalization the
- * various `get*` accessors can be used to reach individual variables inside any
- * conforming state vector.
- */
-class MarmotStateLayoutDynamic {
-public:
   /**
-   * @brief Describes a single named state variable registered in the layout.
+   * @struct StateMapper
+   * @brief Template struct to map raw double pointers and sizes to specific views.
+   * Specializations of this struct should provide a static `map` method that
+   * takes a `double*` and a `std::size_t` size, returning the desired view type.
    */
-  struct VarInfo {
-    std::string name;   ///< Unique name of the state variable.
-    std::size_t size;   ///< Number of `double` values occupied by this variable.
-    std::size_t offset; ///< Byte-offset (in units of `double`) from the beginning of the state vector.
+  template < class View, int... Args >
+  struct StateMapper;
+
+  /// \cond DOXYGEN_SKIP
+  // Template specialisations of StateMapper are hidden from Doxygen because
+  // Sphinx's C++ domain parser cannot handle deeply nested template arguments
+  // (e.g. StateMapper< Eigen::Map< Eigen::MatrixXd > >) and would emit
+  // "Invalid C++ declaration" warnings for every specialisation.
+
+  /**
+   * @struct StateMapper<double>
+   * @brief Specialization of StateMapper for single double values.
+   * This allows mapping a raw double pointer and size to a single double reference.
+   */
+  template <>
+  struct StateMapper< double& > {
+    static double& map( double* ptr, std::size_t n )
+    {
+      if ( n != 1 )
+        throw std::runtime_error( "Size mismatch for double." );
+      return *ptr;
+    }
   };
 
   /**
-   * @brief Register a new named state variable.
-   *
-   * Must be called before finalize(). Adding a variable with an already-registered name
-   * or calling this method after finalize() throws @c std::runtime_error.
-   *
-   * @param name  Unique name for the state variable.
-   * @param size  Number of `double` values required by the variable.
+   * @struct StateMapper<const double>
+   * @brief Specialization of StateMapper for single const double values.
+   * This allows mapping a raw const double pointer and size to a single const double reference.
    */
-  void add( std::string name, std::size_t size )
-  {
-    if ( finalized )
-      throw std::runtime_error( "Cannot add variables after finalize()." );
-
-    if ( name_to_index.contains( name ) )
-      throw std::runtime_error( "Duplicate state variable: " + name );
-
-    name_to_index[name] = variables.size();
-    variables.push_back( { std::move( name ), size, 0 } );
-  }
-
-  /**
-   * @brief Compute and lock the offsets of all registered variables.
-   *
-   * Iterates over the registered variables in registration order, assigns each a
-   * contiguous offset, and sets the total size. After this call no further variables
-   * may be added. Calling finalize() a second time throws @c std::runtime_error.
-   */
-  void finalize()
-  {
-    if ( finalized )
-      throw std::runtime_error( "State layout already finalized." );
-    std::size_t offset = 0;
-    for ( auto& v : variables ) {
-      v.offset = offset;
-      offset += v.size;
+  template <>
+  struct StateMapper< const double& > {
+    static const double& map( const double* ptr, std::size_t n )
+    {
+      if ( n != 1 )
+        throw std::runtime_error( "Size mismatch for double." );
+      return *ptr;
     }
-    total_sz  = offset;
-    finalized = true;
-  }
+  };
+  /**
+   * @struct StateMapper<Fastor::Tensor<double,3,3>>
+   * @brief Specialization of StateMapper for Fastor::Tensor<double,3,3>.
+   * This allows mapping a raw double pointer and size to a Fastor 3x3 tensor.
+   */
+  template <>
+  struct StateMapper< Fastor::TensorMap< double, 3, 3 > > {
+    static Fastor::TensorMap< double, 3, 3 > map( double* ptr, std::size_t n )
+    {
+      if ( n != 9 )
+        throw std::runtime_error( "Size mismatch for Fastor::Tensor<double,3,3>." );
+      return Fastor::TensorMap< double, 3, 3 >( ptr );
+    }
+  };
 
   /**
-   * @brief Return the @ref VarInfo record for a registered variable.
+   * @struct StateMapper<Eigen::Map<Eigen::MatrixXd>>
+   * @brief Specialization of StateMapper for Eigen::Map<Eigen::MatrixXd>.
+   * This allows mapping a raw double pointer and size to an Eigen dynamic matrix map.
+   */
+  template <>
+  struct StateMapper< Eigen::Map< Eigen::MatrixXd > > {
+    template < class... Args >
+    static Eigen::Map< Eigen::MatrixXd > map( double* ptr, std::size_t n, int Rows, int Cols )
+    {
+      // read size form Args
+      if ( int( n ) != Rows * Cols )
+        throw std::runtime_error( "Size mismatch for Eigen::Map." );
+      return Eigen::Map< Eigen::MatrixXd >( ptr, Rows, n / Rows );
+    }
+  };
+
+  /**
+   * @struct StateMapper<Eigen::Map<Eigen::Matrix<Scalar, Rows, Cols>>>
+   * @brief Specialization of StateMapper for fixed-size Eigen::Map types.
+   */
+  template < typename Scalar, int Rows, int Cols >
+  struct StateMapper< Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > > {
+    template < class... Args >
+    static Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > > map( double* ptr, std::size_t n, Args&&... )
+    {
+      // Check if the expected total size matches the provided size 'n'
+      if ( int( n ) != Rows * Cols )
+        throw std::runtime_error( "Size mismatch for fixed-size Eigen::Map." );
+
+      // Map the raw pointer to the Eigen fixed-size matrix map
+      return Eigen::Map< Eigen::Matrix< Scalar, Rows, Cols > >( ptr, Rows, Cols );
+    }
+  };
+  /// \endcond
+
+  /**
+   * @class MarmotStateLayoutDynamic
+   * @brief Runtime-defined layout for a flat array of named `double` state variables.
    *
-   * @param name  Name of the variable to look up.
-   * @return      Const reference to the corresponding @ref VarInfo.
-   * @throws std::runtime_error if @p name is not registered.
+   * Variables are registered by name and size via add(), then the layout is locked
+   * with finalize(), which assigns contiguous offsets. After finalization the
+   * various `get*` accessors can be used to reach individual variables inside any
+   * conforming state vector.
    */
-  const VarInfo& getInfo( const std::string& name ) const
-  {
-    auto it = name_to_index.find( name );
-    if ( it == name_to_index.end() )
-      throw std::runtime_error( "Unknown state variable: " + name );
-    return variables[it->second];
-  }
+  class MarmotStateLayoutDynamic {
+  public:
+    /**
+     * @brief Describes a single named state variable registered in the layout.
+     */
+    struct VarInfo {
+      std::string name;   ///< Unique name of the state variable.
+      std::size_t size;   ///< Number of `double` values occupied by this variable.
+      std::size_t offset; ///< Byte-offset (in units of `double`) from the beginning of the state vector.
+    };
 
-  /**
-   * @brief Return the {offset, size} pair for a registered variable.
-   *
-   * @param name  Name of the variable.
-   * @return      A pair `{offset, size}` (both in units of `double`).
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  std::pair< std::size_t, std::size_t > get( const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return { v.offset, v.size };
-  }
+    /**
+     * @brief Register a new named state variable.
+     *
+     * Must be called before finalize(). Adding a variable with an already-registered name
+     * or calling this method after finalize() throws @c std::runtime_error.
+     *
+     * @param name  Unique name for the state variable.
+     * @param size  Number of `double` values required by the variable.
+     */
+    void add( std::string name, std::size_t size )
+    {
+      if ( finalized )
+        throw std::runtime_error( "Cannot add variables after finalize()." );
 
-  /**
-   * @brief Return a raw pointer to a variable inside a state vector.
-   *
-   * @param base  Pointer to the beginning of the state vector.
-   * @param name  Name of the variable.
-   * @return      `base + offset` for the named variable.
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  double* getPtr( double* base, const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return base + v.offset;
-  }
+      if ( name_to_index.contains( name ) )
+        throw std::runtime_error( "Duplicate state variable: " + name );
 
-  /**
-   * @brief Return a `std::span<double>` view of a variable inside a state vector.
-   *
-   * @param base  Pointer to the beginning of the state vector.
-   * @param name  Name of the variable.
-   * @return      A span covering `[base + offset, base + offset + size)`.
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  std::span< double > getSpan( double* base, const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return { base + v.offset, v.size };
-  }
+      name_to_index[name] = variables.size();
+      variables.push_back( { std::move( name ), size, 0 } );
+    }
 
-  /**
-   * @brief Return a @ref StateView for a variable inside a state vector.
-   *
-   * @param base  Pointer to the beginning of the state vector.
-   * @param name  Name of the variable.
-   * @return      A @ref StateView with `stateLocation = base + offset` and `stateSize = size`.
-   * @throws std::runtime_error if @p name is not registered.
-   */
-  StateView getStateView( double* base, const std::string& name ) const
-  {
-    const auto& v = getInfo( name );
-    return StateView{ base + v.offset, static_cast< int >( v.size ) };
-  }
+    /**
+     * @brief Compute and lock the offsets of all registered variables.
+     *
+     * Iterates over the registered variables in registration order, assigns each a
+     * contiguous offset, and sets the total size. After this call no further variables
+     * may be added. Calling finalize() a second time throws @c std::runtime_error.
+     */
+    void finalize()
+    {
+      if ( finalized )
+        throw std::runtime_error( "State layout already finalized." );
+      std::size_t offset = 0;
+      for ( auto& v : variables ) {
+        v.offset = offset;
+        offset += v.size;
+      }
+      total_sz  = offset;
+      finalized = true;
+    }
 
-  /**
-   * @brief Map a variable inside a state vector to a typed view via `StateMapper`.
-   *
-   * Delegates to `StateMapper<View>::map(base + offset, size, args...)`.
-   * The layout must have been finalized before calling this method.
-   *
-   * @tparam View   Target view type (must have a matching `StateMapper` specialization).
-   * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
-   * @param base    Pointer to the beginning of the state vector.
-   * @param name    Name of the variable.
-   * @param args    Extra arguments forwarded to `StateMapper::map`.
-   * @return        The mapped view of the requested variable.
-   * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
-   */
-  template < class View, class... Args >
-  View getAs( double* base, const std::string& name, Args&&... args ) const
-  {
-    if ( !finalized )
-      throw std::runtime_error( "State layout not finalized." );
+    /**
+     * @brief Return the @ref VarInfo record for a registered variable.
+     *
+     * @param name  Name of the variable to look up.
+     * @return      Const reference to the corresponding @ref VarInfo.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    const VarInfo& getInfo( const std::string& name ) const
+    {
+      auto it = name_to_index.find( name );
+      if ( it == name_to_index.end() )
+        throw std::runtime_error( "Unknown state variable: " + name );
+      return variables[it->second];
+    }
 
-    const auto& v = getInfo( name );
-    return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
-  }
+    /**
+     * @brief Return the {offset, size} pair for a registered variable.
+     *
+     * @param name  Name of the variable.
+     * @return      A pair `{offset, size}` (both in units of `double`).
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    std::pair< std::size_t, std::size_t > get( const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return { v.offset, v.size };
+    }
 
-  /**
-   * @brief Const version of @ref getAs.
-   * @tparam View   Target view type (must have a matching `StateMapper` specialization).
-   * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
-   * @param base    Pointer to the beginning of the state vector.
-   * @param name    Name of the variable.
-   * @param args    Extra arguments forwarded to `StateMapper::map`.
-   * @return        The mapped view of the requested variable.
-   * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
-   */
-  template < class View, class... Args >
-  View getAs( const double* base, const std::string& name, Args&&... args ) const
-  {
-    if ( !finalized )
-      throw std::runtime_error( "State layout not finalized." );
+    /**
+     * @brief Return a raw pointer to a variable inside a state vector.
+     *
+     * @param base  Pointer to the beginning of the state vector.
+     * @param name  Name of the variable.
+     * @return      `base + offset` for the named variable.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    double* getPtr( double* base, const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return base + v.offset;
+    }
 
-    const auto& v = getInfo( name );
-    return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
-  }
+    /**
+     * @brief Return a `std::span<double>` view of a variable inside a state vector.
+     *
+     * @param base  Pointer to the beginning of the state vector.
+     * @param name  Name of the variable.
+     * @return      A span covering `[base + offset, base + offset + size)`.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    std::span< double > getSpan( double* base, const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return { base + v.offset, v.size };
+    }
 
-  /**
-   * @brief Return the total size (in units of `double`) of the state layout.
-   * This is the size of the state vector required to hold all registered variables.
-   */
-  int totalSize() const { return total_sz; }
+    /**
+     * @brief Return a @ref StateView for a variable inside a state vector.
+     *
+     * @param base  Pointer to the beginning of the state vector.
+     * @param name  Name of the variable.
+     * @return      A @ref StateView with `stateLocation = base + offset` and `stateSize = size`.
+     * @throws std::runtime_error if @p name is not registered.
+     */
+    StateView getStateView( double* base, const std::string& name ) const
+    {
+      const auto& v = getInfo( name );
+      return StateView{ base + v.offset, static_cast< int >( v.size ) };
+    }
 
-  /**
-   * @brief Check if the layout has been finalized.
-   * @return `true` if finalize() has been called, `false` otherwise.
-   */
-  bool isFinalized() const { return finalized; }
+    /**
+     * @brief Map a variable inside a state vector to a typed view via `StateMapper`.
+     *
+     * Delegates to `StateMapper<View>::map(base + offset, size, args...)`.
+     * The layout must have been finalized before calling this method.
+     *
+     * @tparam View   Target view type (must have a matching `StateMapper` specialization).
+     * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
+     * @param base    Pointer to the beginning of the state vector.
+     * @param name    Name of the variable.
+     * @param args    Extra arguments forwarded to `StateMapper::map`.
+     * @return        The mapped view of the requested variable.
+     * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
+     */
+    template < class View, class... Args >
+    View getAs( double* base, const std::string& name, Args&&... args ) const
+    {
+      if ( !finalized )
+        throw std::runtime_error( "State layout not finalized." );
 
-private:
-  std::vector< VarInfo >                         variables;
-  std::unordered_map< std::string, std::size_t > name_to_index;
+      const auto& v = getInfo( name );
+      return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
+    }
 
-  bool finalized = false;
-  int  total_sz  = 0;
-};
+    /**
+     * @brief Const version of @ref getAs.
+     * @tparam View   Target view type (must have a matching `StateMapper` specialization).
+     * @tparam Args   Additional constructor arguments forwarded to `StateMapper::map`.
+     * @param base    Pointer to the beginning of the state vector.
+     * @param name    Name of the variable.
+     * @param args    Extra arguments forwarded to `StateMapper::map`.
+     * @return        The mapped view of the requested variable.
+     * @throws std::runtime_error if the layout is not finalized or @p name is not registered.
+     */
+    template < class View, class... Args >
+    View getAs( const double* base, const std::string& name, Args&&... args ) const
+    {
+      if ( !finalized )
+        throw std::runtime_error( "State layout not finalized." );
+
+      const auto& v = getInfo( name );
+      return StateMapper< View >::map( base + v.offset, v.size, std::forward< Args >( args )... );
+    }
+
+    /**
+     * @brief Return the total size (in units of `double`) of the state layout.
+     * This is the size of the state vector required to hold all registered variables.
+     */
+    int totalSize() const { return total_sz; }
+
+    /**
+     * @brief Check if the layout has been finalized.
+     * @return `true` if finalize() has been called, `false` otherwise.
+     */
+    bool isFinalized() const { return finalized; }
+
+  private:
+    std::vector< VarInfo >                         variables;
+    std::unordered_map< std::string, std::size_t > name_to_index;
+
+    bool finalized = false;
+    int  total_sz  = 0;
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotUtils.h
+++ b/modules/core/MarmotUtilitiesCore/include/Marmot/MarmotUtils.h
@@ -24,13 +24,17 @@
  */
 #pragma once
 
-/** @struct StateView
- * @brief Structure to hold a pointer to the state location and its size.
- *
- * This structure is used to provide a view of the state variables in a finite element or material,
- * allowing access to the state data without copying it.
- */
-struct StateView {
-  double* stateLocation; ///< Pointer to the first element of the state variable block.
-  int     stateSize;     ///< Number of `double` values in the state variable block.
-};
+namespace Marmot {
+
+  /** @struct StateView
+   * @brief Structure to hold a pointer to the state location and its size.
+   *
+   * This structure is used to provide a view of the state variables in a finite element or material,
+   * allowing access to the state data without copying it.
+   */
+  struct StateView {
+    double* stateLocation; ///< Pointer to the first element of the state variable block.
+    int     stateSize;     ///< Number of `double` values in the state variable block.
+  };
+
+} // namespace Marmot

--- a/modules/core/MarmotUtilitiesCore/src/MarmotJournal.cpp
+++ b/modules/core/MarmotUtilitiesCore/src/MarmotJournal.cpp
@@ -1,27 +1,31 @@
 #include "Marmot/MarmotJournal.h"
 
-MarmotJournal& MarmotJournal::getInstance()
-{
-  static MarmotJournal instance;
+namespace Marmot {
 
-  return instance;
-}
+  MarmotJournal& MarmotJournal::getInstance()
+  {
+    static MarmotJournal instance;
 
-MarmotJournal::MarmotJournal() : output( nullptr ) {}
+    return instance;
+  }
 
-void MarmotJournal::setMSGOutputDirection( std::ostream& newOutputStream )
-{
-  getInstance().output.rdbuf( newOutputStream.rdbuf() );
-}
+  MarmotJournal::MarmotJournal() : output( nullptr ) {}
 
-bool MarmotJournal::warningToMSG( const std::string& message )
-{
-  getInstance().output << message;
-  return false;
-}
+  void MarmotJournal::setMSGOutputDirection( std::ostream& newOutputStream )
+  {
+    getInstance().output.rdbuf( newOutputStream.rdbuf() );
+  }
 
-bool MarmotJournal::notificationToMSG( const std::string& message )
-{
-  getInstance().output << message;
-  return true;
-}
+  bool MarmotJournal::warningToMSG( const std::string& message )
+  {
+    getInstance().output << message;
+    return false;
+  }
+
+  bool MarmotJournal::notificationToMSG( const std::string& message )
+  {
+    getInstance().output << message;
+    return true;
+  }
+
+} // namespace Marmot

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -42,10 +42,9 @@
 #include <memory>
 #include <vector>
 
-using namespace Marmot;
-using namespace Eigen;
-
 namespace Marmot::Elements {
+
+  using namespace Eigen;
 
   /**
    * @class Marmot::Elements::DisplacementFiniteElement

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -431,10 +431,10 @@ namespace Marmot::Elements {
   {
     for ( auto& qp : qps ) {
       qp.material = std::unique_ptr< MarmotMaterialHypoElastic >(
-        MarmotLibrary::MarmotMaterialHypoElasticFactory::createMaterial( section.materialName,
-                                                                         section.materialProperties,
-                                                                         section.nMaterialProperties,
-                                                                         elLabel ) );
+        Marmot::Registration::MarmotMaterialHypoElasticFactory::createMaterial( section.materialName,
+                                                                                section.materialProperties,
+                                                                                section.nMaterialProperties,
+                                                                                elLabel ) );
 
       if ( !qp.material )
         throw std::invalid_argument( MakeString()

--- a/modules/elements/DisplacementFiniteElement/src/DisplacementFiniteElementRegistration.cpp
+++ b/modules/elements/DisplacementFiniteElement/src/DisplacementFiniteElementRegistration.cpp
@@ -8,12 +8,13 @@ namespace Marmot::Elements::Registration {
   template < class T,
              Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
              typename T::SectionType                             sectionType >
-  MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+  Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
   {
     return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
   }
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
   using namespace Marmot::FiniteElement::Quadrature;
 
   const static bool CPS4_isRegistered = MarmotElementFactory::
@@ -46,19 +47,19 @@ namespace Marmot::Elements::Registration {
                                           FullIntegration,
                                           DisplacementFiniteElement< 2, 8 >::PlaneStrain >() );
 
-  const static bool C3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D8",
                      makeFactoryFunction< DisplacementFiniteElement< 3, 8 >,
                                           FullIntegration,
                                           DisplacementFiniteElement< 3, 8 >::SectionType::Solid >() );
 
-  const static bool C3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20",
                      makeFactoryFunction< DisplacementFiniteElement< 3, 20 >,
                                           FullIntegration,
                                           DisplacementFiniteElement< 3, 20 >::SectionType::Solid >() );
 
-  const static bool C3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20R",
                      makeFactoryFunction< DisplacementFiniteElement< 3, 20 >,
                                           ReducedIntegration,
@@ -74,5 +75,6 @@ namespace Marmot::Elements::Registration {
     constexpr static int nIndicesToBeWrapped  = 2;
     return new MarmotElementSpatialWrapper( 2, 1, 2, 2, indicesToBeWrapped, nIndicesToBeWrapped, std::move( uelT2D2 ) );
   }
-  const static bool T2D2_isRegistered = MarmotLibrary::MarmotElementFactory::registerElement( "T2D2", generateT2D2 );
+  const static bool T2D2_isRegistered = Marmot::Registration::MarmotElementFactory::registerElement( "T2D2",
+                                                                                                     generateT2D2 );
 } // namespace Marmot::Elements::Registration

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -496,10 +496,10 @@ namespace Marmot::Elements {
 
     for ( auto& qp : qps ) {
       qp.material = std::unique_ptr< Material >(
-        MarmotLibrary::MarmotMaterialFiniteStrainFactory::createMaterial( section.materialName,
-                                                                          section.materialProperties,
-                                                                          section.nMaterialProperties,
-                                                                          elLabel ) );
+        Marmot::Registration::MarmotMaterialFiniteStrainFactory::createMaterial( section.materialName,
+                                                                                 section.materialProperties,
+                                                                                 section.nMaterialProperties,
+                                                                                 elLabel ) );
     }
   }
 

--- a/modules/elements/DisplacementFiniteStrainULElement/src/DisplacementFiniteStrainULElement.cpp
+++ b/modules/elements/DisplacementFiniteStrainULElement/src/DisplacementFiniteStrainULElement.cpp
@@ -7,12 +7,13 @@ namespace Marmot::Elements::Registration {
   template < class T,
              Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
              typename T::SectionType                             sectionType >
-  MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+  Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
   {
     return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
   }
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
   using namespace Marmot::FiniteElement::Quadrature;
 
   const static bool CX8RUL_isRegistered = MarmotElementFactory::
@@ -39,19 +40,19 @@ namespace Marmot::Elements::Registration {
                                           FullIntegration,
                                           DisplacementFiniteStrainULElement< 2, 8 >::PlaneStrain >() );
 
-  const static bool C3D8UL_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D8UL_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D8UL",
                      makeFactoryFunction< DisplacementFiniteStrainULElement< 3, 8 >,
                                           FullIntegration,
                                           DisplacementFiniteStrainULElement< 3, 8 >::SectionType::Solid >() );
 
-  const static bool C3D20RUL_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20RUL_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20RUL",
                      makeFactoryFunction< DisplacementFiniteStrainULElement< 3, 20 >,
                                           ReducedIntegration,
                                           DisplacementFiniteStrainULElement< 3, 20 >::SectionType::Solid >() );
 
-  const static bool C3D20UL_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool C3D20UL_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "C3D20UL",
                      makeFactoryFunction< DisplacementFiniteStrainULElement< 3, 20 >,
                                           FullIntegration,

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -39,10 +39,9 @@
 #include <memory>
 #include <vector>
 
-using namespace Marmot;
-using namespace Eigen;
-
 namespace Marmot::Elements {
+
+  using namespace Eigen;
 
   /**
    * @class Marmot::Elements::GeneralGradientEnhancedDisplacementFiniteElement

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -472,7 +472,7 @@ namespace Marmot::Elements {
   {
     for ( auto& qp : qps ) {
       qp.material = std::unique_ptr< MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables > >(
-        MarmotLibrary::MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< nNonlocalVariables >::
+        Marmot::Registration::MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< nNonlocalVariables >::
           createMaterial( section.materialName, section.materialProperties, section.nMaterialProperties, elLabel ) );
     }
   }

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/src/GeneralGradientEnhancedDisplacementFiniteElementRegistration.cpp
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/src/GeneralGradientEnhancedDisplacementFiniteElementRegistration.cpp
@@ -7,12 +7,13 @@ namespace Marmot::Elements::Registration {
   template < class T,
              Marmot::FiniteElement::Quadrature::IntegrationTypes integrationType,
              typename T::SectionType                             sectionType >
-  MarmotLibrary::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
+  Marmot::Registration::MarmotElementFactory::elementFactoryFunction makeFactoryFunction()
   {
     return []( int elementID ) -> MarmotElement* { return new T( elementID, integrationType, sectionType ); };
   }
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
   using namespace Marmot::FiniteElement::Quadrature;
 
   const static bool GCPS4_isRegistered = MarmotElementFactory::
@@ -49,21 +50,21 @@ namespace Marmot::Elements::Registration {
                                           ReducedIntegration,
                                           GeneralGradientEnhancedDisplacementFiniteElement< 2, 8 >::PlaneStrain >() );
 
-  const static bool GC3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool GC3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "GC3D8",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8 >::SectionType::Solid >() );
 
-  const static bool GC3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool GC3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "GC3D20",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20 >::SectionType::Solid >() );
 
-  const static bool GC3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool GC3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "GC3D20R",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20 >,
@@ -91,21 +92,21 @@ namespace Marmot::Elements::Registration {
                        ReducedIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 2, 8, 2 >::PlaneStress >() );
 
-  const static bool G2GC3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G2GC3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G2GC3D8",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 2 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 2 >::SectionType::Solid >() );
 
-  const static bool G2GC3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G2GC3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G2GC3D20",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 2 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 2 >::SectionType::Solid >() );
 
-  const static bool G2GC3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G2GC3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G2GC3D20R",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 2 >,
@@ -119,21 +120,21 @@ namespace Marmot::Elements::Registration {
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 2, 8, 6 >::PlaneStress >() );
 
-  const static bool G6GC3D8_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D8_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D8",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 6 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 8, 6 >::SectionType::Solid >() );
 
-  const static bool G6GC3D20_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6 >,
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6 >::SectionType::Solid >() );
 
-  const static bool G6GC3D20R_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20R_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20R",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6 >,
@@ -147,14 +148,14 @@ namespace Marmot::Elements::Registration {
                        FullIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 2, 8, 6, 4 >::PlaneStress >() );
 
-  const static bool G6GC3D20RM_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20RM_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20RM",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6, 8 >,
                        ReducedIntegration,
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6, 8 >::SectionType::Solid >() );
 
-  const static bool G6GC3D20M_isRegistered = MarmotLibrary::MarmotElementFactory::
+  const static bool G6GC3D20M_isRegistered = Marmot::Registration::MarmotElementFactory::
     registerElement( "G6GC3D20M",
                      makeFactoryFunction<
                        GeneralGradientEnhancedDisplacementFiniteElement< 3, 20, 6, 8 >,

--- a/modules/materials/ADCompressibleNeoHooke/src/ADCompressibleNeoHookeRegistration.cpp
+++ b/modules/materials/ADCompressibleNeoHooke/src/ADCompressibleNeoHookeRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool
       ADCompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< ADCompressibleNeoHooke >(

--- a/modules/materials/ADCompressibleNeoHooke/src/ADCompressibleNeoHookeRegistration.cpp
+++ b/modules/materials/ADCompressibleNeoHooke/src/ADCompressibleNeoHookeRegistration.cpp
@@ -1,16 +1,13 @@
 #include "Marmot/ADCompressibleNeoHooke.h"
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool
+    ADCompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< ADCompressibleNeoHooke >(
+      "ADCOMPRESSIBLENEOHOOKE" );
 
-    const static bool
-      ADCompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< ADCompressibleNeoHooke >(
-        "ADCOMPRESSIBLENEOHOOKE" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/ADLinearElastic/include/Marmot/ADLinearElastic.h
+++ b/modules/materials/ADLinearElastic/include/Marmot/ADLinearElastic.h
@@ -27,8 +27,6 @@
 #include "Marmot/MarmotMaterialHypoElasticAD.h"
 #include "Marmot/MarmotTypedefs.h"
 
-using namespace Marmot;
-
 namespace Marmot::Materials {
   /**
    * @brief Implementation of a isotropic linear elastic material

--- a/modules/materials/ADLinearElastic/src/ADLinearElasticRegistration.cpp
+++ b/modules/materials/ADLinearElastic/src/ADLinearElasticRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool
       ADLinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADLinearElastic >(

--- a/modules/materials/ADLinearElastic/src/ADLinearElasticRegistration.cpp
+++ b/modules/materials/ADLinearElastic/src/ADLinearElasticRegistration.cpp
@@ -1,16 +1,12 @@
 #include "Marmot/ADLinearElastic.h"
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool ADLinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADLinearElastic >(
+    "ADLINEARELASTIC" );
 
-    const static bool
-      ADLinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADLinearElastic >(
-        "ADLINEARELASTIC" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/ADLinearElastic/test/test.cpp
+++ b/modules/materials/ADLinearElastic/test/test.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotTesting.h"
 #include "Marmot/MarmotTypedefs.h"
 
+using Marmot::MakeString;
 using namespace Marmot::Testing;
 using namespace Marmot::Solvers;
 

--- a/modules/materials/ADVonMises/include/Marmot/ADVonMises.h
+++ b/modules/materials/ADVonMises/include/Marmot/ADVonMises.h
@@ -28,8 +28,6 @@
 #include "Marmot/MarmotMaterialHypoElasticAD.h"
 #include <Eigen/src/Core/Map.h>
 
-using namespace Marmot;
-
 namespace Marmot::Materials {
   /**
    * @brief Implementation of a isotropic J2-plasticity  material

--- a/modules/materials/ADVonMises/include/Marmot/ADVonMisesConstants.h
+++ b/modules/materials/ADVonMises/include/Marmot/ADVonMisesConstants.h
@@ -23,14 +23,10 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Marmot::Materials {
-
-  /**
-   * @brief Numerical constants for the ADVonMises return-mapping algorithm.
-   */
-  namespace ADVonMisesConstants {
-    const double innerNewtonTol        = 1e-10; ///< Convergence tolerance for the inner Newton iteration.
-    const int    nMaxInnerNewtonCycles = 15;    ///< Maximum number of inner Newton iterations.
-  }                                             // namespace ADVonMisesConstants
-
-} // namespace Marmot::Materials
+/**
+ * @brief Numerical constants for the ADVonMises return-mapping algorithm.
+ */
+namespace Marmot::Materials::ADVonMisesConstants {
+  const double innerNewtonTol        = 1e-10; ///< Convergence tolerance for the inner Newton iteration.
+  const int    nMaxInnerNewtonCycles = 15;    ///< Maximum number of inner Newton iterations.
+} // namespace Marmot::Materials::ADVonMisesConstants

--- a/modules/materials/ADVonMises/src/ADVonMisesRegistration.cpp
+++ b/modules/materials/ADVonMises/src/ADVonMisesRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool ADVonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADVonMises >(
       "ADVONMISES" );

--- a/modules/materials/ADVonMises/src/ADVonMisesRegistration.cpp
+++ b/modules/materials/ADVonMises/src/ADVonMisesRegistration.cpp
@@ -1,15 +1,12 @@
 #include "Marmot/ADVonMises.h"
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool ADVonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADVonMises >(
+    "ADVONMISES" );
 
-    const static bool ADVonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< ADVonMises >(
-      "ADVONMISES" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/AT2PhaseField/src/AT2PhaseFieldRegistration.cpp
+++ b/modules/materials/AT2PhaseField/src/AT2PhaseFieldRegistration.cpp
@@ -26,15 +26,12 @@
 #include "Marmot/AT2PhaseField.h"
 #include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool AT2PhaseFieldIsRegistered = MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
+    1 >::registerMaterial< AT2PhaseField >( "AT2PHASEFIELD" );
 
-    const static bool AT2PhaseFieldIsRegistered = MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
-      1 >::registerMaterial< AT2PhaseField >( "AT2PHASEFIELD" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/AT2PhaseField/src/AT2PhaseFieldRegistration.cpp
+++ b/modules/materials/AT2PhaseField/src/AT2PhaseFieldRegistration.cpp
@@ -30,11 +30,11 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool AT2PhaseFieldIsRegistered = MarmotMaterialGeneralGradientEnhancedHypoElasticFactory<
       1 >::registerMaterial< AT2PhaseField >( "AT2PHASEFIELD" );
 
   } // namespace Registration
-
 } // namespace Marmot::Materials

--- a/modules/materials/B4/include/Marmot/B4Shrinkage.h
+++ b/modules/materials/B4/include/Marmot/B4Shrinkage.h
@@ -25,46 +25,42 @@
 
 #include "Marmot/MarmotTypedefs.h"
 
-namespace Marmot::Materials {
-  /**
-   * @brief Shrinkage strain computation helpers for the B4 model.
-   */
-  namespace Shrinkage {
-    /**
-     * @brief B4-specific shrinkage strain increment computation.
-     */
-    namespace B4 {
+/**
+ * @brief Shrinkage strain computation helpers for the B4 model.
+ */
+/**
+ * @brief B4-specific shrinkage strain increment computation.
+ */
+namespace Marmot::Materials::Shrinkage::B4 {
 
-      /**
-       * @brief Computes the total shrinkage strain increment over one time step.
-       *
-       * Evaluates the combined autogenous and drying shrinkage strain increment
-       * according to the B4 model.
-       *
-       * @param tStartDays                     Age at the start of the increment (days).
-       * @param dTDays                         Length of the time increment (days).
-       * @param ultimateAutogenousShrinkageStrain Ultimate autogenous shrinkage strain
-       * \f$\eps^\mathrm{shr,au}_\infty\f$.
-       * @param autogenousShrinkageHalfTime    Autogenous shrinkage half-time \f$\tau_\mathrm{shr,au}\f$ (days).
-       * @param alpha                          Exponent parameter \f$\alpha\f$ for autogenous shrinkage.
-       * @param rt                             Drying shrinkage half-time \f$\tau_\mathrm{shr,d}\f$ (days).
-       * @param ultimateDryingShrinkageStrain  Ultimate drying shrinkage strain at zero humidity
-       * \f$\eps^\mathrm{shr,d}_\infty\f$.
-       * @param dryingShrinkageHalfTime        Alternate drying shrinkage half-time parameter (days).
-       * @param kHum                           Humidity-dependent factor \f$k_\mathrm{h}\f$.
-       * @param dryingStart                    Age at the start of drying \f$t_0\f$ (days).
-       * @return Voigt-notation shrinkage strain increment vector.
-       */
-      Marmot::Vector6d computeShrinkageStrainIncrement( const double tStartDays,
-                                                        const double dTDays,
-                                                        const double ultimateAutogenousShrinkageStrain,
-                                                        const double autogenousShrinkageHalfTime,
-                                                        const double alpha,
-                                                        const double rt,
-                                                        const double ultimateDryingShrinkageStrain,
-                                                        const double dryingShrinkageHalfTime,
-                                                        const double kHum,
-                                                        const double dryingStart );
-    } // namespace B4
-  }   // namespace Shrinkage
-} // namespace Marmot::Materials
+  /**
+   * @brief Computes the total shrinkage strain increment over one time step.
+   *
+   * Evaluates the combined autogenous and drying shrinkage strain increment
+   * according to the B4 model.
+   *
+   * @param tStartDays                     Age at the start of the increment (days).
+   * @param dTDays                         Length of the time increment (days).
+   * @param ultimateAutogenousShrinkageStrain Ultimate autogenous shrinkage strain
+   * \f$\eps^\mathrm{shr,au}_\infty\f$.
+   * @param autogenousShrinkageHalfTime    Autogenous shrinkage half-time \f$\tau_\mathrm{shr,au}\f$ (days).
+   * @param alpha                          Exponent parameter \f$\alpha\f$ for autogenous shrinkage.
+   * @param rt                             Drying shrinkage half-time \f$\tau_\mathrm{shr,d}\f$ (days).
+   * @param ultimateDryingShrinkageStrain  Ultimate drying shrinkage strain at zero humidity
+   * \f$\eps^\mathrm{shr,d}_\infty\f$.
+   * @param dryingShrinkageHalfTime        Alternate drying shrinkage half-time parameter (days).
+   * @param kHum                           Humidity-dependent factor \f$k_\mathrm{h}\f$.
+   * @param dryingStart                    Age at the start of drying \f$t_0\f$ (days).
+   * @return Voigt-notation shrinkage strain increment vector.
+   */
+  Marmot::Vector6d computeShrinkageStrainIncrement( const double tStartDays,
+                                                    const double dTDays,
+                                                    const double ultimateAutogenousShrinkageStrain,
+                                                    const double autogenousShrinkageHalfTime,
+                                                    const double alpha,
+                                                    const double rt,
+                                                    const double ultimateDryingShrinkageStrain,
+                                                    const double dryingShrinkageHalfTime,
+                                                    const double kHum,
+                                                    const double dryingStart );
+} // namespace Marmot::Materials::Shrinkage::B4

--- a/modules/materials/B4/include/Marmot/MarmotSolidification.h
+++ b/modules/materials/B4/include/Marmot/MarmotSolidification.h
@@ -26,64 +26,62 @@
 #pragma once
 #include "Marmot/MarmotKelvinChain.h"
 
-namespace Marmot::Materials {
-  namespace SolidificationTheory {
+namespace Marmot::Materials::SolidificationTheory {
 
-    /// \brief material parameters for Solidification Theory
-    struct Parameters {
-      double q1;
-      double q2;
-      double q3;
-      double q4;
-      double n       = 0.1;
-      double m       = 0.5;
-      double lambda0 = 1.;
-    };
+  /// \brief material parameters for Solidification Theory
+  struct Parameters {
+    double q1;
+    double q2;
+    double q3;
+    double q4;
+    double n       = 0.1;
+    double m       = 0.5;
+    double lambda0 = 1.;
+  };
 
-    /**
-     * \brief properties of the Kelvin chain for approximating
-     * the viscoelastic compliance of the %Solidification Theory */
-    struct KelvinChainProperties {
-      double                  E0;
-      KelvinChain::Properties elasticModuli;
-      KelvinChain::Properties retardationTimes;
-    };
+  /**
+   * \brief properties of the Kelvin chain for approximating
+   * the viscoelastic compliance of the %Solidification Theory */
+  struct KelvinChainProperties {
+    double                  E0;
+    KelvinChain::Properties elasticModuli;
+    KelvinChain::Properties retardationTimes;
+  };
 
-    /// \brief uniaxial compliance components of the %Solidification Theory
-    struct UniaxialComplianceComponents {
-      double elastic      = 0.;
-      double viscoelastic = 0.;
-      double flow         = 0.;
-    };
+  /// \brief uniaxial compliance components of the %Solidification Theory
+  struct UniaxialComplianceComponents {
+    double elastic      = 0.;
+    double viscoelastic = 0.;
+    double flow         = 0.;
+  };
 
-    /// \brief results of the %Solidification Theory for a certain time step
-    struct Result {
-      Marmot::Vector6d             creepStrainIncrement;
-      UniaxialComplianceComponents complianceComponents;
-    };
+  /// \brief results of the %Solidification Theory for a certain time step
+  struct Result {
+    Marmot::Vector6d             creepStrainIncrement;
+    UniaxialComplianceComponents complianceComponents;
+  };
 
-    Result computeCreepStrainIncrementAndComplianceComponents(
-      double                                                 tStartDays,
-      double                                                 dTimeDays,
-      double                                                 amplificationFactor,
-      const Marmot::Matrix6d&                                flowUnitCompliance,
-      const Marmot::Vector6d&                                stressOld,
-      const Parameters&                                      parameters,
-      const KelvinChainProperties&                           kelvinChainProperties,
-      const Eigen::Ref< const KelvinChain::StateVarMatrix >& kelvinStateVars );
+  Result computeCreepStrainIncrementAndComplianceComponents(
+    double                                                 tStartDays,
+    double                                                 dTimeDays,
+    double                                                 amplificationFactor,
+    const Marmot::Matrix6d&                                flowUnitCompliance,
+    const Marmot::Vector6d&                                stressOld,
+    const Parameters&                                      parameters,
+    const KelvinChainProperties&                           kelvinChainProperties,
+    const Eigen::Ref< const KelvinChain::StateVarMatrix >& kelvinStateVars );
 
-    /// \brief solidified volume function according to %Solidification Theory
-    double solidifiedVolume( double timeInDays, Parameters params );
+  /// \brief solidified volume function according to %Solidification Theory
+  double solidifiedVolume( double timeInDays, Parameters params );
 
-    /// \brief  to %Solidification Theory
-    double computeZerothElasticModul( double tauMin, double n, int order );
+  /// \brief  to %Solidification Theory
+  double computeZerothElasticModul( double tauMin, double n, int order );
 
-    /// \brief compliance of the hardened constituent
-    template < typename T >
-    T phi( T xi, Parameters params )
-    {
-      return log( 1. + pow( xi, params.n ) );
-    }
+  /// \brief compliance of the hardened constituent
+  template < typename T >
+  T phi( T xi, Parameters params )
+  {
+    return log( 1. + pow( xi, params.n ) );
+  }
 
-  } // namespace SolidificationTheory
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::SolidificationTheory

--- a/modules/materials/B4/src/B4Registration.cpp
+++ b/modules/materials/B4/src/B4Registration.cpp
@@ -3,7 +3,8 @@
 
 namespace Marmot::Materials::Registration {
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
   const static bool B4isRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< B4 >( "B4" );
 

--- a/modules/materials/B4/src/B4Shrinkage.cpp
+++ b/modules/materials/B4/src/B4Shrinkage.cpp
@@ -8,43 +8,41 @@
 using namespace Marmot;
 using namespace std;
 
-namespace Marmot::Materials {
-  namespace Shrinkage::B4 {
-    Vector6d computeShrinkageStrainIncrement( const double tStartDays,
-                                              const double dTDays,
-                                              const double ultimateAutogenousShrinkageStrain,
-                                              const double autogenousShrinkageHalfTime,
-                                              const double alpha,
-                                              const double rt,
-                                              const double ultimateDryingShrinkageStrain,
-                                              const double dryingShrinkageHalfTime,
-                                              const double kHum,
-                                              const double dryingStart )
-    {
+namespace Marmot::Materials::Shrinkage::B4 {
+  Vector6d computeShrinkageStrainIncrement( const double tStartDays,
+                                            const double dTDays,
+                                            const double ultimateAutogenousShrinkageStrain,
+                                            const double autogenousShrinkageHalfTime,
+                                            const double alpha,
+                                            const double rt,
+                                            const double ultimateDryingShrinkageStrain,
+                                            const double dryingShrinkageHalfTime,
+                                            const double kHum,
+                                            const double dryingStart )
+  {
 
-      const double tEndDays = tStartDays + dTDays;
-      if ( tEndDays == 0 )
-        return Vector6d::Zero();
+    const double tEndDays = tStartDays + dTDays;
+    if ( tEndDays == 0 )
+      return Vector6d::Zero();
 
-      // autogenous shrinkage
-      double deltaAutogenous = 0;
+    // autogenous shrinkage
+    double deltaAutogenous = 0;
 
-      if ( tEndDays > 5e-2 ) {
-        deltaAutogenous = pow( 1. + pow( autogenousShrinkageHalfTime / ( tStartDays + dTDays ), alpha ), rt ) -
-                          pow( 1. + pow( autogenousShrinkageHalfTime / tStartDays, alpha ), rt );
-      }
-
-      // drying shrinkage
-
-      const double end         = Math::macauly( tEndDays - dryingStart );
-      double       deltaDrying = 0;
-      double       start       = Math::macauly( tStartDays - dryingStart );
-
-      if ( end != 0 )
-        deltaDrying = tanh( sqrt( end / dryingShrinkageHalfTime ) ) - tanh( sqrt( start / dryingShrinkageHalfTime ) );
-
-      return ContinuumMechanics::VoigtNotation::I * ( ultimateAutogenousShrinkageStrain * deltaAutogenous +
-                                                      ultimateDryingShrinkageStrain * kHum * deltaDrying );
+    if ( tEndDays > 5e-2 ) {
+      deltaAutogenous = pow( 1. + pow( autogenousShrinkageHalfTime / ( tStartDays + dTDays ), alpha ), rt ) -
+                        pow( 1. + pow( autogenousShrinkageHalfTime / tStartDays, alpha ), rt );
     }
-  } // namespace Shrinkage::B4
-} // namespace Marmot::Materials
+
+    // drying shrinkage
+
+    const double end         = Math::macauly( tEndDays - dryingStart );
+    double       deltaDrying = 0;
+    double       start       = Math::macauly( tStartDays - dryingStart );
+
+    if ( end != 0 )
+      deltaDrying = tanh( sqrt( end / dryingShrinkageHalfTime ) ) - tanh( sqrt( start / dryingShrinkageHalfTime ) );
+
+    return ContinuumMechanics::VoigtNotation::I *
+           ( ultimateAutogenousShrinkageStrain * deltaAutogenous + ultimateDryingShrinkageStrain * kHum * deltaDrying );
+  }
+} // namespace Marmot::Materials::Shrinkage::B4

--- a/modules/materials/B4/src/MarmotSolidification.cpp
+++ b/modules/materials/B4/src/MarmotSolidification.cpp
@@ -1,68 +1,65 @@
 #include "Marmot/MarmotSolidification.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::SolidificationTheory {
 
-  namespace SolidificationTheory {
+  double solidifiedVolume( double timeInDays, Parameters params )
+  {
+    return 1. / ( pow( params.lambda0 / timeInDays, params.m ) + params.q3 / params.q2 );
+  }
 
-    double solidifiedVolume( double timeInDays, Parameters params )
-    {
-      return 1. / ( pow( params.lambda0 / timeInDays, params.m ) + params.q3 / params.q2 );
+  double computeZerothElasticModul( double tauMin, double n, int order )
+  {
+
+    const double tau0 = tauMin / std::sqrt( 10. );
+    double       E0;
+    switch ( order ) {
+    case 1: E0 = 1. / ( log( 1. + pow( tau0, n ) ) ); break;
+    case 2:
+      E0 = 1. / ( std::log( 1. + std::pow( 2. * tau0, n ) ) -
+                  n * std::pow( 2. * tau0, n ) / ( 1. + std::pow( 2. * tau0, n ) ) );
+      break;
+    case 3: E0 = 1. / ( ( 1. - n ) * log( 1. + pow( 3. * tau0, n ) ) ); break;
+    default: throw std::invalid_argument( "Invalid approximation order requested" ); break;
     }
+    return E0;
+  }
 
-    double computeZerothElasticModul( double tauMin, double n, int order )
-    {
+  Result computeCreepStrainIncrementAndComplianceComponents(
+    double                                                 tStartDays,
+    double                                                 dTimeDays,
+    double                                                 amplificationFactor,
+    const Marmot::Matrix6d&                                flowUnitCompliance,
+    const Marmot::Vector6d&                                stressOld,
+    const Parameters&                                      parameters,
+    const KelvinChainProperties&                           kelvinChainProperties,
+    const Eigen::Ref< const KelvinChain::StateVarMatrix >& kelvinStateVars )
+  {
 
-      const double tau0 = tauMin / std::sqrt( 10. );
-      double       E0;
-      switch ( order ) {
-      case 1: E0 = 1. / ( log( 1. + pow( tau0, n ) ) ); break;
-      case 2:
-        E0 = 1. / ( std::log( 1. + std::pow( 2. * tau0, n ) ) -
-                    n * std::pow( 2. * tau0, n ) / ( 1. + std::pow( 2. * tau0, n ) ) );
-        break;
-      case 3: E0 = 1. / ( ( 1. - n ) * log( 1. + pow( 3. * tau0, n ) ) ); break;
-      default: throw std::invalid_argument( "Invalid approximation order requested" ); break;
-      }
-      return E0;
-    }
+    Vector6d                     dECreep = Vector6d::Zero();
+    UniaxialComplianceComponents complianceComponents;
 
-    Result computeCreepStrainIncrementAndComplianceComponents(
-      double                                                 tStartDays,
-      double                                                 dTimeDays,
-      double                                                 amplificationFactor,
-      const Marmot::Matrix6d&                                flowUnitCompliance,
-      const Marmot::Vector6d&                                stressOld,
-      const Parameters&                                      parameters,
-      const KelvinChainProperties&                           kelvinChainProperties,
-      const Eigen::Ref< const KelvinChain::StateVarMatrix >& kelvinStateVars )
-    {
+    const double v = solidifiedVolume( tStartDays + dTimeDays / 2., parameters );
 
-      Vector6d                     dECreep = Vector6d::Zero();
-      UniaxialComplianceComponents complianceComponents;
+    complianceComponents.elastic = parameters.q1 * 1e-6;
 
-      const double v = solidifiedVolume( tStartDays + dTimeDays / 2., parameters );
-
-      complianceComponents.elastic = parameters.q1 * 1e-6;
-
-      if ( dTimeDays <= 1e-14 )
-        return { dECreep, complianceComponents };
-
-      complianceComponents.flow = amplificationFactor * parameters.q4 / ( tStartDays + dTimeDays / 2. ) / 2. *
-                                  dTimeDays * 1e-6;
-      dECreep += complianceComponents.flow * 2. * flowUnitCompliance * stressOld;
-
-      complianceComponents.viscoelastic = parameters.q2 / ( v * kelvinChainProperties.E0 ) * amplificationFactor * 1e-6;
-
-      KelvinChain::evaluateKelvinChain( dTimeDays,
-                                        kelvinChainProperties.elasticModuli,
-                                        kelvinChainProperties.retardationTimes,
-                                        kelvinStateVars,
-                                        complianceComponents.viscoelastic,
-                                        dECreep,
-                                        1e-6 * amplificationFactor * parameters.q2 / v );
-
+    if ( dTimeDays <= 1e-14 )
       return { dECreep, complianceComponents };
-    }
 
-  } // namespace SolidificationTheory
-} // namespace Marmot::Materials
+    complianceComponents.flow = amplificationFactor * parameters.q4 / ( tStartDays + dTimeDays / 2. ) / 2. * dTimeDays *
+                                1e-6;
+    dECreep += complianceComponents.flow * 2. * flowUnitCompliance * stressOld;
+
+    complianceComponents.viscoelastic = parameters.q2 / ( v * kelvinChainProperties.E0 ) * amplificationFactor * 1e-6;
+
+    KelvinChain::evaluateKelvinChain( dTimeDays,
+                                      kelvinChainProperties.elasticModuli,
+                                      kelvinChainProperties.retardationTimes,
+                                      kelvinStateVars,
+                                      complianceComponents.viscoelastic,
+                                      dECreep,
+                                      1e-6 * amplificationFactor * parameters.q2 / v );
+
+    return { dECreep, complianceComponents };
+  }
+
+} // namespace Marmot::Materials::SolidificationTheory

--- a/modules/materials/CompressibleFiniteStrainLinearViscoelasticity/src/CompressibleFiniteStrainLinearViscoelasticityRegistration.cpp
+++ b/modules/materials/CompressibleFiniteStrainLinearViscoelasticity/src/CompressibleFiniteStrainLinearViscoelasticityRegistration.cpp
@@ -2,20 +2,17 @@
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 #include "Marmot/MarmotMaterialFiniteStrainSubstepped.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool CompressibleFiniteStrainLinearViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
+    registerMaterial< CompressibleFiniteStrainLinearViscoelasticity >(
+      "COMPRESSIBLEFINITESTRAINLINEARVISCOELASTICITY" );
 
-    const static bool CompressibleFiniteStrainLinearViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
-      registerMaterial< CompressibleFiniteStrainLinearViscoelasticity >(
-        "COMPRESSIBLEFINITESTRAINLINEARVISCOELASTICITY" );
-
-    const static bool
-      CompressibleFiniteStrainLinearViscoelasticitySubsteppedRegistered = MarmotMaterialFiniteStrainFactory::
-        registerMaterial< MarmotMaterialFiniteStrainSubstepped< CompressibleFiniteStrainLinearViscoelasticity > >(
-          "COMPRESSIBLEFINITESTRAINLINEARVISCOELASTICITY_SUBSTEPPED" );
-  } // namespace Registration
-} // namespace Marmot::Materials
+  const static bool
+    CompressibleFiniteStrainLinearViscoelasticitySubsteppedRegistered = MarmotMaterialFiniteStrainFactory::
+      registerMaterial< MarmotMaterialFiniteStrainSubstepped< CompressibleFiniteStrainLinearViscoelasticity > >(
+        "COMPRESSIBLEFINITESTRAINLINEARVISCOELASTICITY_SUBSTEPPED" );
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/CompressibleFiniteStrainLinearViscoelasticity/src/CompressibleFiniteStrainLinearViscoelasticityRegistration.cpp
+++ b/modules/materials/CompressibleFiniteStrainLinearViscoelasticity/src/CompressibleFiniteStrainLinearViscoelasticityRegistration.cpp
@@ -6,7 +6,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool CompressibleFiniteStrainLinearViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
       registerMaterial< CompressibleFiniteStrainLinearViscoelasticity >(

--- a/modules/materials/CompressibleNeoHooke/src/CompressibleNeoHookeRegistration.cpp
+++ b/modules/materials/CompressibleNeoHooke/src/CompressibleNeoHookeRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool
       CompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< CompressibleNeoHooke >(

--- a/modules/materials/CompressibleNeoHooke/src/CompressibleNeoHookeRegistration.cpp
+++ b/modules/materials/CompressibleNeoHooke/src/CompressibleNeoHookeRegistration.cpp
@@ -1,16 +1,13 @@
 #include "Marmot/CompressibleNeoHooke.h"
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool
+    CompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< CompressibleNeoHooke >(
+      "COMPRESSIBLENEOHOOKE" );
 
-    const static bool
-      CompressibleNeoHookeRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial< CompressibleNeoHooke >(
-        "COMPRESSIBLENEOHOOKE" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/FiniteStrainIsotropicBiotViscoelasticity/src/FiniteStrainIsotropicBiotViscoelasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainIsotropicBiotViscoelasticity/src/FiniteStrainIsotropicBiotViscoelasticityRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool FiniteStrainIsotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
       registerMaterial< FiniteStrainIsotropicBiotViscoelasticity >( "FINITESTRAINISOTROPICBIOTVISCOELASTICITY" );

--- a/modules/materials/FiniteStrainIsotropicBiotViscoelasticity/src/FiniteStrainIsotropicBiotViscoelasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainIsotropicBiotViscoelasticity/src/FiniteStrainIsotropicBiotViscoelasticityRegistration.cpp
@@ -1,15 +1,12 @@
 #include "Marmot/FiniteStrainIsotropicBiotViscoelasticity.h"
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool FiniteStrainIsotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
+    registerMaterial< FiniteStrainIsotropicBiotViscoelasticity >( "FINITESTRAINISOTROPICBIOTVISCOELASTICITY" );
 
-    const static bool FiniteStrainIsotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
-      registerMaterial< FiniteStrainIsotropicBiotViscoelasticity >( "FINITESTRAINISOTROPICBIOTVISCOELASTICITY" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/FiniteStrainJ2Plasticity/src/FiniteStrainJ2PlasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainJ2Plasticity/src/FiniteStrainJ2PlasticityRegistration.cpp
@@ -2,22 +2,18 @@
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 #include "Marmot/MarmotMaterialFiniteStrainSubstepped.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool FiniteStrainJ2PlasticityRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
+    FiniteStrainJ2Plasticity >( "FINITESTRAINJ2PLASTICITY" );
 
-    const static bool FiniteStrainJ2PlasticityRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
-      FiniteStrainJ2Plasticity >( "FINITESTRAINJ2PLASTICITY" );
+  // Register the SUBSTEPPED J2 model
+  // This allows you to use "FINITESTRAINJ2PLASTICITY_SUBSTEPPED" in your input file.
+  // The properties array must start with [nSubsteps, K, G, fy, ...]
+  const static bool FiniteStrainJ2PlasticitySubsteppedRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
+    MarmotMaterialFiniteStrainSubstepped< FiniteStrainJ2Plasticity > >( "FINITESTRAINJ2PLASTICITY_SUBSTEPPED" );
 
-    // Register the SUBSTEPPED J2 model
-    // This allows you to use "FINITESTRAINJ2PLASTICITY_SUBSTEPPED" in your input file.
-    // The properties array must start with [nSubsteps, K, G, fy, ...]
-    const static bool FiniteStrainJ2PlasticitySubsteppedRegistered = MarmotMaterialFiniteStrainFactory::
-      registerMaterial< MarmotMaterialFiniteStrainSubstepped< FiniteStrainJ2Plasticity > >(
-        "FINITESTRAINJ2PLASTICITY_SUBSTEPPED" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/FiniteStrainJ2Plasticity/src/FiniteStrainJ2PlasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainJ2Plasticity/src/FiniteStrainJ2PlasticityRegistration.cpp
@@ -6,7 +6,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool FiniteStrainJ2PlasticityRegistered = MarmotMaterialFiniteStrainFactory::registerMaterial<
       FiniteStrainJ2Plasticity >( "FINITESTRAINJ2PLASTICITY" );

--- a/modules/materials/FiniteStrainOrthotropicBiotViscoelasticity/src/FinitStrainOrthotropicBiotViscoelasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainOrthotropicBiotViscoelasticity/src/FinitStrainOrthotropicBiotViscoelasticityRegistration.cpp
@@ -6,7 +6,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool FiniteStrainOrthotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
       registerMaterial< FiniteStrainOrthotropicBiotViscoelasticity >( "FINITESTRAINORTHOTROPICBIOTVISCOELASTICITY" );

--- a/modules/materials/FiniteStrainOrthotropicBiotViscoelasticity/src/FinitStrainOrthotropicBiotViscoelasticityRegistration.cpp
+++ b/modules/materials/FiniteStrainOrthotropicBiotViscoelasticity/src/FinitStrainOrthotropicBiotViscoelasticityRegistration.cpp
@@ -2,20 +2,16 @@
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 #include "Marmot/MarmotMaterialFiniteStrainSubstepped.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool FiniteStrainOrthotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
+    registerMaterial< FiniteStrainOrthotropicBiotViscoelasticity >( "FINITESTRAINORTHOTROPICBIOTVISCOELASTICITY" );
 
-    const static bool FiniteStrainOrthotropicBiotViscoelasticityRegistered = MarmotMaterialFiniteStrainFactory::
-      registerMaterial< FiniteStrainOrthotropicBiotViscoelasticity >( "FINITESTRAINORTHOTROPICBIOTVISCOELASTICITY" );
+  const static bool FiniteStrainOrthotropicBiotViscoelasticitySubsteppedRegistered = MarmotMaterialFiniteStrainFactory::
+    registerMaterial< MarmotMaterialFiniteStrainSubstepped< FiniteStrainOrthotropicBiotViscoelasticity > >(
+      "FINITESTRAINORTHOTROPICBIOTVISCOELASTICITY_SUBSTEPPED" );
 
-    const static bool
-      FiniteStrainOrthotropicBiotViscoelasticitySubsteppedRegistered = MarmotMaterialFiniteStrainFactory::
-        registerMaterial< MarmotMaterialFiniteStrainSubstepped< FiniteStrainOrthotropicBiotViscoelasticity > >(
-          "FINITESTRAINORTHOTROPICBIOTVISCOELASTICITY_SUBSTEPPED" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
+++ b/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
@@ -5,7 +5,8 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool LinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< LinearElastic >(
       "LINEARELASTIC" );

--- a/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
+++ b/modules/materials/LinearElastic/src/LinearElasticRegistration.cpp
@@ -1,15 +1,12 @@
 #include "Marmot/LinearElastic.h"
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool LinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< LinearElastic >(
+    "LINEARELASTIC" );
 
-    const static bool LinearElasticIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< LinearElastic >(
-      "LINEARELASTIC" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/LinearViscoelasticOrthotropicPowerLaw/src/LinearViscoelasticOrthotropicPowerLawRegistration.cpp
+++ b/modules/materials/LinearViscoelasticOrthotropicPowerLaw/src/LinearViscoelasticOrthotropicPowerLawRegistration.cpp
@@ -3,7 +3,8 @@
 
 namespace Marmot::Materials::Registration {
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
   const static bool LinearViscoelasticOrthotropicPowerLawisRegistered = MarmotMaterialHypoElasticFactory::
     registerMaterial< LinearViscoelasticOrthotropicPowerLaw >( "LINEARVISCOELASTICORTHOTROPICPOWERLAW" );

--- a/modules/materials/LinearViscoelasticPowerLaw/src/LinearViscoelasticPowerLawRegistration.cpp
+++ b/modules/materials/LinearViscoelasticPowerLaw/src/LinearViscoelasticPowerLawRegistration.cpp
@@ -3,7 +3,8 @@
 
 namespace Marmot::Materials::Registration {
 
-  using namespace MarmotLibrary;
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
   const static bool LinearViscoelasticPowerLawisRegistered = MarmotMaterialHypoElasticFactory::registerMaterial<
     LinearViscoelasticPowerLaw >( "LINEARVISCOELASTICPOWERLAW" );

--- a/modules/materials/VonMises/include/Marmot/VonMisesConstants.h
+++ b/modules/materials/VonMises/include/Marmot/VonMisesConstants.h
@@ -25,14 +25,10 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Marmot::Materials {
-
-  /**
-   * @brief Numerical constants for the VonMises return-mapping algorithm.
-   */
-  namespace VonMisesConstants {
-    const double innerNewtonTol        = 1e-12; ///< Convergence tolerance for the inner Newton iteration.
-    const int    nMaxInnerNewtonCycles = 15;    ///< Maximum number of inner Newton iterations.
-  }                                             // namespace VonMisesConstants
-
-} // namespace Marmot::Materials
+/**
+ * @brief Numerical constants for the VonMises return-mapping algorithm.
+ */
+namespace Marmot::Materials::VonMisesConstants {
+  const double innerNewtonTol        = 1e-12; ///< Convergence tolerance for the inner Newton iteration.
+  const int    nMaxInnerNewtonCycles = 15;    ///< Maximum number of inner Newton iterations.
+} // namespace Marmot::Materials::VonMisesConstants

--- a/modules/materials/VonMises/src/VonMisesRegistration.cpp
+++ b/modules/materials/VonMises/src/VonMisesRegistration.cpp
@@ -1,15 +1,12 @@
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 #include "Marmot/VonMises.h"
 
-namespace Marmot::Materials {
+namespace Marmot::Materials::Registration {
 
-  namespace Registration {
+  using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                        // scope
 
-    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
-                                          // scope
+  const static bool VonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< VonMisesModel >(
+    "VONMISES" );
 
-    const static bool VonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< VonMisesModel >(
-      "VONMISES" );
-
-  } // namespace Registration
-} // namespace Marmot::Materials
+} // namespace Marmot::Materials::Registration

--- a/modules/materials/VonMises/src/VonMisesRegistration.cpp
+++ b/modules/materials/VonMises/src/VonMisesRegistration.cpp
@@ -5,11 +5,11 @@ namespace Marmot::Materials {
 
   namespace Registration {
 
-    using namespace MarmotLibrary;
+    using namespace Marmot::Registration; // factory/registry namespace, distinct from this file's own ::Registration
+                                          // scope
 
     const static bool VonMisesIsRegistered = MarmotMaterialHypoElasticFactory::registerMaterial< VonMisesModel >(
       "VONMISES" );
 
   } // namespace Registration
-
 } // namespace Marmot::Materials


### PR DESCRIPTION
## Summary
Stage 3 (final) of a 3-stage namespace cleanup. **Stacked on #66** -- this PR's branch is built on top of `refactor/namespace-cleanup-stage2-marmotlibrary-rename`, so its diff currently includes #65's and #66's commits too. Once those merge, this diff will shrink to just this stage's commit.

- Collapses pure passthrough nested namespaces (`namespace A { namespace B { ... } }`) into the C++17 `namespace A::B { ... }` form, wherever a namespace level in a given file has no content of its own besides comments and the next nested opener. Applied file-by-file (not via blanket regex), since some files (e.g. `MarmotVoigt.h`) need only *partial* collapsing.
- Removes `using namespace X;` from header scope -- including `using namespace std;` in two element headers, the classic anti-pattern that pollutes every downstream translation unit -- replacing it with targeted `using X::Symbol;` declarations or explicit qualification.
- Drops now-redundant `using namespace Marmot;` / `using namespace Marmot::FiniteElement;` lines inside method bodies of classes moved into `namespace Marmot` in stage 1 (#65), since ordinary unqualified lookup already finds sibling `Marmot::` symbols from within the namespace.
- Pure refactor, no behavior changes.

## Stack
1. #65 -- base classes into `Marmot::`
2. #66 -- `MarmotLibrary` -> `Marmot::Registration`
3. **This PR** -- brace-style standardization + `using namespace` header cleanup

## Out of scope
Consolidating the math/tensor utility namespace sprawl (`Marmot::Math`, `Marmot::NumericalAlgorithms`, `Marmot::AutomaticDifferentiation`, `Marmot::FastorStandardTensors`, `Marmot::FastorIndices`, `Marmot::EigenTensors`, `Marmot::ContinuumMechanics::TensorUtility`) is a separate, bigger design decision deferred to a future PR.

## Test plan
- [x] `cmake --build .` -- clean, zero errors
- [x] `ctest --output-on-failure` -- 46/46 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)