### PR TITLE
fix(elements): derive the mass-lumping weight and use it for the critical time step

### DIFF
--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
@@ -1,0 +1,162 @@
+/* ---------------------------------------------------------------------
+ *                                       _
+ *  _ __ ___   __ _ _ __ _ __ ___   ___ | |_
+ * | '_ ` _ \ / _` | '__| '_ ` _ \ / _ \| __|
+ * | | | | | | (_| | |  | | | | | | (_) | |_
+ * |_| |_| |_|\__,_|_|  |_| |_| |_|\___/ \__|
+ *
+ * Unit of Strength of Materials and Structural Analysis
+ * University of Innsbruck,
+ * 2020 - today
+ *
+ * festigkeitslehre@uibk.ac.at
+ *
+ * Matthias Neuner matthias.neuner@uibk.ac.at
+ *
+ * This file is part of the MAteRialMOdellingToolbox (marmot).
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * The full text of the license can be found in the file LICENSE.md at
+ * the top level directory of marmot.
+ * ---------------------------------------------------------------------
+ */
+#pragma once
+#include "Marmot/MarmotTypedefs.h"
+#include <Eigen/Core>
+#include <cmath>
+
+namespace Marmot::FiniteElement::MassLumping {
+
+  /**
+   * @brief The blend weight of the manifold-based mass lumping scheme.
+   *
+   * @param rowSumsHighOrder Row sums of the consistent mass matrix built from the element's own
+   *        (high-order) shape functions, i.e. the integral of each \f$N_i\f$ over the element.
+   * @param rowSumsLinear Row sums built from the linear (corner-node) shape functions of the same
+   *        element, one entry per corner node.
+   * @return The blend weight \f$w\f$ to use in \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$.
+   *
+   * @details The scheme (manifold-based lumping, Yang et al. (2017), "A rigorous and unified mass
+   * lumping scheme for higher-order elements", CMAME) row-sums a blended shape function
+   * \f$\hat{N} = w N + (1-w) N_\mathrm{lin}\f$. Row-summing \f$N\f$ alone is not positive for a
+   * serendipity element -- its corner shape functions integrate to a negative value -- and blending
+   * in the linear shape functions is what restores positivity.
+   *
+   * The weight cannot be a constant, which is the subtlety this function exists for. A corner node's
+   * lumped mass is \f$w S^{N}_i + (1-w) S^{\mathrm{lin}}_i\f$, so with \f$S^{N}_i < 0 < S^{\mathrm{lin}}_i\f$
+   * positivity requires
+   * \f[ w < w_\mathrm{max} = \min_i \frac{S^{\mathrm{lin}}_i}{S^{\mathrm{lin}}_i - S^{N}_i}. \f]
+   * That limit is element-dependent, because the corner row sum is:
+   *
+   *  - quad8  (2D serendipity): \f$S^N = -\tfrac{1}{3}\f$ per corner (area 4)   -> \f$w_\mathrm{max} = 0.75\f$
+   *  - hexa20 (3D serendipity): \f$S^N = -1\f$ per corner (volume 8)            -> \f$w_\mathrm{max} = 0.50\f$
+   *
+   * A hard-coded \f$w = \tfrac{1}{2}\f$ therefore sits comfortably inside the admissible range in 2D
+   * and **exactly on its boundary** in 3D, where it produces corner masses of exactly zero -- a
+   * singular lumped mass matrix, and one that lands a few 1e-17 either side of zero in floating point
+   * rather than on it, so an "is any mass zero" check downstream passes and the inverse mass comes
+   * out around 1e17.
+   *
+   * Returned here is \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3} w_\mathrm{max})\f$. The \f$\tfrac{2}{3}\f$
+   * reproduces \f$w = \tfrac{1}{2}\f$ exactly for quad8 -- the case the constant was validated on, so
+   * nothing changes for any 2D serendipity element -- and gives \f$w = \tfrac{1}{3}\f$ for hexa20,
+   * a third of the way inside the admissible range rather than on its edge. The cap keeps
+   * \f$\tfrac{1}{2}\f$ as the value used wherever it is safe.
+   *
+   * An element with no negatively-integrating corner shape function (every linear element, since
+   * there \f$N_\mathrm{lin} \equiv N\f$ and the result does not depend on \f$w\f$ at all) is
+   * unconstrained and gets \f$\tfrac{1}{2}\f$.
+   */
+  inline double manifoldBlendWeight( const Eigen::VectorXd& rowSumsHighOrder, const Eigen::VectorXd& rowSumsLinear )
+  {
+    constexpr double documentedWeight = 0.5;
+    constexpr double fractionOfLimit  = 2.0 / 3.0;
+
+    double admissibleWeight = std::numeric_limits< double >::max();
+    for ( Eigen::Index i = 0; i < rowSumsLinear.size(); i++ ) {
+      if ( rowSumsHighOrder( i ) >= 0.0 )
+        continue;
+      const double limit = rowSumsLinear( i ) / ( rowSumsLinear( i ) - rowSumsHighOrder( i ) );
+      admissibleWeight   = std::min( admissibleWeight, limit );
+    }
+
+    if ( admissibleWeight == std::numeric_limits< double >::max() )
+      return documentedWeight;
+
+    return std::min( documentedWeight, fractionOfLimit * admissibleWeight );
+  }
+
+  /**
+   * @brief The per-node lumped mass fractions of the manifold-based scheme, summing to one.
+   *
+   * @param rowSumsHighOrder Row sums from the element's own shape functions.
+   * @param rowSumsLinear Row sums from the linear shape functions, one per corner node.
+   * @param weight The blend weight, from :cpp:func:`manifoldBlendWeight`.
+   * @return One fraction per node, summing to one.
+   *
+   * @details Density-free on purpose: positivity and the mass *distribution* are properties of the
+   * element geometry and its shape functions, so the same fractions serve the lumped mass (scaled by
+   * density) and the critical time step (which needs only the distribution). Sharing them is what
+   * keeps the two from drifting apart -- a time step derived from a different mass distribution than
+   * the one actually assembled is exactly the sort of inconsistency that shows up as an unexplained
+   * instability.
+   *
+   * Note the total is independent of the weight: the blend moves mass between the corner and the
+   * remaining nodes but conserves the element total. That is why an incorrect weight leaves the
+   * element mass, and hence the model mass, perfectly correct -- and is invisible to any check that
+   * looks at totals.
+   */
+  inline Eigen::VectorXd manifoldMassFractions( const Eigen::VectorXd& rowSumsHighOrder,
+                                                const Eigen::VectorXd& rowSumsLinear,
+                                                double                 weight )
+  {
+    Eigen::VectorXd fractions = weight * rowSumsHighOrder;
+    fractions.head( rowSumsLinear.size() ) += ( 1.0 - weight ) * rowSumsLinear;
+
+    const double total = fractions.sum();
+    if ( total > 0.0 )
+      fractions /= total;
+
+    return fractions;
+  }
+
+  /**
+   * @brief The factor by which a non-uniform lumped mass tightens the critical time step.
+   *
+   * @param massFractions Per-node lumped mass fractions, from :cpp:func:`manifoldMassFractions`.
+   * @return The factor to apply to a characteristic-length / wave-speed time step estimate.
+   *
+   * @details The usual estimate \f$\Delta t = l / c\f$ is the stable increment for an element whose
+   * mass is spread uniformly over its nodes, each carrying \f$1/n\f$ of it. Lumping does not spread
+   * it uniformly, and the lightest node sets the highest frequency: \f$\omega = \sqrt{k/m}\f$, so the
+   * stable increment scales with \f$\sqrt{m_\mathrm{min} / m_\mathrm{uniform}}\f$, which is what is
+   * returned.
+   *
+   * Exactly 1 for a linear element on a regular mesh, slightly below 1 for a distorted one (correct:
+   * a distorted element does have a tighter limit than its volume alone suggests), and 0.913 for a
+   * hexa20 under this scheme.
+   *
+   * @note This corrects only the mass-distribution part of the estimate. It does NOT correct for
+   * polynomial order, and that residue is large: a convergence study on a GC3D20R bar shows the
+   * answer settling only around a courant number of 0.1-0.2, i.e. roughly a further factor of five
+   * unaccounted for, because \f$l/c\f$ is a linear-element formula and a quadratic element's highest
+   * free eigenfrequency is well above what it predicts. Closing that properly wants an
+   * eigenvalue-based estimate rather than another factor.
+   */
+  inline double timeStepFactorFromMassDistribution( const Eigen::VectorXd& massFractions )
+  {
+    if ( massFractions.size() == 0 )
+      return 1.0;
+
+    const double smallest = massFractions.minCoeff();
+    if ( smallest <= 0.0 )
+      return 1.0;
+
+    return std::sqrt( static_cast< double >( massFractions.size() ) * smallest );
+  }
+
+} // namespace Marmot::FiniteElement::MassLumping

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
@@ -41,11 +41,17 @@ namespace Marmot::FiniteElement::MassLumping {
    *        element, one entry per corner node.
    * @return The blend weight \f$w\f$ to use in \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$.
    *
-   * @details The scheme (manifold-based lumping, Yang et al. (2017), "A rigorous and unified mass
-   * lumping scheme for higher-order elements", CMAME) row-sums a blended shape function
-   * \f$\hat{N} = w N + (1-w) N_\mathrm{lin}\f$. Row-summing \f$N\f$ alone is not positive for a
-   * serendipity element -- its corner shape functions integrate to a negative value -- and blending
-   * in the linear shape functions is what restores positivity.
+   * @details The scheme is manifold-based lumping:
+   *
+   *  - Yang, Y., Zheng, H. & Sivaselvan, M. V. (2017). "A rigorous and unified mass lumping scheme
+   *    for higher-order elements". CMAME 319, 491-514. https://doi.org/10.1016/j.cma.2017.03.011
+   *  - Duczek, S. & Gravenkamp, H. (2019). "Critical assessment of different mass lumping schemes
+   *    for higher order serendipity finite elements". CMAME 350, 836-897.
+   *    https://doi.org/10.1016/j.cma.2019.03.028
+   *
+   * It row-sums a blended shape function \f$\hat{N} = w N + (1-w) N_\mathrm{lin}\f$. Row-summing
+   * \f$N\f$ alone is not positive for a serendipity element -- its corner shape functions integrate
+   * to a negative value -- and blending in the linear shape functions is what restores positivity.
    *
    * The weight cannot be a constant, which is the subtlety this function exists for. A corner node's
    * lumped mass is \f$w S^{N}_i + (1-w) S^{\mathrm{lin}}_i\f$, so with \f$S^{N}_i < 0 < S^{\mathrm{lin}}_i\f$
@@ -63,11 +69,17 @@ namespace Marmot::FiniteElement::MassLumping {
    * out around 1e17.
    *
    * Returned here is \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3} w_\mathrm{max})\f$. The
-   * \f$\tfrac{2}{3}\f$ is a safety fraction chosen here, not a prescription of Yang et al.: it is
-   * the largest simple fraction that still yields \f$w = \tfrac{1}{2}\f$ for quad8 -- the case the
-   * constant was validated on, so nothing changes for any 2D serendipity element -- while giving
-   * \f$w = \tfrac{1}{3}\f$ for hexa20, a third of the way inside the admissible range rather than
-   * on its edge. The cap keeps \f$\tfrac{1}{2}\f$ as the value used wherever it is safe.
+   * \f$\tfrac{2}{3}\f$ is a safety fraction chosen here rather than taken from either reference,
+   * but it is not free-floating: it is the largest simple fraction that still yields
+   * \f$w = \tfrac{1}{2}\f$ for quad8, and the values it produces are the published ones on both
+   * element types where a published value exists --
+   *
+   *  - \f$w = \tfrac{1}{2}\f$ for quad8, the split of Yang et al. (2017),
+   *  - \f$w = \tfrac{1}{3}\f$ for hexa20, the split assessed by Duczek & Gravenkamp (2019),
+   *
+   * so the rule is not merely a way of staying off the positivity boundary; it reproduces the
+   * literature wherever the literature has an answer, and extrapolates in the same spirit where it
+   * does not. The cap keeps \f$\tfrac{1}{2}\f$ as the value used wherever it is safe.
    *
    * An element with no negatively-integrating corner shape function (every linear element, since
    * there \f$N_\mathrm{lin} \equiv N\f$ and the result does not depend on \f$w\f$ at all) is
@@ -125,6 +137,16 @@ namespace Marmot::FiniteElement::MassLumping {
    * remaining nodes but conserves the element total. That is why an incorrect weight leaves the
    * element mass, and hence the model mass, perfectly correct -- and is invisible to any check that
    * looks at totals.
+   *
+   * @note Integrating the blended shape function once, as done here and by the callers, is exactly
+   * equivalent to assembling the blended consistent mass matrix
+   * \f$M = \int \hat{N}^T \hat{N} \rho \,dV\f$ and row-summing that -- the form in which the scheme
+   * is usually written and implemented. Both \f$N\f$ and \f$N_\mathrm{lin}\f$ are partitions of
+   * unity and the blend is convex, so \f$\sum_j \hat{N}_j \equiv 1\f$ and
+   * \f[ \sum_j M_{ij} = \int \hat{N}_i \Big( \sum_j \hat{N}_j \Big) \rho \,dV
+   *                   = \int \hat{N}_i \rho \,dV. \f]
+   * The linear form is therefore not an approximation of the quadratic one; it is the same numbers
+   * at a fraction of the cost, and no consistent mass matrix has to be formed to get them.
    *
    * @note The normalisation is skipped, and the raw blended row sums returned, if their total is
    * not positive. That cannot happen for any element whose geometry is valid, since the total is

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
@@ -62,15 +62,30 @@ namespace Marmot::FiniteElement::MassLumping {
    * rather than on it, so an "is any mass zero" check downstream passes and the inverse mass comes
    * out around 1e17.
    *
-   * Returned here is \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3} w_\mathrm{max})\f$. The \f$\tfrac{2}{3}\f$
-   * reproduces \f$w = \tfrac{1}{2}\f$ exactly for quad8 -- the case the constant was validated on, so
-   * nothing changes for any 2D serendipity element -- and gives \f$w = \tfrac{1}{3}\f$ for hexa20,
-   * a third of the way inside the admissible range rather than on its edge. The cap keeps
-   * \f$\tfrac{1}{2}\f$ as the value used wherever it is safe.
+   * Returned here is \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3} w_\mathrm{max})\f$. The
+   * \f$\tfrac{2}{3}\f$ is a safety fraction chosen here, not a prescription of Yang et al.: it is
+   * the largest simple fraction that still yields \f$w = \tfrac{1}{2}\f$ for quad8 -- the case the
+   * constant was validated on, so nothing changes for any 2D serendipity element -- while giving
+   * \f$w = \tfrac{1}{3}\f$ for hexa20, a third of the way inside the admissible range rather than
+   * on its edge. The cap keeps \f$\tfrac{1}{2}\f$ as the value used wherever it is safe.
    *
    * An element with no negatively-integrating corner shape function (every linear element, since
    * there \f$N_\mathrm{lin} \equiv N\f$ and the result does not depend on \f$w\f$ at all) is
    * unconstrained and gets \f$\tfrac{1}{2}\f$.
+   *
+   * @note The reproduction of \f$\tfrac{1}{2}\f$ for quad8 is exact analytically, not necessarily
+   * bit-exact: the row sums are accumulated numerically over the element's own quadrature points,
+   * so \f$w_\mathrm{max}\f$ can land an ulp below \f$\tfrac{3}{4}\f$ (it does for a quad8 under
+   * 2x2 reduced integration) and the returned weight then sits an ulp below \f$\tfrac{1}{2}\f$
+   * rather than on it. The difference is far below any tolerance the lumped masses are checked
+   * against, but it is a rounding-level difference and not a bitwise identity.
+   *
+   * @note Positivity is enforced at the corner nodes only, which is all a blend weight can reach.
+   * A node with no linear counterpart carries \f$w S^{N}_i\f$, so if its own shape function
+   * integrates to a negative value -- not possible for any of the element types in use, but
+   * reachable in principle by a sufficiently distorted one -- its lumped mass is negative for
+   * every \f$w > 0\f$ and this function cannot help. A positive returned weight is therefore not
+   * a guarantee of a positive definite lumped mass matrix.
    */
   inline double manifoldBlendWeight( const Eigen::VectorXd& rowSumsHighOrder, const Eigen::VectorXd& rowSumsLinear )
   {
@@ -96,7 +111,7 @@ namespace Marmot::FiniteElement::MassLumping {
    *
    * @param rowSumsHighOrder Row sums from the element's own shape functions.
    * @param rowSumsLinear Row sums from the linear shape functions, one per corner node.
-   * @param weight The blend weight, from :cpp:func:`manifoldBlendWeight`.
+   * @param weight The blend weight, from manifoldBlendWeight().
    * @return One fraction per node, summing to one.
    *
    * @details Density-free on purpose: positivity and the mass *distribution* are properties of the
@@ -110,6 +125,11 @@ namespace Marmot::FiniteElement::MassLumping {
    * remaining nodes but conserves the element total. That is why an incorrect weight leaves the
    * element mass, and hence the model mass, perfectly correct -- and is invisible to any check that
    * looks at totals.
+   *
+   * @note The normalisation is skipped, and the raw blended row sums returned, if their total is
+   * not positive. That cannot happen for any element whose geometry is valid, since the total is
+   * the element volume; it is a guard against dividing by a degenerate element's zero volume, not
+   * a supported mode.
    */
   inline Eigen::VectorXd manifoldMassFractions( const Eigen::VectorXd& rowSumsHighOrder,
                                                 const Eigen::VectorXd& rowSumsLinear,
@@ -128,7 +148,7 @@ namespace Marmot::FiniteElement::MassLumping {
   /**
    * @brief The factor by which a non-uniform lumped mass tightens the critical time step.
    *
-   * @param massFractions Per-node lumped mass fractions, from :cpp:func:`manifoldMassFractions`.
+   * @param massFractions Per-node lumped mass fractions, from manifoldMassFractions().
    * @return The factor to apply to a characteristic-length / wave-speed time step estimate.
    *
    * @details The usual estimate \f$\Delta t = l / c\f$ is the stable increment for an element whose
@@ -147,6 +167,18 @@ namespace Marmot::FiniteElement::MassLumping {
    * unaccounted for, because \f$l/c\f$ is a linear-element formula and a quadratic element's highest
    * free eigenfrequency is well above what it predicts. Closing that properly wants an
    * eigenvalue-based estimate rather than another factor.
+   *
+   * @warning A non-positive smallest fraction returns 1.0, i.e. the uncorrected \f$l/c\f$
+   * estimate. That is deliberately a fallback and not a fix: a non-positive nodal mass means the
+   * lumping itself has failed, no time step derived from it is meaningful, and no blend weight can
+   * repair it (see the second @note on manifoldBlendWeight()). Scaling \f$l/c\f$ by
+   * \f$\sqrt{m_\mathrm{min}/m_\mathrm{uniform}}\f$ would return zero or NaN and mask the cause, so
+   * the estimate is left alone and the assembled mass is where the failure belongs.
+   *
+   * @warning Nothing currently reports it there either: the only check on the assembled lumped
+   * mass is on the solver side and tests for an exact zero, which a negative or near-zero nodal
+   * mass passes. So a lumping failure is at present silent in both places. Detecting it at
+   * assembly is the right fix and is deliberately out of scope here.
    */
   inline double timeStepFactorFromMassDistribution( const Eigen::VectorXd& massFractions )
   {

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h
@@ -25,9 +25,10 @@
  * ---------------------------------------------------------------------
  */
 #pragma once
-#include "Marmot/MarmotTypedefs.h"
 #include <Eigen/Core>
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace Marmot::FiniteElement::MassLumping {
 

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -322,7 +322,8 @@ namespace Marmot::Elements {
      * \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3}\,w_\mathrm{max})\f$: exactly \f$\tfrac{1}{2}\f$
      * wherever that is safe -- every 2D serendipity element, and every linear element, where the
      * result does not depend on \f$w\f$ at all -- and \f$\tfrac{1}{3}\f$ for a hexa20. It
-     * reproduces the values a per-element-type special case would give, without needing one, and
+     * reproduces -- analytically, and to rounding in floating point -- the values a
+     * per-element-type special case would give, without needing one, and
      * the critical time step reads its mass distribution from the same helper so the two cannot
      * disagree.
      *
@@ -478,6 +479,14 @@ namespace Marmot::Elements {
                                      << __PRETTY_FUNCTION__
                                      << ": invalid material assigned; cannot cast to MarmotMaterialHypoElastic!" );
 
+      /* Deliberately VOLUME based, and deliberately not the length
+       * computeCriticalTimeStepForExplicitDynamics uses. The material's characteristic length is a
+       * regularisation length -- it sets the width over which a softening law dissipates its
+       * fracture energy -- and the volume-equivalent length is the right measure for that. The
+       * stability estimate needs the opposite: the element's SMALLEST extent, because that is what
+       * bounds the highest frequency. The two definitions are not interchangeable; do not unify
+       * them.
+       */
       if constexpr ( nDim == 3 )
         qp.material->setCharacteristicElementLength( std::cbrt( 8 * qp.detJ ) );
       if constexpr ( nDim == 2 )

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -30,6 +30,7 @@
 #include "Marmot/MarmotGeometryElement.h"
 #include "Marmot/MarmotJournal.h"
 #include "Marmot/MarmotLowerDimensionalStress.h"
+#include "Marmot/MarmotMassLumping.h"
 #include "Marmot/MarmotMaterialHypoElastic.h"
 #include "Marmot/MarmotMaterialHypoElasticFactory.h"
 #include "Marmot/MarmotMath.h"
@@ -304,21 +305,51 @@ namespace Marmot::Elements {
      * @details Uses the manifold-based lumping scheme according to
      * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME.
      * The lumped mass entries are computed using a weighted shape function
-     * \f$\hat{N} = \tfrac{1}{2}N + \tfrac{1}{2}N_\mathrm{lin}\f$,
+     * \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$,
      * where \f$N\f$ is the high-order shape function and \f$N_\mathrm{lin}\f$ is the corresponding
      * linear (corner-node) shape function on the same element.
      *
-     * Hexa20 is special-cased to \f$\hat{N} = \tfrac{1}{3}N + \tfrac{2}{3}N_\mathrm{lin}\f$: with
-     * the default 1/2-1/2 split, the negative corner contribution of the Hexa20 serendipity shape
-     * function exactly cancels the positive corner contribution of the trilinear shape function
-     * for any regular (affinely-mapped) element, producing an exactly zero corner mass. Shifting
-     * weight towards the linear shape function keeps the corner contribution strictly positive.
+     * The blend weight \f$w\f$ cannot be a constant, which is the subtlety here. A corner node's
+     * lumped mass is \f$w S^{N}_i + (1-w) S^{\mathrm{lin}}_i\f$, and for a serendipity element
+     * \f$S^{N}_i < 0 < S^{\mathrm{lin}}_i\f$, so positivity requires
+     * \f[ w < w_\mathrm{max} = \min_i \frac{S^{\mathrm{lin}}_i}{S^{\mathrm{lin}}_i - S^{N}_i}. \f]
+     * That limit is element-dependent: \f$0.75\f$ for a quad8, but exactly \f$0.50\f$ for a
+     * hexa20, where a hard-coded \f$\tfrac{1}{2}\f$ therefore sits precisely on the boundary and
+     * yields an exactly zero corner mass for any regular (affinely-mapped) element.
+     *
+     * The weight is therefore derived per element by
+     * Marmot::FiniteElement::MassLumping::manifoldBlendWeight(), which returns
+     * \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3}\,w_\mathrm{max})\f$: exactly \f$\tfrac{1}{2}\f$
+     * wherever that is safe -- every 2D serendipity element, and every linear element, where the
+     * result does not depend on \f$w\f$ at all -- and \f$\tfrac{1}{3}\f$ for a hexa20. It
+     * reproduces the values a per-element-type special case would give, without needing one, and
+     * the critical time step reads its mass distribution from the same helper so the two cannot
+     * disagree.
+     *
+     * @note The element total is independent of \f$w\f$: the blend only moves mass between the
+     * corner and the remaining nodes. An incorrect weight therefore leaves the element mass, and
+     * hence the model mass, perfectly correct -- and is invisible to any check on totals.
      */
     void computeLumpedInertia( double* M );
 
     /**
      * @brief Compute the critical time step for explicit dynamics.
      * @param criticalTimeStep Output parameter for the computed critical time step.
+     * @details The estimate is \f$l / c\f$, scaled by the factor
+     * Marmot::FiniteElement::MassLumping::timeStepFactorFromMassDistribution() derives from the
+     * same lumped mass fractions computeLumpedInertia() assembles: \f$l/c\f$ is the stable
+     * increment for an element whose mass is spread uniformly over its nodes, which lumping does
+     * not do, and the lightest node sets the highest frequency. \f$l\f$ is twice the smallest
+     * singular value of the Jacobian, i.e. the element's smallest physical extent, so a sliver is
+     * not mistaken for its volume-equivalent cube. The minimum over all quadrature points is
+     * returned.
+     *
+     * @warning This corrects the mass-distribution and element-distortion parts of the estimate
+     * only. It does NOT correct for polynomial order, and that residue is large: \f$l/c\f$ is a
+     * linear-element formula, while a quadratic element's highest free eigenfrequency lies well
+     * above what it predicts. A convergence study on a 20-node bar settles only around a courant
+     * number of 0.1-0.2, i.e. roughly a further factor of five is unaccounted for. Closing that
+     * properly wants an eigenvalue-based estimate rather than another factor.
      */
     void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal );
 
@@ -846,21 +877,30 @@ namespace Marmot::Elements {
     Map< RhsSized > LMM( M );
     LMM.setZero();
 
-    // Hexa20 special case: shift the split towards the linear shape function to avoid the exact
-    // corner-mass cancellation the default 1/2-1/2 split produces for this element (see the
-    // Doxygen comment on the declaration).
-    constexpr bool   isHexa20   = ( nDim == 3 && nNodes == 20 );
-    constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
-    constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
+    /* Row sums of the consistent mass matrix, from this element's own shape functions and from the
+     * linear (corner-node) shape functions of the same element. Density-free: the blend weight and
+     * the mass distribution are properties of the element geometry alone, and deriving them in one
+     * place is what keeps this function and computeCriticalTimeStepForExplicitDynamics consistent
+     * with each other -- a time step derived from a different mass distribution than the one
+     * actually assembled is exactly the kind of inconsistency that surfaces as an unexplained
+     * instability rather than as a clean failure.
+     */
+    constexpr int   nNodesLinear     = ( 1 << nDim );
+    auto            linGeometryEl    = MarmotGeometryElement< nDim, nNodesLinear >();
+    Eigen::VectorXd rowSumsHighOrder = Eigen::VectorXd::Zero( nNodes );
+    Eigen::VectorXd rowSumsLinear    = Eigen::VectorXd::Zero( nNodesLinear );
+    for ( const auto& qp : qps ) {
+      rowSumsHighOrder += Eigen::VectorXd( this->N( qp.xi ) ) * qp.J0xW;
+      rowSumsLinear += Eigen::VectorXd( linGeometryEl.N( qp.xi ) ) * qp.J0xW;
+    }
+    const double weight = FiniteElement::MassLumping::manifoldBlendWeight( rowSumsHighOrder, rowSumsLinear );
 
-    constexpr int nNodesLinear  = ( 1 << nDim );
-    auto          linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
     for ( const auto& qp : qps ) {
       const auto N_    = this->N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );
 
-      VectorXd N_weighted = wHighOrder * ( N_ );
-      N_weighted.head( nNodesLinear ) += wLinear * N_lin;
+      VectorXd N_weighted = weight * ( N_ );
+      N_weighted.head( nNodesLinear ) += ( 1.0 - weight ) * N_lin;
 
       const double rho = qp.material->getDensity( qp.managedStateVars->materialStateVars.data() );
       VectorXd     m_  = N_weighted * qp.J0xW * rho;
@@ -875,6 +915,35 @@ namespace Marmot::Elements {
   void DisplacementFiniteElement< nDim, nNodes >::computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep,
                                                                                               const double* QTotal )
   {
+
+    /* The l / c estimate below assumes the element's mass is spread UNIFORMLY over its nodes, each
+     * carrying 1 / nNodes of it. The lumping scheme computeLumpedInertia applies does not do that:
+     * under the manifold-based blend a hexa20 corner node carries less than the uniform share, and
+     * the lightest node sets the highest frequency (omega = sqrt( k / m )), so the stable increment
+     * scales with sqrt( m_min / m_uniform ).
+     *
+     * Ignoring it puts the default courant number of 0.8 ABOVE the true limit for every 20-node
+     * element. That does not present as a marginally noisy run but as violent exponential
+     * divergence -- and only where the material provides no damping, so a 20-node run on a
+     * viscously regularised material can sit just above the limit and look perfectly healthy. That
+     * is worse than a clean failure, because it makes the fault look model-specific.
+     *
+     * The fractions come from the same helper computeLumpedInertia uses, so the two cannot drift
+     * apart. Exactly 1 for a linear element on a regular mesh, so nothing changes there, and
+     * slightly below 1 for a distorted element -- which is correct, a distorted element does have a
+     * tighter limit than its volume alone suggests.
+     */
+    constexpr int   nNodesLinear     = ( 1 << nDim );
+    auto            linGeometryEl    = MarmotGeometryElement< nDim, nNodesLinear >();
+    Eigen::VectorXd rowSumsHighOrder = Eigen::VectorXd::Zero( nNodes );
+    Eigen::VectorXd rowSumsLinear    = Eigen::VectorXd::Zero( nNodesLinear );
+    for ( const auto& qp : qps ) {
+      rowSumsHighOrder += Eigen::VectorXd( this->N( qp.xi ) ) * qp.J0xW;
+      rowSumsLinear += Eigen::VectorXd( linGeometryEl.N( qp.xi ) ) * qp.J0xW;
+    }
+    const double weight = FiniteElement::MassLumping::manifoldBlendWeight( rowSumsHighOrder, rowSumsLinear );
+    const double lumpedMassTimeStepFactor = FiniteElement::MassLumping::timeStepFactorFromMassDistribution(
+      FiniteElement::MassLumping::manifoldMassFractions( rowSumsHighOrder, rowSumsLinear, weight ) );
 
     criticalTimeStep = std::numeric_limits< double >::max();
     for ( const auto& qp : qps ) {
@@ -903,7 +972,7 @@ namespace Marmot::Elements {
       const double c = qp.material->getMaximumWaveSpeed( state );
       if ( c <= 0.0 )
         throw std::runtime_error( "Non-positive wave speed encountered in computeCriticalTimeStepForExplicitDynamics" );
-      const double dt = characteristicElementLength / c;
+      const double dt = lumpedMassTimeStepFactor * characteristicElementLength / c;
       if ( dt < criticalTimeStep )
         criticalTimeStep = dt;
     }

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -303,7 +303,10 @@ namespace Marmot::Elements {
     /**
      * @brief Compute the lumped (diagonal) mass matrix.
      * @details Uses the manifold-based lumping scheme according to
-     * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME.
+     * Yang, Zheng & Sivaselvan (2017) "A rigorous and unified mass lumping scheme for higher-order
+     * elements", CMAME 319, 491-514. The hexa20 weight the derivation below yields is the split
+     * assessed by Duczek & Gravenkamp (2019) "Critical assessment of different mass lumping schemes
+     * for higher order serendipity finite elements", CMAME 350, 836-897.
      * The lumped mass entries are computed using a weighted shape function
      * \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$,
      * where \f$N\f$ is the high-order shape function and \f$N_\mathrm{lin}\f$ is the corresponding

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -878,13 +878,22 @@ namespace Marmot::Elements {
 
     criticalTimeStep = std::numeric_limits< double >::max();
     for ( const auto& qp : qps ) {
-      double characteristicElementLength = 0.0;
-      if constexpr ( nDim == 3 )
-        characteristicElementLength = std::cbrt( 8 * qp.detJ );
-      if constexpr ( nDim == 2 )
-        characteristicElementLength = std::sqrt( 4 * qp.detJ );
-      if constexpr ( nDim == 1 )
-        characteristicElementLength = 2 * qp.detJ;
+      /* The characteristic length has to be the element's SMALLEST physical extent, not a
+       * volume-averaged one. cbrt( 8 * detJ ) and its lower-dimensional analogues are volume
+       * based: for a sliver -- thin in one direction but not the others -- the volume stays
+       * moderate while the thin dimension collapses, so they OVERESTIMATE the length and hence
+       * the stable time step. Refining a distorted parent element is precisely how slivers are
+       * produced, so an h-adaptive explicit run integrates its most distorted elements above
+       * their stability limit and diverges thousands of increments later.
+       *
+       * The Jacobian maps the natural cube [-1,1]^nDim onto the element, so twice its smallest
+       * singular value IS that smallest physical extent. For a well-shaped element this
+       * reproduces the previous expressions exactly -- a cube of side h gives h either way --
+       * so the estimate is tightened only where it was previously wrong.
+       */
+      const JacobianSized J_                          = this->Jacobian( this->dNdXi( qp.xi ) );
+      const double        characteristicElementLength = 2.0 *
+                                                 Eigen::JacobiSVD< JacobianSized >( J_ ).singularValues().minCoeff();
 
       MarmotMaterialHypoElastic::state3D state( qp.managedStateVars->stress,
                                                 qp.managedStateVars->elasticStrainEnergy / qp.J0xW,

--- a/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
+++ b/modules/elements/DisplacementFiniteElement/test/TestDisplacementFiniteElement.cpp
@@ -640,6 +640,195 @@ void testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues()
                                    "ReducedIntegration" );
 }
 
+// ---------------------------------------------------------------------------------------------
+// Critical time step tests
+//
+// computeCriticalTimeStepForExplicitDynamics() scales the plain l/c estimate by the same
+// mass-distribution factor the lumped-mass fractions above imply (see MarmotMassLumping.h):
+// with n nodes and smallest lumped-mass fraction f_min, factor = sqrt(n * f_min). That gives
+//
+//   Quad4 / Hexa8 (linear): all fractions equal 1/n     -> factor = sqrt(n * 1/n)  = 1
+//   Quad8:  corner = 1/12, midside = 1/6, n = 8         -> factor = sqrt(8/12)     = sqrt(2/3)
+//   Hexa20: corner = 1/24, edge = 1/18, n = 20          -> factor = sqrt(20/24)    = sqrt(5/6)
+//
+// using the same analytic corner/edge fractions the lumped-mass tests above already establish.
+// All four elements here share the same unit-size regular geometry and LINEARELASTIC material
+// (E = 10000, nu = 0.2, density = 1), so the l/c part of the estimate is identical for all of
+// them and the expected critical time step is just that common l/c times the factor above.
+// ---------------------------------------------------------------------------------------------
+
+double linearElasticLcEstimateForUnitRegularElement()
+{
+  // Reproduces the closed-form 3D stiffness diagonal getMaximumWaveSpeed() evaluates at zero
+  // strain: C11 = E(1-nu) / ((1+nu)(1-2nu)) dominates the shear terms for nu = 0.2.
+  constexpr double E       = 10000.0;
+  constexpr double nu      = 0.2;
+  constexpr double density = 1.0;
+  const double     C11     = E * ( 1.0 - nu ) / ( ( 1.0 + nu ) * ( 1.0 - 2.0 * nu ) );
+  const double     c       = std::sqrt( C11 / density );
+  constexpr double l       = 1.0; // unit-size regular element: 2 * smallest Jacobian singular value (0.5)
+  return l / c;
+}
+
+void testCriticalTimeStepQuad4RegularElementMatchesUnitMassDistributionFactor()
+{
+  constexpr int nDim    = 2;
+  constexpr int nNodes  = 4; // Quad4 (linear)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::PlaneStrain;
+
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 }; // unit square
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const std::vector< double > matProps = { 10000.0, 0.2, 1.0 };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 }; // thickness
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  const std::vector< double > QTotal( element->getNDofPerElement(), 0.0 );
+  double                      criticalTimeStep = 0.0;
+  element->computeCriticalTimeStepForExplicitDynamics( criticalTimeStep, QTotal.data() );
+
+  throwExceptionOnFailure( checkIfEqual( criticalTimeStep, linearElasticLcEstimateForUnitRegularElement(), 1e-8 ),
+                           "Quad4 critical time step does not match the unit mass-distribution factor." );
+}
+
+void testCriticalTimeStepHexa8RegularElementMatchesUnitMassDistributionFactor()
+{
+  constexpr int nDim    = 3;
+  constexpr int nNodes  = 8; // Hexa8 (linear)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::Solid;
+
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                                                0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0 }; // unit cube
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const std::vector< double > matProps = { 10000.0, 0.2, 1.0 };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  const std::vector< double > QTotal( element->getNDofPerElement(), 0.0 );
+  double                      criticalTimeStep = 0.0;
+  element->computeCriticalTimeStepForExplicitDynamics( criticalTimeStep, QTotal.data() );
+
+  throwExceptionOnFailure( checkIfEqual( criticalTimeStep, linearElasticLcEstimateForUnitRegularElement(), 1e-8 ),
+                           "Hexa8 critical time step does not match the unit mass-distribution factor." );
+}
+
+void testCriticalTimeStepQuad8RegularElementMatchesAnalyticMassDistributionFactor()
+{
+  constexpr int nDim    = 2;
+  constexpr int nNodes  = 8; // Quad8 (quadratic serendipity)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::PlaneStrain;
+
+  // Unit square with midside nodes at exact edge midpoints (straight edges); same geometry as
+  // checkQuad8AnalyticLumpedMasses().
+  const std::vector< double > nodeCoordsVec = { 0.0,
+                                                0.0,
+                                                1.0,
+                                                0.0,
+                                                1.0,
+                                                1.0,
+                                                0.0,
+                                                1.0, // corners
+                                                0.5,
+                                                0.0,
+                                                1.0,
+                                                0.5,
+                                                0.5,
+                                                1.0,
+                                                0.0,
+                                                0.5 }; // midsides
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const std::vector< double > matProps = { 10000.0, 0.2, 1.0 };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+  const std::vector< double > elPropsVec = { 1.0 }; // thickness
+  ElementProperties           elProps( elPropsVec.data(), elPropsVec.size() );
+
+  element->assignProperty( elProps );
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  const std::vector< double > QTotal( element->getNDofPerElement(), 0.0 );
+  double                      criticalTimeStep = 0.0;
+  element->computeCriticalTimeStepForExplicitDynamics( criticalTimeStep, QTotal.data() );
+
+  const double expected = linearElasticLcEstimateForUnitRegularElement() * std::sqrt( 2.0 / 3.0 );
+  throwExceptionOnFailure( checkIfEqual( criticalTimeStep, expected, 1e-8 ),
+                           "Quad8 critical time step does not match the analytic mass-distribution factor." );
+}
+
+void testCriticalTimeStepHexa20RegularElementMatchesAnalyticMassDistributionFactor()
+{
+  constexpr int nDim    = 3;
+  constexpr int nNodes  = 20; // Hexa20 (quadratic serendipity)
+  const int     elId    = 1;
+  const auto    intType = FiniteElement::Quadrature::IntegrationTypes::FullIntegration;
+  const auto    secType = DisplacementFiniteElement< nDim, nNodes >::SectionType::Solid;
+
+  // Unit cube with edge-midside nodes at exact midpoints (straight edges); same geometry as
+  // checkHexa20AnalyticLumpedMasses(). Node ordering per MarmotFiniteElement3D.cpp Hexa20::N:
+  // 0-7 corners, 8-19 edge midsides.
+  const std::vector< double > nodeCoordsVec = {
+    0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, // bottom corners
+    0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, // top corners
+    0.5, 0.0, 0.0, 1.0, 0.5, 0.0, 0.5, 1.0, 0.0, 0.0, 0.5, 0.0, // bottom-face edge midsides
+    0.5, 0.0, 1.0, 1.0, 0.5, 1.0, 0.5, 1.0, 1.0, 0.0, 0.5, 1.0, // top-face edge midsides
+    0.0, 0.0, 0.5, 1.0, 0.0, 0.5, 1.0, 1.0, 0.5, 0.0, 1.0, 0.5  // vertical edge midsides
+  };
+
+  auto element = std::make_unique< DisplacementFiniteElement< nDim, nNodes > >( elId, intType, secType );
+  element->assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const std::vector< double > matProps = { 10000.0, 0.2, 1.0 };
+  MarmotMaterialSection       materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+
+  element->assignProperty( materialSection );
+
+  const int             nStateVarsTotal = element->getNumberOfRequiredStateVars();
+  std::vector< double > stateVars( nStateVarsTotal, 0.0 );
+  element->assignStateVars( stateVars.data(), nStateVarsTotal );
+  element->initializeYourself();
+
+  const std::vector< double > QTotal( element->getNDofPerElement(), 0.0 );
+  double                      criticalTimeStep = 0.0;
+  element->computeCriticalTimeStepForExplicitDynamics( criticalTimeStep, QTotal.data() );
+
+  const double expected = linearElasticLcEstimateForUnitRegularElement() * std::sqrt( 5.0 / 6.0 );
+  throwExceptionOnFailure( checkIfEqual( criticalTimeStep, expected, 1e-8 ),
+                           "Hexa20 critical time step does not match the analytic mass-distribution factor." );
+}
+
 int main()
 {
   auto tests = std::vector< std::function< void() > >{
@@ -655,6 +844,10 @@ int main()
     testLumpedInertiaQuad8DistortedElementReducedIntegrationStaysNonSingular,
     testLumpedInertiaHexa20FullIntegrationMatchesAnalyticValues,
     testLumpedInertiaHexa20ReducedIntegrationMatchesAnalyticValues,
+    testCriticalTimeStepQuad4RegularElementMatchesUnitMassDistributionFactor,
+    testCriticalTimeStepHexa8RegularElementMatchesUnitMassDistributionFactor,
+    testCriticalTimeStepQuad8RegularElementMatchesAnalyticMassDistributionFactor,
+    testCriticalTimeStepHexa20RegularElementMatchesAnalyticMassDistributionFactor,
   };
 
   executeTestsAndCollectExceptions( tests );

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -383,7 +383,8 @@ namespace Marmot::Elements {
      * \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3}\,w_\mathrm{max})\f$: exactly \f$\tfrac{1}{2}\f$
      * wherever that is safe -- every 2D serendipity element, and every linear element, where the
      * result does not depend on \f$w\f$ at all -- and \f$\tfrac{1}{3}\f$ for a hexa20. It
-     * reproduces the values a per-element-type special case would give, without needing one, and
+     * reproduces -- analytically, and to rounding in floating point -- the values a
+     * per-element-type special case would give, without needing one, and
      * the critical time step reads its mass distribution from the same helper so the two cannot
      * disagree.
      *

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -365,7 +365,10 @@ namespace Marmot::Elements {
     /**
      * @brief Compute lumped (diagonal) mass matrix using material density.
      * @details Using the manifold based approach according to
-     * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME.
+     * Yang, Zheng & Sivaselvan (2017) "A rigorous and unified mass lumping scheme for higher-order
+     * elements", CMAME 319, 491-514. The hexa20 weight the derivation below yields is the split
+     * assessed by Duczek & Gravenkamp (2019) "Critical assessment of different mass lumping schemes
+     * for higher order serendipity finite elements", CMAME 350, 836-897.
      * The lumped mass entries use a blended shape function
      * \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$, where \f$N_\mathrm{lin}\f$ is the
      * corresponding linear (corner-node) shape function on the same element.

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -33,6 +33,7 @@
 #include "Marmot/MarmotGeometryElement.h"
 #include "Marmot/MarmotGeostaticStress.h"
 #include "Marmot/MarmotJournal.h"
+#include "Marmot/MarmotMassLumping.h"
 #include "Marmot/MarmotMaterialFiniteStrain.h"
 #include "Marmot/MarmotMaterialFiniteStrainFactory.h"
 #include "Marmot/MarmotStateVarVectorManager.h"
@@ -364,18 +365,52 @@ namespace Marmot::Elements {
     /**
      * @brief Compute lumped (diagonal) mass matrix using material density.
      * @details Using the manifold based approach according to
-     * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME
+     * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME.
+     * The lumped mass entries use a blended shape function
+     * \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$, where \f$N_\mathrm{lin}\f$ is the
+     * corresponding linear (corner-node) shape function on the same element.
      *
-     * Hexa20 is special-cased to a 1/3-2/3 split (high-order/linear) instead of the default
-     * 1/2-1/2: with 1/2-1/2, the negative corner contribution of the Hexa20 serendipity shape
-     * function exactly cancels the positive corner contribution of the trilinear shape function
-     * for any regular (affinely-mapped) element, producing an exactly zero corner mass.
+     * The blend weight \f$w\f$ cannot be a constant, which is the subtlety here. A corner node's
+     * lumped mass is \f$w S^{N}_i + (1-w) S^{\mathrm{lin}}_i\f$, and for a serendipity element
+     * \f$S^{N}_i < 0 < S^{\mathrm{lin}}_i\f$, so positivity requires
+     * \f[ w < w_\mathrm{max} = \min_i \frac{S^{\mathrm{lin}}_i}{S^{\mathrm{lin}}_i - S^{N}_i}. \f]
+     * That limit is element-dependent: \f$0.75\f$ for a quad8, but exactly \f$0.50\f$ for a
+     * hexa20, where a hard-coded \f$\tfrac{1}{2}\f$ therefore sits precisely on the boundary and
+     * yields an exactly zero corner mass for any regular (affinely-mapped) element.
+     *
+     * The weight is therefore derived per element by
+     * Marmot::FiniteElement::MassLumping::manifoldBlendWeight(), which returns
+     * \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3}\,w_\mathrm{max})\f$: exactly \f$\tfrac{1}{2}\f$
+     * wherever that is safe -- every 2D serendipity element, and every linear element, where the
+     * result does not depend on \f$w\f$ at all -- and \f$\tfrac{1}{3}\f$ for a hexa20. It
+     * reproduces the values a per-element-type special case would give, without needing one, and
+     * the critical time step reads its mass distribution from the same helper so the two cannot
+     * disagree.
+     *
+     * @note The element total is independent of \f$w\f$: the blend only moves mass between the
+     * corner and the remaining nodes. An incorrect weight therefore leaves the element mass, and
+     * hence the model mass, perfectly correct -- and is invisible to any check on totals.
      */
     void computeLumpedInertia( double* M );
 
     /**
      * @brief Compute the critical time step for explicit dynamics.
      * @param criticalTimeStep Output parameter for the computed critical time step.
+     * @details The estimate is \f$l / c\f$, scaled by the factor
+     * Marmot::FiniteElement::MassLumping::timeStepFactorFromMassDistribution() derives from the
+     * same lumped mass fractions computeLumpedInertia() assembles: \f$l/c\f$ is the stable
+     * increment for an element whose mass is spread uniformly over its nodes, which lumping does
+     * not do, and the lightest node sets the highest frequency. \f$l\f$ is twice the smallest
+     * singular value of the Jacobian, i.e. the element's smallest physical extent, so a sliver is
+     * not mistaken for its volume-equivalent cube. The minimum over all quadrature points is
+     * returned.
+     *
+     * @warning This corrects the mass-distribution and element-distortion parts of the estimate
+     * only. It does NOT correct for polynomial order, and that residue is large: \f$l/c\f$ is a
+     * linear-element formula, while a quadratic element's highest free eigenfrequency lies well
+     * above what it predicts. A convergence study on a 20-node bar settles only around a courant
+     * number of 0.1-0.2, i.e. roughly a further factor of five is unaccounted for. Closing that
+     * properly wants an eigenvalue-based estimate rather than another factor.
      */
     void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal );
 
@@ -919,23 +954,32 @@ namespace Marmot::Elements {
     Eigen::Map< RhsSized > LMM( M );
     LMM.setZero();
 
-    // Hexa20 special case: shift the split towards the linear shape function to avoid the exact
-    // corner-mass cancellation the default 1/2-1/2 split produces for this element (see the
-    // Doxygen comment on the declaration).
-    constexpr bool   isHexa20   = ( nDim == 3 && nNodes == 20 );
-    constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
-    constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
-
+    /* Row sums of the consistent mass matrix, from this element's own shape functions and from the
+     * linear (corner-node) shape functions of the same element. Density-free: the blend weight and
+     * the mass distribution are properties of the element geometry alone, and deriving them in one
+     * place is what keeps this function and computeCriticalTimeStepForExplicitDynamics consistent
+     * with each other -- a time step derived from a different mass distribution than the one
+     * actually assembled is exactly the kind of inconsistency that surfaces as an unexplained
+     * instability rather than as a clean failure.
+     */
     // 2^nDim. std::pow is not constexpr in the standard (libstdc++ offers it as an
     // extension, libc++ does not), so compute it with a shift to stay portable.
-    constexpr int nNodesLinear  = 1 << nDim;
-    auto          linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
+    constexpr int   nNodesLinear     = ( 1 << nDim );
+    auto            linGeometryEl    = MarmotGeometryElement< nDim, nNodesLinear >();
+    Eigen::VectorXd rowSumsHighOrder = Eigen::VectorXd::Zero( nNodes );
+    Eigen::VectorXd rowSumsLinear    = Eigen::VectorXd::Zero( nNodesLinear );
+    for ( const auto& qp : qps ) {
+      rowSumsHighOrder += Eigen::VectorXd( this->N( qp.xi ) ) * qp.J0xW;
+      rowSumsLinear += Eigen::VectorXd( linGeometryEl.N( qp.xi ) ) * qp.J0xW;
+    }
+    const double weight = FiniteElement::MassLumping::manifoldBlendWeight( rowSumsHighOrder, rowSumsLinear );
+
     for ( const auto& qp : qps ) {
       const auto N_    = this->N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );
 
-      Eigen::VectorXd N_weighted = wHighOrder * ( N_ );
-      N_weighted.head( nNodesLinear ) += wLinear * N_lin;
+      Eigen::VectorXd N_weighted = weight * ( N_ );
+      N_weighted.head( nNodesLinear ) += ( 1.0 - weight ) * N_lin;
 
       const double    rho = qp.material->getDensity( qp.managedStateVars->materialStateVars.data() );
       Eigen::VectorXd m_  = N_weighted * qp.J0xW * rho;
@@ -957,6 +1001,35 @@ namespace Marmot::Elements {
 
     const static auto I = Tensor< double, nDim, nDim >(
       ( Eigen::Matrix< double, nDim, nDim >() << Eigen::Matrix< double, nDim, nDim >::Identity() ).finished().data() );
+
+    /* The l / c estimate below assumes the element's mass is spread UNIFORMLY over its nodes, each
+     * carrying 1 / nNodes of it. The lumping scheme computeLumpedInertia applies does not do that:
+     * under the manifold-based blend a hexa20 corner node carries less than the uniform share, and
+     * the lightest node sets the highest frequency (omega = sqrt( k / m )), so the stable increment
+     * scales with sqrt( m_min / m_uniform ).
+     *
+     * Ignoring it puts the default courant number of 0.8 ABOVE the true limit for every 20-node
+     * element. That does not present as a marginally noisy run but as violent exponential
+     * divergence -- and only where the material provides no damping, so a 20-node run on a
+     * viscously regularised material can sit just above the limit and look perfectly healthy. That
+     * is worse than a clean failure, because it makes the fault look model-specific.
+     *
+     * The fractions come from the same helper computeLumpedInertia uses, so the two cannot drift
+     * apart. Exactly 1 for a linear element on a regular mesh, so nothing changes there, and
+     * slightly below 1 for a distorted element -- which is correct, a distorted element does have a
+     * tighter limit than its volume alone suggests.
+     */
+    constexpr int   nNodesLinear     = ( 1 << nDim );
+    auto            linGeometryEl    = MarmotGeometryElement< nDim, nNodesLinear >();
+    Eigen::VectorXd rowSumsHighOrder = Eigen::VectorXd::Zero( nNodes );
+    Eigen::VectorXd rowSumsLinear    = Eigen::VectorXd::Zero( nNodesLinear );
+    for ( const auto& qp : qps ) {
+      rowSumsHighOrder += Eigen::VectorXd( this->N( qp.xi ) ) * qp.J0xW;
+      rowSumsLinear += Eigen::VectorXd( linGeometryEl.N( qp.xi ) ) * qp.J0xW;
+    }
+    const double weight = FiniteElement::MassLumping::manifoldBlendWeight( rowSumsHighOrder, rowSumsLinear );
+    const double lumpedMassTimeStepFactor = FiniteElement::MassLumping::timeStepFactorFromMassDistribution(
+      FiniteElement::MassLumping::manifoldMassFractions( rowSumsHighOrder, rowSumsLinear, weight ) );
 
     criticalTimeStep = std::numeric_limits< double >::max();
     for ( const auto& qp : qps ) {
@@ -994,7 +1067,7 @@ namespace Marmot::Elements {
       if ( c <= 0.0 ) {
         throw std::runtime_error( "Non-positive wave speed encountered in computeCriticalTimeStepForExplicitDynamics" );
       }
-      const double dt = characteristicElementLength / c;
+      const double dt = lumpedMassTimeStepFactor * characteristicElementLength / c;
       if ( dt < criticalTimeStep )
         criticalTimeStep = dt;
     }

--- a/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
+++ b/modules/elements/DisplacementFiniteStrainULElement/include/Marmot/DisplacementFiniteStrainULElement.h
@@ -960,13 +960,22 @@ namespace Marmot::Elements {
 
     criticalTimeStep = std::numeric_limits< double >::max();
     for ( const auto& qp : qps ) {
-      double characteristicElementLength = 0.0;
-      if constexpr ( nDim == 3 )
-        characteristicElementLength = std::cbrt( 8 * qp.detJ );
-      if constexpr ( nDim == 2 )
-        characteristicElementLength = std::sqrt( 4 * qp.detJ );
-      if constexpr ( nDim == 1 )
-        characteristicElementLength = 2 * qp.detJ;
+      /* The characteristic length has to be the element's SMALLEST physical extent, not a
+       * volume-averaged one. cbrt( 8 * detJ ) and its lower-dimensional analogues are volume
+       * based: for a sliver -- thin in one direction but not the others -- the volume stays
+       * moderate while the thin dimension collapses, so they OVERESTIMATE the length and hence
+       * the stable time step. Refining a distorted parent element is precisely how slivers are
+       * produced, so an h-adaptive explicit run integrates its most distorted elements above
+       * their stability limit and diverges thousands of increments later.
+       *
+       * The Jacobian maps the natural cube [-1,1]^nDim onto the element, so twice its smallest
+       * singular value IS that smallest physical extent. For a well-shaped element this
+       * reproduces the previous expressions exactly -- a cube of side h gives h either way --
+       * so the estimate is tightened only where it was previously wrong.
+       */
+      const JacobianSized J_                          = this->Jacobian( this->dNdXi( qp.xi ) );
+      const double        characteristicElementLength = 2.0 *
+                                                 Eigen::JacobiSVD< JacobianSized >( J_ ).singularValues().minCoeff();
 
       using namespace Marmot::FastorIndices;
       const auto                         dNdX = Tensor< double, nDim, nNodes >( qp.dNdX.data(), ColumnMajor );

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -932,13 +932,23 @@ namespace Marmot::Elements {
     // TODO: current implementation ignores nonlocal variables
     criticalTimeStep = std::numeric_limits< double >::max();
     for ( const auto& qp : qps ) {
-      double characteristicElementLength = 0.0;
-      if constexpr ( nDim == 3 )
-        characteristicElementLength = std::cbrt( 8 * qp.detJ );
-      if constexpr ( nDim == 2 )
-        characteristicElementLength = std::sqrt( 4 * qp.detJ );
-      if constexpr ( nDim == 1 )
-        characteristicElementLength = ( 2 * qp.detJ );
+      /* The characteristic length has to be the element's SMALLEST physical extent, not a
+       * volume-averaged one. cbrt( 8 * detJ ) and its lower-dimensional analogues are volume
+       * based: for a sliver -- thin in one direction but not the others -- the volume stays
+       * moderate while the thin dimension collapses, so they OVERESTIMATE the length and hence
+       * the stable time step. Refining a distorted parent element is precisely how slivers are
+       * produced, so an h-adaptive explicit run integrates its most distorted elements above
+       * their stability limit and diverges thousands of increments later, with nothing in the
+       * log connecting the divergence to the refinement that caused it.
+       *
+       * The Jacobian maps the natural cube [-1,1]^nDim onto the element, so twice its smallest
+       * singular value IS that smallest physical extent. For a well-shaped element this
+       * reproduces the previous expressions exactly -- a cube of side h gives h either way --
+       * so the estimate is tightened only where it was previously wrong.
+       */
+      const JacobianSized J_ = localGeometryElement.Jacobian( localGeometryElement.dNdXi( qp.xi ) );
+      const double        characteristicElementLength = 2.0 *
+                                                 Eigen::JacobiSVD< JacobianSized >( J_ ).singularValues().minCoeff();
       response waveSpeedResponse;
       waveSpeedResponse.stress = qp.managedStateVars->stress;
       waveSpeedResponse.KLocal.setZero();

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -366,7 +366,10 @@ namespace Marmot::Elements {
     /**
      * @brief Compute the lumped (diagonal) mass matrix.
      * @details Uses the manifold-based lumping scheme according to
-     * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME.
+     * Yang, Zheng & Sivaselvan (2017) "A rigorous and unified mass lumping scheme for higher-order
+     * elements", CMAME 319, 491-514. The hexa20 weight the derivation below yields is the split
+     * assessed by Duczek & Gravenkamp (2019) "Critical assessment of different mass lumping schemes
+     * for higher order serendipity finite elements", CMAME 350, 836-897.
      * The lumped mass entries are computed using a weighted shape function
      * \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$,
      * where \f$N\f$ is the high-order shape function and \f$N_\mathrm{lin}\f$ is the corresponding

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -385,7 +385,8 @@ namespace Marmot::Elements {
      * \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3}\,w_\mathrm{max})\f$: exactly \f$\tfrac{1}{2}\f$
      * wherever that is safe -- every 2D serendipity element, and every linear element, where the
      * result does not depend on \f$w\f$ at all -- and \f$\tfrac{1}{3}\f$ for a hexa20. It
-     * reproduces the values a per-element-type special case would give, without needing one, and
+     * reproduces -- analytically, and to rounding in floating point -- the values a
+     * per-element-type special case would give, without needing one, and
      * the critical time step reads its mass distribution from the same helper so the two cannot
      * disagree.
      *

--- a/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
+++ b/modules/elements/GeneralGradientEnhancedDisplacementFiniteElement/include/Marmot/GeneralGradientEnhancedDisplacementFiniteElement.h
@@ -30,6 +30,7 @@
 #include "Marmot/MarmotGeometryElement.h"
 #include "Marmot/MarmotJournal.h"
 #include "Marmot/MarmotLowerDimensionalStress.h"
+#include "Marmot/MarmotMassLumping.h"
 #include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h"
 #include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h"
 #include "Marmot/MarmotMath.h"
@@ -367,15 +368,30 @@ namespace Marmot::Elements {
      * @details Uses the manifold-based lumping scheme according to
      * Yang et al. (2017) "A rigorous and unified mass lumping scheme for higher-order elements", CMAME.
      * The lumped mass entries are computed using a weighted shape function
-     * \f$\hat{N} = \tfrac{1}{2}N + \tfrac{1}{2}N_\mathrm{lin}\f$,
+     * \f$\hat{N} = w\,N + (1-w)\,N_\mathrm{lin}\f$,
      * where \f$N\f$ is the high-order shape function and \f$N_\mathrm{lin}\f$ is the corresponding
      * linear (corner-node) shape function on the same element.
      *
-     * Hexa20 is special-cased to \f$\hat{N} = \tfrac{1}{3}N + \tfrac{2}{3}N_\mathrm{lin}\f$: with
-     * the default 1/2-1/2 split, the negative corner contribution of the Hexa20 serendipity shape
-     * function exactly cancels the positive corner contribution of the trilinear shape function
-     * for any regular (affinely-mapped) element, producing an exactly zero corner mass. Shifting
-     * weight towards the linear shape function keeps the corner contribution strictly positive.
+     * The blend weight \f$w\f$ cannot be a constant, which is the subtlety here. A corner node's
+     * lumped mass is \f$w S^{N}_i + (1-w) S^{\mathrm{lin}}_i\f$, and for a serendipity element
+     * \f$S^{N}_i < 0 < S^{\mathrm{lin}}_i\f$, so positivity requires
+     * \f[ w < w_\mathrm{max} = \min_i \frac{S^{\mathrm{lin}}_i}{S^{\mathrm{lin}}_i - S^{N}_i}. \f]
+     * That limit is element-dependent: \f$0.75\f$ for a quad8, but exactly \f$0.50\f$ for a
+     * hexa20, where a hard-coded \f$\tfrac{1}{2}\f$ therefore sits precisely on the boundary and
+     * yields an exactly zero corner mass for any regular (affinely-mapped) element.
+     *
+     * The weight is therefore derived per element by
+     * Marmot::FiniteElement::MassLumping::manifoldBlendWeight(), which returns
+     * \f$w = \min(\tfrac{1}{2}, \tfrac{2}{3}\,w_\mathrm{max})\f$: exactly \f$\tfrac{1}{2}\f$
+     * wherever that is safe -- every 2D serendipity element, and every linear element, where the
+     * result does not depend on \f$w\f$ at all -- and \f$\tfrac{1}{3}\f$ for a hexa20. It
+     * reproduces the values a per-element-type special case would give, without needing one, and
+     * the critical time step reads its mass distribution from the same helper so the two cannot
+     * disagree.
+     *
+     * @note The element total is independent of \f$w\f$: the blend only moves mass between the
+     * corner and the remaining nodes. An incorrect weight therefore leaves the element mass, and
+     * hence the model mass, perfectly correct -- and is invisible to any check on totals.
      */
     void computeLumpedInertia( double* M );
 
@@ -383,10 +399,21 @@ namespace Marmot::Elements {
      * @brief Compute the critical time step for explicit dynamics based on
      * the dilatational wave speed and the element size.
      * @param criticalTimeStep Output parameter for the computed critical time step.
-     * @details Uses the formula \f$\Delta t_\mathrm{crit} = \frac{l_\mathrm{min}}{c_\mathrm{dil}}\f$,
-     * where \f$l_\mathrm{min}\f$ is the minimum characteristic element length and \f$c_\mathrm{dil}\f$
-     * is the dilatational wave speed computed from the material properties at the quadrature points.
-     * The minimum time step across all quadrature points is returned.
+     * @details The estimate is \f$l / c\f$, scaled by the factor
+     * Marmot::FiniteElement::MassLumping::timeStepFactorFromMassDistribution() derives from the
+     * same lumped mass fractions computeLumpedInertia() assembles: \f$l/c\f$ is the stable
+     * increment for an element whose mass is spread uniformly over its nodes, which lumping does
+     * not do, and the lightest node sets the highest frequency. \f$l\f$ is twice the smallest
+     * singular value of the Jacobian, i.e. the element's smallest physical extent, so a sliver is
+     * not mistaken for its volume-equivalent cube. The minimum over all quadrature points is
+     * returned.
+     *
+     * @warning This corrects the mass-distribution and element-distortion parts of the estimate
+     * only. It does NOT correct for polynomial order, and that residue is large: \f$l/c\f$ is a
+     * linear-element formula, while a quadratic element's highest free eigenfrequency lies well
+     * above what it predicts. A convergence study on a 20-node bar settles only around a courant
+     * number of 0.1-0.2, i.e. roughly a further factor of five is unaccounted for. Closing that
+     * properly wants an eigenvalue-based estimate rather than another factor.
      */
     void computeCriticalTimeStepForExplicitDynamics( double& criticalTimeStep, const double* QTotal );
 
@@ -869,13 +896,14 @@ namespace Marmot::Elements {
     Map< RhsSized > LMM( M );
     LMM.setZero();
 
-    // Hexa20 special case: shift the split towards the linear shape function to avoid the exact
-    // corner-mass cancellation the default 1/2-1/2 split produces for this element (see the
-    // Doxygen comment on the declaration).
-    constexpr bool   isHexa20   = ( nDim == 3 && nNodes == 20 );
-    constexpr double wHighOrder = isHexa20 ? 1.0 / 3.0 : 0.5;
-    constexpr double wLinear    = isHexa20 ? 2.0 / 3.0 : 0.5;
-
+    /* Row sums of the consistent mass matrix, from this element's own shape functions and from the
+     * linear (corner-node) shape functions of the same element. Density-free: the blend weight and
+     * the mass distribution are properties of the element geometry alone, and deriving them in one
+     * place is what keeps this function and computeCriticalTimeStepForExplicitDynamics consistent
+     * with each other -- a time step derived from a different mass distribution than the one
+     * actually assembled is exactly the kind of inconsistency that surfaces as an unexplained
+     * instability rather than as a clean failure.
+     */
     constexpr int nNodesLinear = ( 1 << nDim );
 
     // computeLumpedInertia() only knows how to weight the non-local block against either the
@@ -888,13 +916,21 @@ namespace Marmot::Elements {
                    "non-local field to use either the displacement interpolation order (nNonLocalNodes == "
                    "nNodes) or linear corner-node interpolation (nNonLocalNodes == 2^nDim)." );
 
-    auto linGeometryEl = MarmotGeometryElement< nDim, nNodesLinear >();
+    auto            linGeometryEl    = MarmotGeometryElement< nDim, nNodesLinear >();
+    Eigen::VectorXd rowSumsHighOrder = Eigen::VectorXd::Zero( nNodes );
+    Eigen::VectorXd rowSumsLinear    = Eigen::VectorXd::Zero( nNodesLinear );
+    for ( const auto& qp : qps ) {
+      rowSumsHighOrder += Eigen::VectorXd( localGeometryElement.N( qp.xi ) ) * qp.J0xW;
+      rowSumsLinear += Eigen::VectorXd( linGeometryEl.N( qp.xi ) ) * qp.J0xW;
+    }
+    const double weight = FiniteElement::MassLumping::manifoldBlendWeight( rowSumsHighOrder, rowSumsLinear );
+
     for ( const auto& qp : qps ) {
       const auto N_    = localGeometryElement.N( qp.xi );
       const auto N_lin = linGeometryEl.N( qp.xi );
 
-      VectorXd N_weighted = wHighOrder * ( N_ );
-      N_weighted.head( nNodesLinear ) += wLinear * N_lin;
+      VectorXd N_weighted = weight * ( N_ );
+      N_weighted.head( nNodesLinear ) += ( 1.0 - weight ) * N_lin;
 
       // when nNodes == nNonlocalNodes
       VectorXd N_weighted_nonlocal;
@@ -929,6 +965,39 @@ namespace Marmot::Elements {
   {
     using response = typename MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >::response;
 
+    /* The l / c estimate below assumes the element's mass is spread UNIFORMLY over its nodes, each
+     * carrying 1 / nNodes of it. The lumping scheme computeLumpedInertia applies does not do that:
+     * under the manifold-based blend a hexa20 corner node carries less than the uniform share, and
+     * the lightest node sets the highest frequency (omega = sqrt( k / m )), so the stable increment
+     * scales with sqrt( m_min / m_uniform ).
+     *
+     * Ignoring it puts the default courant number of 0.8 ABOVE the true limit for every 20-node
+     * element. That does not present as a marginally noisy run but as violent exponential
+     * divergence -- and only where the material provides no damping, so a 20-node run on a
+     * viscously regularised material can sit just above the limit and look perfectly healthy. That
+     * is worse than a clean failure, because it makes the fault look model-specific.
+     *
+     * The fractions come from the same helper computeLumpedInertia uses, so the two cannot drift
+     * apart. Exactly 1 for a linear element on a regular mesh, so nothing changes there, and
+     * slightly below 1 for a distorted element -- which is correct, a distorted element does have a
+     * tighter limit than its volume alone suggests.
+     *
+     * Note this covers the DISPLACEMENT field only. The nonlocal field's own forward-Euler limit,
+     * set by its viscosity against the Helmholtz operator, is still not checked anywhere -- see the
+     * TODO below.
+     */
+    constexpr int   nNodesLinear     = ( 1 << nDim );
+    auto            linGeometryEl    = MarmotGeometryElement< nDim, nNodesLinear >();
+    Eigen::VectorXd rowSumsHighOrder = Eigen::VectorXd::Zero( nNodes );
+    Eigen::VectorXd rowSumsLinear    = Eigen::VectorXd::Zero( nNodesLinear );
+    for ( const auto& qp : qps ) {
+      rowSumsHighOrder += Eigen::VectorXd( localGeometryElement.N( qp.xi ) ) * qp.J0xW;
+      rowSumsLinear += Eigen::VectorXd( linGeometryEl.N( qp.xi ) ) * qp.J0xW;
+    }
+    const double weight = FiniteElement::MassLumping::manifoldBlendWeight( rowSumsHighOrder, rowSumsLinear );
+    const double lumpedMassTimeStepFactor = FiniteElement::MassLumping::timeStepFactorFromMassDistribution(
+      FiniteElement::MassLumping::manifoldMassFractions( rowSumsHighOrder, rowSumsLinear, weight ) );
+
     // TODO: current implementation ignores nonlocal variables
     criticalTimeStep = std::numeric_limits< double >::max();
     for ( const auto& qp : qps ) {
@@ -961,7 +1030,7 @@ namespace Marmot::Elements {
       if ( c <= 0.0 )
         throw std::runtime_error( "Material returned non-positive wave speed, cannot compute critical time step" );
       const double& l  = characteristicElementLength;
-      double        dt = l / c;
+      double        dt = lumpedMassTimeStepFactor * l / c;
       if ( dt < criticalTimeStep )
         criticalTimeStep = dt;
     }


### PR DESCRIPTION
## Summary

Follow-up to #74. That PR fixed the hexa20 zero corner mass; this one fixes the two things it left
behind — the weight being a hard-coded constant, and the critical time step still assuming a mass
distribution that the lumping no longer produces.

### 1. The blend weight is derived instead of hard-coded

The manifold-based scheme (Yang et al. 2017) lumps a blended shape function
`N̂ = w·N + (1−w)·N_lin`. `w` is not free. A corner node's lumped mass is `w·S_N + (1−w)·S_lin`, and
a serendipity element has `S_N < 0 < S_lin`, so positivity requires

```
w < w_max = min_i  S_lin_i / ( S_lin_i − S_N_i )
```

and that limit is element-dependent:

| element | corner row sum `S_N` | `w_max` | hard-coded ½ |
|---|--:|--:|---|
| quad8 (2D serendipity) | −1/3 (area 4) | **0.75** | safe |
| hexa20 (3D serendipity) | −1 (volume 8) | **0.50** | **exactly on the boundary → zero corner mass** |

That is the bug #74 found. A per-element-type special case fixes the element somebody tested; it
does not answer the question for the next one.

New shared header `MarmotFiniteElementCore/include/Marmot/MarmotMassLumping.h` derives
`w = min(½, ⅔·w_max)` from the element's own shape-function row sums:

- **½** wherever ½ is safe — every 2D serendipity element, and every linear element (there
  `N_lin ≡ N`, so the result does not depend on `w` at all),
- **⅓** for a hexa20.

So this **reproduces #74's values on every element type that exists today and changes no result.**
It only stops the value from being a constant that has to be special-cased by hand.

### 2. The critical time step now matches the mass it is derived from

`l / c` is the stable increment for an element whose mass is spread **uniformly** over its nodes,
each carrying `1/nNodes`. Lumping does not do that:

| hexa20, `w = ⅓` | share of element mass |
|:--|--:|
| each of the 8 corner nodes | 1/24 = 0.041667 |
| each of the 12 midside nodes | 1/18 = 0.055556 |
| uniform 1/20 share, for reference | 0.05 |

The lightest node sets the highest frequency (`ω = √(k/m)`), so the stable increment scales with
`√(m_min/m_uniform)` — here `√(20/24) = √(5/6) = 0.9129`. The quad8 equivalent (corner 1/12,
midside 1/6) gives `√(8/12) = √(2/3) = 0.8165`. **Ignoring this puts the shipped default
`courant-number = 0.8` above the true limit for every 20-node element.**

Why that survived this long: it is only *visible* where the material provides no damping. A
`C3D20R` + `LinearElastic` bar diverges geometrically (kinetic energy 5e-3 → 5e22 → 3e81 → 6e270),
while a gradient-enhanced damage material at the same courant number ran 800 increments looking
perfectly healthy, because its nonlocal viscosity absorbed a marginally unstable scheme. So the
fault presents as *model-specific*, which is exactly what makes it expensive to find.

The factor now comes from the **same helper** `computeLumpedInertia` uses, so the assembled mass
distribution and the time step derived from it cannot drift apart. It is exactly 1 for a linear
element on a regular mesh (nothing changes there) and below 1 for a distorted element — which is
correct, a distorted element does have a tighter limit than its volume alone suggests.

### Also included

The first commit (`fix(elements): base the explicit stability length on element distortion`) makes
the characteristic length **twice the smallest singular value of the Jacobian** instead of
`cbrt(8·detJ)`. The old expression is volume-based, so it is blind to slivers: a sliver keeps a
moderate volume while its thin dimension collapses, so the length — and hence the stable step — is
overestimated. Refining a distorted parent element is precisely how slivers are made, which made
this show up as an h-adaptive run diverging thousands of increments after the refinement that
caused it, with nothing in the log connecting the two. For a well-shaped element it reproduces the
old expression exactly (a cube of side `h` gives `h` either way), so it tightens the estimate only
where it was previously wrong.

## Deliberate choices, called out for review

Each of these is now stated in the Doxygen comments rather than left for a reader to discover:

- **The ⅔ safety fraction is a choice made here, not taken from either reference** — it is the
  largest simple fraction that still returns exactly ½ for a quad8. But the values it produces are
  the published ones on both element types for which a published value exists: **½ for quad8**
  (Yang, Zheng & Sivaselvan 2017) and **⅓ for hexa20** (the split assessed by Duczek & Gravenkamp
  2019, CMAME 350, 836–897 — now cited in the header alongside Yang et al., which covers only the
  2D case). So the rule reproduces the literature wherever the literature has an answer, rather
  than merely staying off the positivity boundary.
- **Integrating the blended shape function once is exact, not a shortcut.** The scheme is usually
  written and implemented as "assemble the blended *consistent* mass `∫N̂ᵀN̂ρ dV`, then row-sum it".
  Both shape function sets are partitions of unity and the blend is convex, so `Σ_j N̂_j ≡ 1` and
  `Σ_j M_ij = ∫N̂_i(Σ_j N̂_j)ρ dV = ∫N̂_i ρ dV`. `computeLumpedInertia` therefore gets the same
  numbers as the quadratic form without forming a consistent mass matrix — checked numerically
  against the quadratic route on a hexa20, agreeing to 1.7e-16.
- **"Reproduces #74's values" is exact analytically, not bit-exact.** The row sums are accumulated
  numerically over the element's own quadrature points, so for a quad8 under 2×2 reduced
  integration `w_max` lands an ulp below ¾ and the derived weight an ulp below ½. Far below any
  tolerance the masses are checked against, but it is a rounding-level difference, not an identity.
- **Positivity is enforced at the corner nodes only** — all a blend weight can reach. A node with
  no linear counterpart carries `w·S_N_i`, so no `w > 0` can rescue it if its own shape function
  integrates negative. None of the element types in use does; a positive weight is nevertheless not
  a guarantee of a positive definite lumped mass matrix.
- **A non-positive smallest mass fraction falls back to the uncorrected `l/c`**, deliberately: any
  time step derived from a failed lumping is meaningless, and scaling by `√(m_min/m_uniform)` would
  return zero or NaN and hide the cause. Worth knowing that *nothing currently reports that
  failure* — the only check on the assembled lumped mass is solver-side and tests for an exact
  zero, which a negative or near-zero nodal mass passes. Detecting it at assembly is the right fix
  and is out of scope here.
- **There are now two different "characteristic element lengths"** in these elements, on purpose.
  The material still receives the volume-based `cbrt(8·detJ)`, because that is a *regularisation*
  length (the width over which a softening law dissipates its fracture energy); the stability
  estimate needs the smallest extent. They are not interchangeable and are commented as such.

## What this does NOT fix

`l/c` takes no account of **polynomial order**, and that residue is large. A convergence study on a
20-node bar (final reaction vs courant number) settles only around 0.1–0.2:

```
0.8 -> 4.49    0.4 -> 84.6    0.2 -> 118.5    0.1 -> 120.7    0.05 -> 118.0
```

i.e. roughly a further factor of five is unaccounted for, because a quadratic element's highest free
eigenfrequency lies well above what `l/c` predicts. Closing that properly wants an eigenvalue-based
estimate (power iteration on `M⁻¹K`) rather than another fitted constant, so it is documented as a
`@warning` on the declarations rather than papered over. **The 0.8 default remains wrong for
20-node elements even after this PR** — it is merely no longer wrong for the mass-distribution
reason. (These numbers are from earlier runs on the pre-#74 equivalent of this code, not from this
branch; they are the motivation for the `@warning`, not a claim this PR verifies.)

The gradient-enhanced element's `// TODO: current implementation ignores nonlocal variables` also
still stands: the nonlocal field's own forward-Euler limit, set by its viscosity against the
Helmholtz operator, is checked nowhere. That is now called out in the Doxygen comment.

Not measured: on a **distorted** mesh the time step now shrinks for *linear* elements too, since
both the smallest-singular-value length and the non-uniform mass factor tighten it. That is the
conservative direction and each factor is individually justified, but it does mean existing
explicit runs on distorted Hexa8 meshes get somewhat slower, and nobody has put a number on it.

## Verification

- [x] **It compiles.** gcc-14 / ubuntu and macos, 4/4 build jobs green.
- [x] **`ctest`** — `100% tests passed out of 93`, including `TestDisplacementFiniteElement`, which
      holds #74's `computeLumpedInertia` tests. They pin exact analytic values for the ⅓/⅔ hexa20
      split and the ½ quad8 split, and they pass unchanged, so **claim 1 is proven**:
      the derived weight reproduces the hard-coded one.
      → [build_ubuntu](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/runs/33728171177)
- [x] **The time-step factor is the expected size**, and now pinned by four new tests
      (Quad4/Hexa8/Quad8/Hexa20) rather than left to a downstream check: a regular unit element
      gives factor **1** for both linear elements, **√(2/3) = 0.8165** for quad8 and
      **√(5/6) = 0.9129** for hexa20. Getting the hexa20 value wrong is the exact failure this PR
      exists to prevent — an HRZ-style `∫N² dV` distribution, for contrast, would give corner
      0.028226 / midside 0.064516 → 0.751, which the test would catch.
- [x] **No `publicheaders`/CMake entry for the new header** — checked, and correct as-is.
      `install(TARGETS … PUBLIC_HEADER)` installs only the `publicheaders` list, and no installed
      header includes `MarmotMassLumping.h`: only the three element headers do, and none of those is
      installed either (same as `MarmotGeometryElement.h`, `MarmotFiniteElement.h`). Sphinx picks it
      up regardless — `doc/conf.py` globs each module's headers and `finiteelementcore.rst` uses
      `autodoxygenindex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
