### PR TITLE
fix(elements): Hexa20 zero corner mass in computeLumpedInertia

### DIFF
--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -307,6 +307,12 @@ namespace Marmot::Elements {
      * \f$\hat{N} = \tfrac{1}{2}N + \tfrac{1}{2}N_\mathrm{lin}\f$,
      * where \f$N\f$ is the high-order shape function and \f$N_\mathrm{lin}\f$ is the corresponding
      * linear (corner-node) shape function on the same element.
+     *
+     * Hexa20 is special-cased to \f$\hat{N} = \tfrac{1}{3}N + \tfrac{2}{3}N_\mathrm{lin}\f$: with
+     * the default 1/2-1/2 split, the negative corner contribution of the Hexa20 serendipity shape
+     * function exactly cancels the positive corner contribution of the trilinear shape function
+     * for any regular (affinely-mapped) element, producing an exactly zero corner mass. Shifting
+     * weight towards the linear shape function keeps the corner contribution strictly positive.
      */
     void computeLumpedInertia( double* M );
 
@@ -840,14 +846,21 @@ namespace Marmot::Elements {
     Map< RhsSized > LMM( M );
     LMM.setZero();
 
+    // Hexa20 special case: shift the split towards the linear shape function to avoid the exact
+    // corner-mass cancellation the default 1/2-1/2 split produces for this element (see the
+    // Doxygen comment on the declaration).
+    constexpr bool   isHexa20   = ( nDim == 3 && nNodes == 20 );
+    constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
+    constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
+
     constexpr int nNodesLinear  = ( 1 << nDim );
     auto          linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
     for ( const auto& qp : qps ) {
       const auto N_    = this->N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );
 
-      VectorXd N_weighted = 0.5 * ( N_ );
-      N_weighted.head( nNodesLinear ) += 0.5 * N_lin;
+      VectorXd N_weighted = wHighOrder * ( N_ );
+      N_weighted.head( nNodesLinear ) += wLinear * N_lin;
 
       const double rho = qp.material->getDensity( qp.managedStateVars->materialStateVars.data() );
       VectorXd     m_  = N_weighted * qp.J0xW * rho;

--- a/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
+++ b/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
@@ -2,6 +2,8 @@
 #include "Marmot/MarmotElementProperty.h"
 #include "Marmot/MarmotFiniteElement.h"
 #include "Marmot/MarmotTesting.h"
+#include <cmath>
+#include <string>
 
 using namespace Marmot;
 using namespace Marmot::Elements;
@@ -255,12 +257,405 @@ void testInitializeYourselfAndShapeFunctions()
   throwExceptionOnFailure( checkIfEqual( qp0.B( 2, 3 ), expected_dN2dx ), "Incorrect B(2,3) for QP0." );
 }
 
+// ---------------------------------------------------------------------------------------------
+// Lumped (diagonal) mass matrix tests
+//
+// computeLumpedInertia() uses the manifold-based scheme of Yang et al. (2017), mixing the
+// high-order shape function N with the corresponding corner-node linear shape function N_lin
+// via N_weighted = w*N + (1-w)*N_lin (only the corner entries receive the N_lin correction),
+// with w = 1/2 by default and w = 1/3 special-cased for Hexa20 (see below). The tests below check
+// the two properties any lumping scheme must satisfy to be usable in explicit dynamics: (1) no
+// singular (zero or negative) nodal mass, and (2) conservation of the total element mass. Linear
+// elements are included as a sanity baseline; quadratic elements (Quad8, Hexa20) get closer
+// scrutiny, since the correction term is exactly what can drive a nodal mass towards (or
+// through) zero.
+// ---------------------------------------------------------------------------------------------
+
+void testLumpedInertiaQuad4RegularElementIsPositiveAndConservesMass()
+{
+  constexpr int nDim    = 2;
+  constexpr int nNodes  = 4; // Quad4 (linear)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::PlaneStrain;
+
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 }; // unit square
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 10000.0, 0.2, density };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 }; // thickness
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Unit square, uniform density: by symmetry each corner carries exactly area*density/4.
+  for ( int i = 0; i < nNodes; i++ ) {
+    throwExceptionOnFailure( M[i * nDim] > 0.0, "Quad4 lumped mass entry is not strictly positive." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], 0.25, 1e-12 ),
+                             "Quad4 lumped mass entry does not match the analytic value." );
+  }
+}
+
+void testLumpedInertiaHexa8RegularElementIsPositiveAndConservesMass()
+{
+  constexpr int nDim    = 3;
+  constexpr int nNodes  = 8; // Hexa8 (linear)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::Solid;
+
+  // Unit cube; node ordering per MarmotFiniteElement3D.cpp Hexa8::N.
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+                                                0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 10000.0, 0.2, density };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Unit cube, uniform density: by symmetry each corner carries exactly volume*density/8.
+  for ( int i = 0; i < nNodes; i++ ) {
+    throwExceptionOnFailure( M[i * nDim] > 0.0, "Hexa8 lumped mass entry is not strictly positive." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], 0.125, 1e-12 ),
+                             "Hexa8 lumped mass entry does not match the analytic value." );
+  }
+}
+
+void checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes intType, const std::string& label )
+{
+  constexpr int nDim    = 2;
+  constexpr int nNodes  = 8; // Quad8 (quadratic serendipity)
+  const int     elId    = 1;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::PlaneStrain;
+
+  // Unit square with midside nodes at exact edge midpoints (straight edges). Node ordering
+  // per MarmotFiniteElement2D.cpp Quad8::N: 0-3 corners CCW, 4-7 midsides.
+  const std::vector< double > nodeCoordsVec = { 0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0, // corners
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5 }; // midsides
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 10000.0, 0.2, density };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 };
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Reference values from an independent symbolic (SymPy) double integration of
+  // 0.5*N_serendipity + 0.5*N_bilinear over the reference square: corners = 1/12,
+  // midsides = 1/6. Because the geometry map is affine here (straight edges, midsides at
+  // exact midpoints), both full (3x3) and reduced (2x2) Gauss integrate the (low-degree)
+  // integrand exactly, so both integration types must reproduce these same values.
+  const double expectedCorner  = 1.0 / 12.0;
+  const double expectedMidside = 1.0 / 6.0;
+
+  double totalMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 4 ? expectedCorner : expectedMidside;
+    throwExceptionOnFailure( M[i * nDim] > 0.0,
+                             label + ": Quad8 lumped mass entry is not strictly positive (node " + std::to_string( i ) +
+                               ")." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], expected, 1e-10 ),
+                             label + ": Quad8 lumped mass entry does not match the analytic reference (node " +
+                               std::to_string( i ) + ")." );
+    totalMass += M[i * nDim];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalMass, 1.0, 1e-10 ),
+                           label + ": Quad8 lumped mass does not conserve the total element mass." );
+}
+
+void testLumpedInertiaQuad8FullIntegrationMatchesAnalyticValues()
+{
+  checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::FullIntegration, "FullIntegration" );
+}
+
+void testLumpedInertiaQuad8ReducedIntegrationMatchesAnalyticValues()
+{
+  checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                  "ReducedIntegration" );
+}
+
+void checkQuad8DistortedElementStaysNonSingular( FiniteElement::Quadrature::IntegrationTypes intType,
+                                                 const std::string&                          label )
+{
+  constexpr int nDim    = 2;
+  constexpr int nNodes  = 8;
+  const int     elId    = 1;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::PlaneStrain;
+
+  // Curved-edge quarter-annulus sector (r_in=1, r_out=2, 0-90deg): a realistic curved-boundary
+  // quadratic element, where the isoparametric mapping is no longer affine (unlike the regular
+  // element above), exercising the mass-lumping scheme's robustness under distortion.
+  const std::vector< double > nodeCoordsVec = {
+    1.0,
+    0.0,              // node 0: (r_in, 0deg)
+    2.0,
+    0.0,              // node 1: (r_out, 0deg)
+    0.0,
+    2.0,              // node 2: (r_out, 90deg)
+    0.0,
+    1.0,              // node 3: (r_in, 90deg)
+    1.5,
+    0.0,              // node 4: mid of edge 0-1
+    std::sqrt( 2.0 ),
+    std::sqrt( 2.0 ), // node 5: true arc midpoint of edge 1-2 (curved!)
+    0.0,
+    1.5,              // node 6: mid of edge 2-3
+    std::sqrt( 0.5 ),
+    std::sqrt( 0.5 )  // node 7: true arc midpoint of edge 3-0 (curved!)
+  };
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 10000.0, 0.2, density };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 };
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  // Independently compute the total element mass from the same quadrature rule the element
+  // itself uses (sum of rho * J0xW over all quadrature points), instead of relying on a
+  // hardcoded reference value for this distorted (non-affine) geometry.
+  double totalMassFromQuadrature = 0.0;
+  for ( const auto& qp : element->qps ) {
+    const double rho = qp.material->getDensity( qp.managedStateVars->materialStateVars.data() );
+    totalMassFromQuadrature += rho * qp.J0xW;
+  }
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  double totalLumpedMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    throwExceptionOnFailure( M[i * nDim] > 1e-8,
+                             label + ": distorted Quad8 lumped mass entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    totalLumpedMass += M[i * nDim];
+  }
+
+  throwExceptionOnFailure( checkIfEqual( totalLumpedMass, totalMassFromQuadrature, 1e-10 ),
+                           label + ": distorted Quad8 lumped mass does not conserve the total element mass." );
+}
+
+void testLumpedInertiaQuad8DistortedElementFullIntegrationStaysNonSingular()
+{
+  checkQuad8DistortedElementStaysNonSingular( FiniteElement::Quadrature::IntegrationTypes::FullIntegration,
+                                              "FullIntegration" );
+}
+
+void testLumpedInertiaQuad8DistortedElementReducedIntegrationStaysNonSingular()
+{
+  checkQuad8DistortedElementStaysNonSingular( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                              "ReducedIntegration" );
+}
+
+void checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes intType, const std::string& label )
+{
+  constexpr int nDim    = 3;
+  constexpr int nNodes  = 20; // Hexa20 (quadratic serendipity)
+  const int     elId    = 1;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::Solid;
+
+  // Unit cube with edge-midside nodes at exact midpoints (straight edges). Node ordering per
+  // MarmotFiniteElement3D.cpp Hexa20::N: 0-7 corners, 8-19 edge midsides.
+  const std::vector< double > nodeCoordsVec = { // corners
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                // bottom-face edge midsides (0-1, 1-2, 2-3, 3-0)
+                                                0.5,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                0.5,
+                                                0.0,
+                                                // top-face edge midsides (4-5, 5-6, 6-7, 7-4)
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.5,
+                                                1.0,
+                                                0.5,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                // vertical edge midsides (0-4, 1-5, 2-6, 3-7)
+                                                0.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                1.0,
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5 };
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 10000.0, 0.2, density };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Reference values from an independent symbolic (SymPy) double integration of
+  // 1/3*N_serendipity + 2/3*N_trilinear over the reference cube: corners = 1/24,
+  // edges = 1/18. Both full (3x3x3) and reduced (2x2x2) Gauss integrate this exactly for a
+  // regular (affinely-mapped) element, so both integration types must reproduce these values.
+  //
+  // REGRESSION GUARD: the default 1/2-1/2 split (used for every other element) makes the
+  // negative corner contribution of the Hexa20 serendipity shape function EXACTLY cancel the
+  // positive corner contribution of the trilinear shape function for any regular element: all 8
+  // corners end up with EXACTLY ZERO lumped mass. Hexa20 is special-cased in computeLumpedInertia
+  // to a 1/3-2/3 split for exactly this reason; this test checks both that the corner masses are
+  // strictly positive and that they match the analytic reference for that special-cased split.
+  const double expectedCorner = 1.0 / 24.0;
+  const double expectedEdge   = 1.0 / 18.0;
+
+  double totalMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 8 ? expectedCorner : expectedEdge;
+    throwExceptionOnFailure( M[i * nDim] > 0.0,
+                             label + ": Hexa20 lumped mass entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], expected, 1e-10 ),
+                             label + ": Hexa20 lumped mass entry does not match the analytic reference (node " +
+                               std::to_string( i ) + ")." );
+    totalMass += M[i * nDim];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalMass, 1.0, 1e-10 ),
+                           label + ": Hexa20 lumped mass does not conserve the total element mass." );
+}
+
+void testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues()
+{
+  checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::FullIntegration, "FullIntegration" );
+}
+
+void testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues()
+{
+  checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                   "ReducedIntegration" );
+}
+
 int main()
 {
-  auto tests = std::vector< std::function< void() > >{ testDefaultNamedPropertyInterface,
-                                                       testInstantiationAndBasicProperties,
-                                                       testStiffnessMatrixCalculationPlaneStress,
-                                                       testInitializeYourselfAndShapeFunctions };
+  auto tests = std::vector< std::function< void() > >{
+    testDefaultNamedPropertyInterface,
+    testInstantiationAndBasicProperties,
+    testStiffnessMatrixCalculationPlaneStress,
+    testInitializeYourselfAndShapeFunctions,
+    testLumpedInertiaQuad4RegularElementIsPositiveAndConservesMass,
+    testLumpedInertiaHexa8RegularElementIsPositiveAndConservesMass,
+    testLumpedInertiaQuad8FullIntegrationMatchesAnalyticValues,
+    testLumpedInertiaQuad8ReducedIntegrationMatchesAnalyticValues,
+    testLumpedInertiaQuad8DistortedElementFullIntegrationStaysNonSingular,
+    testLumpedInertiaQuad8DistortedElementReducedIntegrationStaysNonSingular,
+    testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues,
+    testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues,
+  };
 
   executeTestsAndCollectExceptions( tests );
 

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -365,6 +365,11 @@ namespace Marmot::Elements {
      * @brief Compute lumped (diagonal) mass matrix using material density.
      * @details Using the manifold based approach according to
      * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME
+     *
+     * Hexa20 is special-cased to a 1/3-2/3 split (high-order/linear) instead of the default
+     * 1/2-1/2: with 1/2-1/2, the negative corner contribution of the Hexa20 serendipity shape
+     * function exactly cancels the positive corner contribution of the trilinear shape function
+     * for any regular (affinely-mapped) element, producing an exactly zero corner mass.
      */
     void computeLumpedInertia( double* M );
 
@@ -914,6 +919,13 @@ namespace Marmot::Elements {
     Eigen::Map< RhsSized > LMM( M );
     LMM.setZero();
 
+    // Hexa20 special case: shift the split towards the linear shape function to avoid the exact
+    // corner-mass cancellation the default 1/2-1/2 split produces for this element (see the
+    // Doxygen comment on the declaration).
+    constexpr bool   isHexa20   = ( nDim == 3 && nNodes == 20 );
+    constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
+    constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
+
     // 2^nDim. std::pow is not constexpr in the standard (libstdc++ offers it as an
     // extension, libc++ does not), so compute it with a shift to stay portable.
     constexpr int nNodesLinear  = 1 << nDim;
@@ -922,8 +934,8 @@ namespace Marmot::Elements {
       const auto N_    = this->N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );
 
-      Eigen::VectorXd N_weighted = 0.5 * ( N_ );
-      N_weighted.head( nNodesLinear ) += 0.5 * N_lin;
+      Eigen::VectorXd N_weighted = wHighOrder * ( N_ );
+      N_weighted.head( nNodesLinear ) += wLinear * N_lin;
 
       const double    rho = qp.material->getDensity( qp.managedStateVars->materialStateVars.data() );
       Eigen::VectorXd m_  = N_weighted * qp.J0xW * rho;

--- a/modules/elements/DisplacementFiniteStrainULElement/test.cmake
+++ b/modules/elements/DisplacementFiniteStrainULElement/test.cmake
@@ -1,0 +1,5 @@
+# add current directory to the source for the tests
+SET(CURR_TEST_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test")
+
+# Tests for DisplacementFiniteStrainULElement
+add_marmot_test("TestDisplacementFiniteStrainULElement" "${CURR_TEST_SOURCE_DIR}/TestDisplacementFiniteStrainULElement.cpp")

--- a/modules/elements/DisplacementFiniteStrainULElement/test/TestDisplacementFiniteStrainULElement.cpp
+++ b/modules/elements/DisplacementFiniteStrainULElement/test/TestDisplacementFiniteStrainULElement.cpp
@@ -1,0 +1,276 @@
+#include "Marmot/DisplacementFiniteStrainULElement.h"
+#include "Marmot/MarmotElementProperty.h"
+#include "Marmot/MarmotFiniteElement.h"
+#include "Marmot/MarmotTesting.h"
+#include <string>
+
+using namespace Marmot;
+using namespace Marmot::Elements;
+using namespace Marmot::Testing;
+
+// ---------------------------------------------------------------------------------------------
+// Lumped (diagonal) mass matrix tests
+//
+// computeLumpedInertia() uses the manifold-based scheme of Yang et al. (2017), mixing the
+// high-order shape function N with the corresponding corner-node linear shape function N_lin
+// via N_weighted = w*N + (1-w)*N_lin (only the corner entries receive the N_lin correction),
+// with w = 1/2 by default and w = 1/3 special-cased for Hexa20: with the default split, the
+// negative corner contribution of the Hexa20 serendipity shape function exactly cancels the
+// positive corner contribution of the trilinear shape function for any regular element,
+// producing exactly zero corner mass (see TestDisplacementFiniteElement.cpp for the derivation).
+// The reference values below come from an independent SymPy computation; they are identical to
+// the DisplacementFiniteElement case because both classes share the same Quad8/Hexa20 shape
+// functions via MarmotGeometryElement<nDim,nNodes>.
+// ---------------------------------------------------------------------------------------------
+
+void testLumpedInertiaHexa8RegularElementIsPositiveAndConservesMass()
+{
+  constexpr int nDim    = 3;
+  constexpr int nNodes  = 8; // Hexa8 (linear)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteStrainULElement< nDim, nNodes >::SectionType::Solid;
+
+  // Unit cube; node ordering per MarmotFiniteElement3D.cpp Hexa8::N.
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+                                                0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+
+  auto element = std::make_unique< DisplacementFiniteStrainULElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 1.0, 1.0, density }; // K, G, density
+  MarmotMaterialSection       materialSection( "COMPRESSIBLENEOHOOKE", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Unit cube, uniform density: by symmetry each corner carries exactly volume*density/8.
+  for ( int i = 0; i < nNodes; i++ ) {
+    throwExceptionOnFailure( M[i * nDim] > 0.0, "Hexa8 lumped mass entry is not strictly positive." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], 0.125, 1e-12 ),
+                             "Hexa8 lumped mass entry does not match the analytic value." );
+  }
+}
+
+void checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes intType, const std::string& label )
+{
+  constexpr int nDim    = 2;
+  constexpr int nNodes  = 8; // Quad8 (quadratic serendipity)
+  const int     elId    = 1;
+  const auto    secType = DisplacementFiniteStrainULElement< nDim, nNodes >::SectionType::PlaneStrain;
+
+  // Unit square with midside nodes at exact edge midpoints (straight edges). Node ordering
+  // per MarmotFiniteElement2D.cpp Quad8::N: 0-3 corners CCW, 4-7 midsides.
+  const std::vector< double > nodeCoordsVec = { 0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0, // corners
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5 }; // midsides
+
+  auto element = std::make_unique< DisplacementFiniteStrainULElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 1.0, 1.0, density }; // K, G, density
+  MarmotMaterialSection       materialSection( "COMPRESSIBLENEOHOOKE", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 };             // thickness
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Reference values (see TestDisplacementFiniteElement.cpp for the SymPy derivation): corners
+  // = 1/12, midsides = 1/6. Because the geometry map is affine here, both full (3x3) and reduced
+  // (2x2) Gauss integrate this exactly, so both integration types reproduce the same values.
+  const double expectedCorner  = 1.0 / 12.0;
+  const double expectedMidside = 1.0 / 6.0;
+
+  double totalMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 4 ? expectedCorner : expectedMidside;
+    throwExceptionOnFailure( M[i * nDim] > 0.0,
+                             label + ": Quad8 lumped mass entry is not strictly positive (node " + std::to_string( i ) +
+                               ")." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], expected, 1e-10 ),
+                             label + ": Quad8 lumped mass entry does not match the analytic reference (node " +
+                               std::to_string( i ) + ")." );
+    totalMass += M[i * nDim];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalMass, 1.0, 1e-10 ),
+                           label + ": Quad8 lumped mass does not conserve the total element mass." );
+}
+
+void testLumpedInertiaQuad8FullIntegrationMatchesAnalyticValues()
+{
+  checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::FullIntegration, "FullIntegration" );
+}
+
+void testLumpedInertiaQuad8ReducedIntegrationMatchesAnalyticValues()
+{
+  checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                  "ReducedIntegration" );
+}
+
+void checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes intType, const std::string& label )
+{
+  constexpr int nDim    = 3;
+  constexpr int nNodes  = 20; // Hexa20 (quadratic serendipity)
+  const int     elId    = 1;
+  const auto    secType = DisplacementFiniteStrainULElement< nDim, nNodes >::SectionType::Solid;
+
+  // Unit cube with edge-midside nodes at exact midpoints (straight edges). Node ordering per
+  // MarmotFiniteElement3D.cpp Hexa20::N: 0-7 corners, 8-19 edge midsides.
+  const std::vector< double > nodeCoordsVec = { // corners
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                // bottom-face edge midsides (0-1, 1-2, 2-3, 3-0)
+                                                0.5,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                0.5,
+                                                0.0,
+                                                // top-face edge midsides (4-5, 5-6, 6-7, 7-4)
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.5,
+                                                1.0,
+                                                0.5,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                // vertical edge midsides (0-4, 1-5, 2-6, 3-7)
+                                                0.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                1.0,
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5 };
+
+  auto element = std::make_unique< DisplacementFiniteStrainULElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const double                density  = 1.0;
+  const std::vector< double > matProps = { 1.0, 1.0, density }; // K, G, density
+  MarmotMaterialSection       materialSection( "COMPRESSIBLENEOHOOKE", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Reference values (see TestDisplacementFiniteElement.cpp for the SymPy derivation of the
+  // Hexa20 1/3-2/3 special case): corners = 1/24, edges = 1/18.
+  const double expectedCorner = 1.0 / 24.0;
+  const double expectedEdge   = 1.0 / 18.0;
+
+  double totalMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 8 ? expectedCorner : expectedEdge;
+    throwExceptionOnFailure( M[i * nDim] > 0.0,
+                             label + ": Hexa20 lumped mass entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], expected, 1e-10 ),
+                             label + ": Hexa20 lumped mass entry does not match the analytic reference (node " +
+                               std::to_string( i ) + ")." );
+    totalMass += M[i * nDim];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalMass, 1.0, 1e-10 ),
+                           label + ": Hexa20 lumped mass does not conserve the total element mass." );
+}
+
+void testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues()
+{
+  checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::FullIntegration, "FullIntegration" );
+}
+
+void testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues()
+{
+  checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                   "ReducedIntegration" );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testLumpedInertiaHexa8RegularElementIsPositiveAndConservesMass,
+    testLumpedInertiaQuad8FullIntegrationMatchesAnalyticValues,
+    testLumpedInertiaQuad8ReducedIntegrationMatchesAnalyticValues,
+    testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues,
+    testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -370,6 +370,12 @@ namespace Marmot::Elements {
      * \f$\hat{N} = \tfrac{1}{2}N + \tfrac{1}{2}N_\mathrm{lin}\f$,
      * where \f$N\f$ is the high-order shape function and \f$N_\mathrm{lin}\f$ is the corresponding
      * linear (corner-node) shape function on the same element.
+     *
+     * Hexa20 is special-cased to \f$\hat{N} = \tfrac{1}{3}N + \tfrac{2}{3}N_\mathrm{lin}\f$: with
+     * the default 1/2-1/2 split, the negative corner contribution of the Hexa20 serendipity shape
+     * function exactly cancels the positive corner contribution of the trilinear shape function
+     * for any regular (affinely-mapped) element, producing an exactly zero corner mass. Shifting
+     * weight towards the linear shape function keeps the corner contribution strictly positive.
      */
     void computeLumpedInertia( double* M );
 
@@ -863,14 +869,21 @@ namespace Marmot::Elements {
     Map< RhsSized > LMM( M );
     LMM.setZero();
 
+    // Hexa20 special case: shift the split towards the linear shape function to avoid the exact
+    // corner-mass cancellation the default 1/2-1/2 split produces for this element (see the
+    // Doxygen comment on the declaration).
+    constexpr bool   isHexa20   = ( nDim == 3 && nNodes == 20 );
+    constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
+    constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
+
     constexpr int nNodesLinear  = ( 1 << nDim );
     auto          linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
     for ( const auto& qp : qps ) {
       const auto N_    = localGeometryElement.N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );
 
-      VectorXd N_weighted = 0.5 * ( N_ );
-      N_weighted.head( nNodesLinear ) += 0.5 * N_lin;
+      VectorXd N_weighted = wHighOrder * ( N_ );
+      N_weighted.head( nNodesLinear ) += wLinear * N_lin;
 
       // when nNodes == nNonlocalNodes
       VectorXd N_weighted_nonlocal;

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -876,8 +876,19 @@ namespace Marmot::Elements {
     constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
     constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
 
-    constexpr int nNodesLinear  = ( 1 << nDim );
-    auto          linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
+    constexpr int nNodesLinear = ( 1 << nDim );
+
+    // computeLumpedInertia() only knows how to weight the non-local block against either the
+    // displacement interpolation itself (equal-order, nNonLocalNodes == nNodes) or the linear
+    // corner-node interpolation (reduced-order, nNonLocalNodes == nNodesLinear); assigning N_lin
+    // to a differently-sized non-local weight vector below would silently misbehave for any other
+    // nNonLocalNodes.
+    static_assert( nNodes == nNonLocalNodes || nNonLocalNodes == nNodesLinear,
+                   "GeneralGradientEnhancedDisplacementFiniteElement::computeLumpedInertia requires the "
+                   "non-local field to use either the displacement interpolation order (nNonLocalNodes == "
+                   "nNodes) or linear corner-node interpolation (nNonLocalNodes == 2^nDim)." );
+
+    auto linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
     for ( const auto& qp : qps ) {
       const auto N_    = localGeometryElement.N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/test/TestGeneralGradientEnhancedDisplacementFiniteElement.cpp
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/test/TestGeneralGradientEnhancedDisplacementFiniteElement.cpp
@@ -1,6 +1,7 @@
 #include "Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h"
 #include "Marmot/MarmotFiniteElement.h"
 #include "Marmot/MarmotTesting.h"
+#include <string>
 
 using namespace Marmot;
 using namespace Marmot::Elements;
@@ -228,6 +229,269 @@ void testCoordinatesAtQuadraturePoints()
   }
 }
 
+// ---------------------------------------------------------------------------------------------
+// Lumped (diagonal) mass/capacity matrix tests
+//
+// computeLumpedInertia() uses the manifold-based scheme of Yang et al. (2017) for both the
+// displacement block (using density) and each non-local field block (using non-local
+// viscosity), mixing the high-order shape function N with the corresponding corner-node linear
+// shape function N_lin via N_weighted = w*N + (1-w)*N_lin (only the corner entries receive the
+// N_lin correction), with w = 1/2 by default and w = 1/3 special-cased for Hexa20: with the
+// default split, the negative corner contribution of the Hexa20 serendipity shape function
+// exactly cancels the positive corner contribution of the trilinear shape function for any
+// regular element, producing exactly zero corner mass (see TestDisplacementFiniteElement.cpp for
+// the derivation).
+//
+// Both tests below use equal-order interpolation (nNonLocalNodes == nNodes, the default), with
+// density == non-local viscosity == 1, so the non-local block reduces to the exact same
+// shape-function diagonal pattern as the displacement block, and the reference values (from an
+// independent SymPy computation) apply identically to both blocks.
+// ---------------------------------------------------------------------------------------------
+
+void checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes intType, const std::string& label )
+{
+  constexpr int nDim          = 2;
+  constexpr int nNodes        = 8; // Quad8 (quadratic serendipity)
+  constexpr int nNonlocalVars = 1;
+  const int     elId          = 1;
+  using ElemType              = GeneralGradientEnhancedDisplacementFiniteElement< nDim, nNodes, nNonlocalVars >;
+  const auto secType          = ElemType::SectionType::PlaneStrain;
+
+  // Unit square with midside nodes at exact edge midpoints (straight edges). Node ordering
+  // per MarmotFiniteElement2D.cpp Quad8::N: 0-3 corners CCW, 4-7 midsides.
+  const std::vector< double > nodeCoordsVec = { 0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0, // corners
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5 }; // midsides
+
+  auto element = std::make_unique< ElemType >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  // AT2PhaseField properties: E, nu, Gc, l, density, nonlocalViscosity
+  const std::vector< double > matProps = { 20000.0, 0.2, 1.0, 1.0, 1.0, 1.0 };
+  MarmotMaterialSection       materialSection( "AT2PHASEFIELD", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 }; // thickness
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Reference values (see TestDisplacementFiniteElement.cpp for the SymPy derivation): corners
+  // = 1/12, midsides = 1/6. Because the geometry map is affine here, both full (3x3) and reduced
+  // (2x2) Gauss integrate this exactly, so both integration types reproduce the same values.
+  const double expectedCorner  = 1.0 / 12.0;
+  const double expectedMidside = 1.0 / 6.0;
+
+  constexpr int sizeDoFU = nNodes * nDim;
+
+  double totalMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 4 ? expectedCorner : expectedMidside;
+    throwExceptionOnFailure( M[i * nDim] > 0.0,
+                             label + ": Quad8 displacement lumped mass entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], expected, 1e-10 ),
+                             label +
+                               ": Quad8 displacement lumped mass entry does not match the analytic reference "
+                               "(node " +
+                               std::to_string( i ) + ")." );
+    totalMass += M[i * nDim];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalMass, 1.0, 1e-10 ),
+                           label + ": Quad8 displacement block does not conserve the total element mass." );
+
+  double totalCapacity = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 4 ? expectedCorner : expectedMidside;
+    throwExceptionOnFailure( M[sizeDoFU + i] > 0.0,
+                             label + ": Quad8 non-local lumped capacity entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    throwExceptionOnFailure( checkIfEqual( M[sizeDoFU + i], expected, 1e-10 ),
+                             label +
+                               ": Quad8 non-local lumped capacity entry does not match the analytic "
+                               "reference (node " +
+                               std::to_string( i ) + ")." );
+    totalCapacity += M[sizeDoFU + i];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalCapacity, 1.0, 1e-10 ),
+                           label + ": Quad8 non-local block does not conserve the total element capacity." );
+}
+
+void testLumpedInertiaQuad8FullIntegrationMatchesAnalyticValues()
+{
+  checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::FullIntegration, "FullIntegration" );
+}
+
+void testLumpedInertiaQuad8ReducedIntegrationMatchesAnalyticValues()
+{
+  checkQuad8AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                  "ReducedIntegration" );
+}
+
+void checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes intType, const std::string& label )
+{
+  constexpr int nDim          = 3;
+  constexpr int nNodes        = 20; // Hexa20 (quadratic serendipity)
+  constexpr int nNonlocalVars = 1;
+  const int     elId          = 1;
+  using ElemType              = GeneralGradientEnhancedDisplacementFiniteElement< nDim, nNodes, nNonlocalVars >;
+  const auto secType          = ElemType::SectionType::Solid;
+
+  // Unit cube with edge-midside nodes at exact midpoints (straight edges). Node ordering per
+  // MarmotFiniteElement3D.cpp Hexa20::N: 0-7 corners, 8-19 edge midsides.
+  const std::vector< double > nodeCoordsVec = { // corners
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                // bottom-face edge midsides (0-1, 1-2, 2-3, 3-0)
+                                                0.5,
+                                                0.0,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.0,
+                                                0.5,
+                                                0.0,
+                                                // top-face edge midsides (4-5, 5-6, 6-7, 7-4)
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.5,
+                                                1.0,
+                                                0.5,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                // vertical edge midsides (0-4, 1-5, 2-6, 3-7)
+                                                0.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5,
+                                                1.0,
+                                                1.0,
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5 };
+
+  auto element = std::make_unique< ElemType >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  // AT2PhaseField properties: E, nu, Gc, l, density, nonlocalViscosity
+  const std::vector< double > matProps = { 20000.0, 0.2, 1.0, 1.0, 1.0, 1.0 };
+  MarmotMaterialSection       materialSection( "AT2PHASEFIELD", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  std::vector< double > M( element->getNDofPerElement(), 0.0 );
+  element->computeLumpedInertia( M.data() );
+
+  // Reference values (see TestDisplacementFiniteElement.cpp for the SymPy derivation of the
+  // Hexa20 1/3-2/3 special case): corners = 1/24, edges = 1/18.
+  const double expectedCorner = 1.0 / 24.0;
+  const double expectedEdge   = 1.0 / 18.0;
+
+  constexpr int sizeDoFU = nNodes * nDim;
+
+  double totalMass = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 8 ? expectedCorner : expectedEdge;
+    throwExceptionOnFailure( M[i * nDim] > 0.0,
+                             label + ": Hexa20 displacement lumped mass entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    throwExceptionOnFailure( checkIfEqual( M[i * nDim], expected, 1e-10 ),
+                             label +
+                               ": Hexa20 displacement lumped mass entry does not match the analytic "
+                               "reference (node " +
+                               std::to_string( i ) + ")." );
+    totalMass += M[i * nDim];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalMass, 1.0, 1e-10 ),
+                           label + ": Hexa20 displacement block does not conserve the total element mass." );
+
+  double totalCapacity = 0.0;
+  for ( int i = 0; i < nNodes; i++ ) {
+    const double expected = i < 8 ? expectedCorner : expectedEdge;
+    throwExceptionOnFailure( M[sizeDoFU + i] > 0.0,
+                             label + ": Hexa20 non-local lumped capacity entry is not strictly positive (node " +
+                               std::to_string( i ) + ")." );
+    throwExceptionOnFailure( checkIfEqual( M[sizeDoFU + i], expected, 1e-10 ),
+                             label +
+                               ": Hexa20 non-local lumped capacity entry does not match the analytic "
+                               "reference (node " +
+                               std::to_string( i ) + ")." );
+    totalCapacity += M[sizeDoFU + i];
+  }
+  throwExceptionOnFailure( checkIfEqual( totalCapacity, 1.0, 1e-10 ),
+                           label + ": Hexa20 non-local block does not conserve the total element capacity." );
+}
+
+void testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues()
+{
+  checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::FullIntegration, "FullIntegration" );
+}
+
+void testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues()
+{
+  checkHexa20AnalyticLumpedMasses( FiniteElement::Quadrature::IntegrationTypes::ReducedIntegration,
+                                   "ReducedIntegration" );
+}
+
 int main()
 {
   auto tests = std::vector< std::function< void() > >{
@@ -239,6 +503,10 @@ int main()
     testNodeFieldsOneNonlocalVar,
     testCoordinatesAtCenter,
     testCoordinatesAtQuadraturePoints,
+    testLumpedInertiaQuad8FullIntegrationMatchesAnalyticValues,
+    testLumpedInertiaQuad8ReducedIntegrationMatchesAnalyticValues,
+    testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues,
+    testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues,
   };
 
   executeTestsAndCollectExceptions( tests );


### PR DESCRIPTION
## Summary
- `computeLumpedInertia()` mixes the high-order shape function `N` with the corner-node linear shape function `N_lin` via a fixed 1/2-1/2 split. For any regular (affinely-mapped) Hexa20 element, that split makes the negative corner contribution of the serendipity shape function exactly cancel the positive corner contribution of the trilinear shape function, producing an **exactly zero** lumped mass at every corner node — fatal for explicit dynamics (`acceleration = F/m`).
- Special-case Hexa20 to a 1/3 (high-order) / 2/3 (linear) split instead, which keeps the corner contribution strictly positive while still conserving the total element mass. All other elements keep the original 1/2-1/2 split.
- Applied consistently to the three element classes that duplicate this scheme: `DisplacementFiniteElement`, `DisplacementFiniteStrainULElement`, `GeneralGradientEnhancedDisplacementFiniteElement`.
- Every numeric reference value in the new tests was cross-checked with an independent SymPy symbolic integration before being hardcoded (see comments in the test files).

## Test plan
- [x] New regression tests for `computeLumpedInertia`: linear-element sanity checks (Quad4/Hexa8), Quad8 exact analytic values (full & reduced integration), a distorted curved-edge Quad8 positivity/mass-conservation check, and Hexa20 exact analytic values for the new 1/3-2/3 split (full & reduced integration).
- [x] `DisplacementFiniteStrainULElement` had **no test coverage at all** before this change; added `test.cmake` + a new test executable exercising the same Hexa8/Quad8/Hexa20 cases.
- [x] Extended `GeneralGradientEnhancedDisplacementFiniteElement`'s existing test file with the same Quad8/Hexa20 checks, covering both the displacement mass block and the non-local capacity block.
- [x] Confirmed the tests reproduce the bug (fail with exactly-zero Hexa20 corner mass) against the pre-fix `computeLumpedInertia`, and pass after the fix.
- [x] Full `ctest` suite: 49/49 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)