### PR TITLE
ci: add code coverage pipeline with Codecov upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,95 @@
+# This is a workflow to measure C++ code coverage on ubuntu and upload it to Codecov
+name: coverage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CC:   gcc-14
+      CXX:  g++-14
+
+    steps:
+      - name: Install lcov
+        shell: bash -leo pipefail {0}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y lcov
+
+      - name: Install Eigen
+        shell: bash -leo pipefail {0}
+        run: |
+          git clone --branch 3.4.0 https://gitlab.com/libeigen/eigen.git
+          cd eigen
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF  ..
+          sudo make install
+          cd ../..
+
+      - name: Install Autodiff
+        shell: bash -leo pipefail {0}
+        run: |
+          git clone --branch v1.1.0 https://github.com/autodiff/autodiff.git
+          cd autodiff
+          mkdir build
+          cd build
+          cmake -DAUTODIFF_BUILD_TESTS=OFF -DAUTODIFF_BUILD_PYTHON=OFF -DAUTODIFF_BUILD_EXAMPLES=OFF -DAUTODIFF_BUILD_DOCS=OFF ..
+          sudo make install
+          cd ../..
+
+      - name: Install Fastor
+        shell: bash -leo pipefail {0}
+        run: |
+          git clone --branch V0.6.4 https://github.com/romeric/Fastor.git
+          cd Fastor
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF  ..
+          sudo make install
+          cd ../..
+
+      - name: Check out Marmot
+        uses: actions/checkout@v4
+
+      - name: Build Marmot with coverage instrumentation
+        shell: bash -leo pipefail {0}
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMARMOT_ENABLE_COVERAGE=ON ..
+          make -j$(nproc)
+
+      - name: Run tests
+        shell: bash -leo pipefail {0}
+        run: |
+          cd build
+          # --no-tests=error: ctest exits 0 on an empty test set, which would
+          # report success for a build that produced no coverage at all.
+          ctest --output-on-failure --no-tests=error
+
+      - name: Capture coverage
+        shell: bash -leo pipefail {0}
+        run: |
+          cd build
+          lcov --gcov-tool gcov-14 --directory . --capture --output-file coverage.info
+          lcov --remove coverage.info \
+            '/usr/*' \
+            '*/eigen/*' \
+            '*/autodiff/*' \
+            '*/Fastor/*' \
+            '*/build/*' \
+            --output-file coverage.filtered.info \
+            --ignore-errors unused
+          lcov --list coverage.filtered.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/coverage.filtered.info
+          fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 'next_v*' ]
   pull_request:
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          # GitHub withholds repo secrets (CODECOV_TOKEN included) from `pull_request`
+          # runs whose head repo is a fork, which is how most PRs reach this repo -
+          # codecov-action falls back to its tokenless upload for public repos in that
+          # case, so don't fail_ci_if_error and break an external contributor's PR
+          # check over an upload hiccup.
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/coverage.filtered.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,16 @@ make install                                       # also installs the `marmot` 
 ctest -R Python_                                   # run the python solver example tests only
 ```
 
+To measure code coverage locally (GCC/Clang only, requires `lcov`):
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DMARMOT_ENABLE_COVERAGE=ON && make -j$(nproc)
+ctest --output-on-failure
+lcov --directory . --capture --output-file coverage.info
+lcov --remove coverage.info '/usr/*' '*/eigen/*' '*/autodiff/*' '*/Fastor/*' '*/build/*' --output-file coverage.filtered.info
+genhtml coverage.filtered.info --output-directory coverage_html      # open coverage_html/index.html
+```
+CI runs the same instrumentation on every push/PR (`.github/workflows/coverage.yml`) and uploads results to Codecov.
+
 ## General Coding Rules & Best Practices
 
 - **Minimal Diffs**: Keep changes focused and strictly scoped; avoid reformatting unrelated files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,25 @@ if(SHARED_LIBRARIES)
     message("+------------------------------------------------------------------------------+")
 endif()
 
+# ── Code coverage ──────────────────────────────────────────────────────────────
+
+# Opt-in: instruments only the Marmot library itself (not the test executables) with
+# gcov, since the library sources are what coverage is meant to measure. Link options
+# are PUBLIC so that test executables linking against Marmot also link the gcov runtime.
+option(MARMOT_ENABLE_COVERAGE "Instrument libMarmot with gcov code coverage (GCC/Clang only)" OFF)
+
+if(MARMOT_ENABLE_COVERAGE)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(FATAL_ERROR "MARMOT_ENABLE_COVERAGE requires GCC or Clang")
+    endif()
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        message(WARNING "MARMOT_ENABLE_COVERAGE is intended to be used with -DCMAKE_BUILD_TYPE=Debug for accurate line coverage")
+    endif()
+    message(STATUS "Instrumenting ${PROJECT_NAME} for code coverage (--coverage)")
+    target_compile_options(${PROJECT_NAME} PRIVATE --coverage -O0)
+    target_link_options(${PROJECT_NAME} PUBLIC --coverage)
+endif()
+
 # Include test definitions for all installed modules
 foreach(MODULEPATH IN LISTS INSTALLED_MODULEPATHS)
     if(EXISTS "${MODULEPATH}/test.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,15 @@ function(add_marmot_test test_name test_source)
       BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
   )
   add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  # Many Marmot classes are templates (<int nDim, int nNodes>) that get implicitly
+  # re-instantiated inside each test's own translation unit. An uninstrumented test
+  # binary's own copy of such a template method wins symbol resolution over the
+  # library's instrumented copy, so gcov never sees it. Instrumenting the tests too
+  # (MARMOT_ENABLE_COVERAGE, set further down before this function is ever called)
+  # avoids that blind spot.
+  if(MARMOT_ENABLE_COVERAGE)
+    target_compile_options(${test_name} PRIVATE --coverage -O0)
+  endif()
 endfunction()
 
 set(MODULES_DIR ${CMAKE_SOURCE_DIR}/modules)
@@ -247,10 +256,12 @@ endif()
 
 # ── Code coverage ──────────────────────────────────────────────────────────────
 
-# Opt-in: instruments only the Marmot library itself (not the test executables) with
-# gcov, since the library sources are what coverage is meant to measure. Link options
-# are PUBLIC so that test executables linking against Marmot also link the gcov runtime.
-option(MARMOT_ENABLE_COVERAGE "Instrument libMarmot with gcov code coverage (GCC/Clang only)" OFF)
+# Opt-in: instruments the Marmot library with gcov. Test executables are instrumented
+# too (see add_marmot_test below) because templated classes get re-instantiated per
+# translation unit, and an uninstrumented test binary's own copy of a template method
+# otherwise wins symbol resolution over the library's instrumented one, hiding it from
+# coverage entirely. Link options are PUBLIC so consumers link the gcov runtime too.
+option(MARMOT_ENABLE_COVERAGE "Instrument libMarmot and its tests with gcov code coverage (GCC/Clang only)" OFF)
 
 if(MARMOT_ENABLE_COVERAGE)
     if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ function(add_marmot_test test_name test_source)
   # avoids that blind spot.
   if(MARMOT_ENABLE_COVERAGE)
     target_compile_options(${test_name} PRIVATE --coverage -O0)
+    target_link_options(${test_name} PRIVATE --coverage)
   endif()
 endfunction()
 
@@ -260,7 +261,9 @@ endif()
 # too (see add_marmot_test below) because templated classes get re-instantiated per
 # translation unit, and an uninstrumented test binary's own copy of a template method
 # otherwise wins symbol resolution over the library's instrumented one, hiding it from
-# coverage entirely. Link options are PUBLIC so consumers link the gcov runtime too.
+# coverage entirely. Flags are kept PRIVATE: PUBLIC link options would be exported into
+# MarmotTargets.cmake, silently forcing --coverage onto any downstream consumer that
+# links Marmot::Marmot from a coverage-enabled install.
 option(MARMOT_ENABLE_COVERAGE "Instrument libMarmot and its tests with gcov code coverage (GCC/Clang only)" OFF)
 
 if(MARMOT_ENABLE_COVERAGE)
@@ -272,7 +275,7 @@ if(MARMOT_ENABLE_COVERAGE)
     endif()
     message(STATUS "Instrumenting ${PROJECT_NAME} for code coverage (--coverage)")
     target_compile_options(${PROJECT_NAME} PRIVATE --coverage -O0)
-    target_link_options(${PROJECT_NAME} PUBLIC --coverage)
+    target_link_options(${PROJECT_NAME} PRIVATE --coverage)
 endif()
 
 # Include test definitions for all installed modules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![build](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/workflows/build_ubuntu.yml/badge.svg)
+[![codecov](https://codecov.io/gh/MAteRialMOdelingToolbox/Marmot/branch/master/graph/badge.svg)](https://codecov.io/gh/MAteRialMOdelingToolbox/Marmot)
 ![clang-format](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/workflows/indent.yml/badge.svg)
 [![documentation](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/workflows/sphinx.yml/badge.svg)](https://materialmodelingtoolbox.github.io/Marmot/)
 [![license](https://img.shields.io/badge/license-LGPLv2-blue.svg)](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![build](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/workflows/build_ubuntu.yml/badge.svg)
 [![codecov](https://codecov.io/gh/MAteRialMOdelingToolbox/Marmot/branch/master/graph/badge.svg)](https://codecov.io/gh/MAteRialMOdelingToolbox/Marmot)
+[![codecov (next_v26.11)](https://codecov.io/gh/MAteRialMOdelingToolbox/Marmot/branch/next_v26.11/graph/badge.svg)](https://codecov.io/gh/MAteRialMOdelingToolbox/Marmot/branch/next_v26.11)
 ![clang-format](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/workflows/indent.yml/badge.svg)
 [![documentation](https://github.com/MAteRialMOdelingToolbox/Marmot/actions/workflows/sphinx.yml/badge.svg)](https://materialmodelingtoolbox.github.io/Marmot/)
 [![license](https://img.shields.io/badge/license-LGPLv2-blue.svg)](LICENSE.md)


### PR DESCRIPTION
## Summary
- Add a `MARMOT_ENABLE_COVERAGE` CMake option that instruments libMarmot with gcov (`--coverage`), opt-in and GCC/Clang only.
- Add `.github/workflows/coverage.yml`: builds with coverage enabled, runs `ctest`, captures results via `lcov` (filtering out system/Eigen/autodiff/Fastor/build noise), and uploads to Codecov.
- Add a Codecov badge to the README and document the local coverage workflow in AGENTS.md.

## Notes
- Requires a `CODECOV_TOKEN` repo secret and the Codecov app enabled on `MAteRialMOdelingToolbox/Marmot` before the upload step will succeed.

## Test plan
- [x] Locally configured/built `libMarmot` with `-DMARMOT_ENABLE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug` and confirmed `.gcno` files plus `__gcov_init`/`__gcov_exit` symbols are emitted for the library.
- [x] Verified with an isolated shared-library repro that gcov data is written correctly end-to-end at runtime.
- [ ] CI `coverage` workflow run (left for review; not polled per usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA