### PR TITLE
ci(docs): enable pull request CI for documentation build and modernize workflow

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [ master, next_v26.05, next_v26.11 ]
+    branches: [ master ]
   pull_request:
 
 jobs:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -2,17 +2,18 @@ name: Documentation
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, next_v26.05, next_v26.11 ]
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           use-mamba: true
           miniforge-variant: Miniforge3
@@ -54,21 +55,23 @@ jobs:
       - name: Install Fastor
         shell: bash -l {0}
         run: |
-          git clone https://github.com/romeric/Fastor.git
+          git clone --branch V0.6.4 https://github.com/romeric/Fastor.git
           cd Fastor
           cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX .
           make install
           cd ..
 
-      - name: Building Marmot  documentation
+      - name: Building Marmot documentation
         shell: bash -l {0}
         run: |
           python scripts/buildDocumentation.py
 
       - name: Deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc/doc_out/sphinx
           publish_branch: gh-pages
+
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -66,6 +66,14 @@ jobs:
         run: |
           python scripts/buildDocumentation.py
 
+      - name: Upload documentation artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: ./doc/doc_out/sphinx
+          retention-days: 7
+
       - name: Deploy
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3

--- a/scripts/buildDocumentation.py
+++ b/scripts/buildDocumentation.py
@@ -1,10 +1,25 @@
-import os
+import subprocess
+import sys
+from pathlib import Path
 
 # change to doc directory
-os.chdir("doc")
+doc_dir = Path(__file__).resolve().parent.parent / "doc"
 
-# run doxgen
-os.system("doxygen Doxyfile")
+# run doxygen
+subprocess.run(["doxygen", "Doxyfile"], cwd=doc_dir, check=True)
 
 # run sphinx
-os.system("sphinx-build -b html -Dbreathe_projects.Marmot=doc_out/xml . doc_out/sphinx")
+subprocess.run(
+    [
+        sys.executable,
+        "-m",
+        "sphinx",
+        "-b",
+        "html",
+        "-Dbreathe_projects.Marmot=doc_out/xml",
+        ".",
+        "doc_out/sphinx",
+    ],
+    cwd=doc_dir,
+    check=True,
+)


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to [.github/workflows/sphinx.yml](file:///home/alex/code/Marmot/.github/workflows/sphinx.yml) while keeping `push` restricted to `master`.
- Modernize workflow actions to `@v4` / `setup-miniconda@v3` and pin Fastor to release `V0.6.4`.
- Ensure GitHub Pages deployment only runs on `push` to `master`.
- Update [scripts/buildDocumentation.py](file:///home/alex/code/Marmot/scripts/buildDocumentation.py) to use `subprocess.run(..., check=True)` so that Doxygen/Sphinx failures properly fail CI.