### PR TITLE
test(core): add tests for the MarmotFiniteElementCore module

### DIFF
--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotDofLayoutTools.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotDofLayoutTools.h
@@ -37,7 +37,10 @@ namespace Marmot {
     /**
      * @brief Builds a node-field layout from a map of field names to their DOF dimensions.
      *
-     * @param fieldSizes Map from field name to a pair (nodesPerElement, dofsPerNode).
+     * @param fieldSizes Map from field name to a pair (dofsPerNode, nodesForField): the number of
+     * scalar components the field has at each of its nodes, and how many of the element's nodes
+     * carry that field (<= the element's total node count for a reduced-order field, e.g. corner-
+     * only pressure in a mixed Taylor-Hood-style element).
      * @return A 2-D vector where each row corresponds to a node and each entry is a field name.
      */
     const std::vector< std::vector< std::string > > makeNodeFieldLayout(
@@ -47,7 +50,8 @@ namespace Marmot {
      * @brief Computes the DOF permutation pattern for a blocked (field-major) layout.
      *
      * @param nodeFields     Node-field layout as returned by @ref makeNodeFieldLayout.
-     * @param fieldSizes     Map from field name to a pair (nodesPerElement, dofsPerNode).
+     * @param fieldSizes     Map from field name to a pair (dofsPerNode, nodesForField); see
+     * @ref makeNodeFieldLayout.
      * @return Integer permutation vector that reorders DOFs from node-major to field-major order.
      */
     std::vector< int > makeBlockedLayoutPermutationPattern(

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElement.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElement.h
@@ -520,13 +520,13 @@ namespace Marmot {
       /**
        * @brief Construct a BoundaryElement from a parent shape and face number.
        * @param[in] parentShape        Shape enum of the parent volume element.
-       * @param[in] nDim               Number of spatial dimensions.
        * @param[in] parentFaceNumber   Zero-based index of the boundary face on the parent element.
+       * @param[in] nDim               Number of spatial dimensions.
        * @param[in] parentCoordinates  Flat vector of parent nodal coordinates.
        */
       BoundaryElement( ElementShapes          parentShape,
-                       int                    nDim,
                        int                    parentFaceNumber,
+                       int                    nDim,
                        const Eigen::VectorXd& parentCoordinates );
 
       /// @brief Compute the scalar (pressure) load vector for a unit pressure.

--- a/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
+++ b/modules/core/MarmotFiniteElementCore/include/Marmot/MarmotFiniteElementSpatialWrapper.h
@@ -54,6 +54,9 @@ public:
   Eigen::MatrixXd                  T;            ///< Coordinate transformation matrix from child to parent space.
   Eigen::MatrixXd                  P;            ///< Projection matrix mapping parent DOFs to child DOFs.
   Eigen::MatrixXd                  projectedCoordinates; ///< Nodal coordinates expressed in the child (local) frame.
+  Eigen::VectorXd referenceCoordinates; ///< Ambient-space coordinates of node 0, needed to recover the translation
+                                        ///< (T alone only encodes the rotation) when mapping a child-space point
+                                        ///< back into ambient space.
 
   /**
    * @brief Construct the spatial wrapper.

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement2D.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElement2D.cpp
@@ -151,6 +151,15 @@ namespace Marmot {
 
       } // end of namespace Quad8
 
+    }   // end of namespace Spatial2D
+  }     // end of namespace FiniteElement
+
+  // Declared under Marmot::FiniteElement::Quadrature::Spatial2D (see MarmotFiniteElement.h); this
+  // definition previously lived one namespace level too shallow (Marmot::FiniteElement::Spatial2D,
+  // missing the Quadrature level), so it could never actually be linked against its own
+  // declaration -- and, with no callers anywhere in the codebase, nothing noticed.
+  namespace FiniteElement::Quadrature {
+    namespace Spatial2D {
       void modifyCharElemLengthAbaqusLike( double& charElemLength, int intPoint )
       {
         switch ( intPoint ) {
@@ -167,6 +176,6 @@ namespace Marmot {
         case 8: charElemLength *= std::sqrt( 5. / 18. ); break;
         }
       }
-    } // end of namespace Spatial2D
-  }   // end of namespace FiniteElement
+    } // namespace Spatial2D
+  }   // namespace FiniteElement::Quadrature
 } // end of namespace Marmot

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementBoundary.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementBoundary.cpp
@@ -251,7 +251,7 @@ namespace Marmot {
       /** Condense any scalar quantiaty parent vector to the corresponding boundary child vector (e.g.
        * temperature fields ) dependent on the underlying indices mapping
        * */
-      VectorXd boundaryVector( nNodes * nDim );
+      VectorXd boundaryVector( nNodes );
 
       for ( int i = 0; i < mapBoundaryToParentScalar.size(); i++ )
         boundaryVector( i ) = parentVector( mapBoundaryToParentScalar( i ) );

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
@@ -198,7 +198,7 @@ void MarmotElementSpatialWrapper::computeDistributedLoad( DistributedLoadTypes l
   MatrixXd Ke_Projected( projectedSize, projectedSize );
 
   childElement
-    ->computeDistributedLoad( loadType, P_Projected.data(), Ke_Projected.data(), elementFace, QTotal, load, time, dT );
+    ->computeDistributedLoad( loadType, P_Projected.data(), Ke_Projected.data(), elementFace, load, QTotal, time, dT );
 
   Map< VectorXd > P_Unprojected( P_, unprojectedSize );
   P_Unprojected = P.transpose() * P_Projected;
@@ -244,7 +244,11 @@ std::vector< double > MarmotElementSpatialWrapper::getCoordinatesAtCenter()
   const auto                          coordsChild_ = childElement->getCoordinatesAtCenter();
   Eigen::Map< const Eigen::VectorXd > coordsChild( &coordsChild_[0], coordsChild_.size() );
 
-  coordsMap = P.transpose() * coordsChild;
+  // coordsChild is a single point in the CHILD's local (nDimChild-sized) space; project it into
+  // ambient (nDim-sized) space with the geometric transform T (nDimChild x nDim), not with P
+  // (projectedSize x unprojectedSize), which maps full DOF vectors, not coordinates, and is the
+  // wrong shape whenever nNodes > 1.
+  coordsMap = T.transpose() * coordsChild;
 
   return coords;
 }
@@ -259,8 +263,11 @@ std::vector< std::vector< double > > MarmotElementSpatialWrapper::getCoordinates
   Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
 
   for ( const auto& coordsChild : listedChildCoords ) {
-    Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], nDim );
-    coordsMap = P.transpose() * coordsChildMap;
+    // Each coordsChild entry is a single point in the CHILD's local (nDimChild-sized) space, not
+    // an nDim-sized ambient point: mapping it with size nDim here would read past the end of a
+    // shorter (e.g. nDimChild=1) vector. Project with T (see getCoordinatesAtCenter() above).
+    Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], coordsChild.size() );
+    coordsMap = T.transpose() * coordsChildMap;
 
     listedCoords.push_back( coords );
   }

--- a/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/src/MarmotFiniteElementSpatialWrapper.cpp
@@ -146,6 +146,11 @@ void MarmotElementSpatialWrapper::assignNodeCoordinates( const double* coordinat
     }
   }
 
+  // Reference point (ambient-space coordinates of node 0) needed to recover the translation when
+  // later mapping a child-space point back into ambient space; see getCoordinatesAtCenter() /
+  // getCoordinatesAtQuadraturePoints() below.
+  referenceCoordinates = unprojectedCoordinates.col( 0 );
+
   // Projection of node coordinates
   projectedCoordinates = MatrixXd::Zero( nDimChild, nNodes );
   for ( int i = 0; i < nNodes; i++ )
@@ -248,7 +253,12 @@ std::vector< double > MarmotElementSpatialWrapper::getCoordinatesAtCenter()
   // ambient (nDim-sized) space with the geometric transform T (nDimChild x nDim), not with P
   // (projectedSize x unprojectedSize), which maps full DOF vectors, not coordinates, and is the
   // wrong shape whenever nNodes > 1.
-  coordsMap = T.transpose() * coordsChild;
+  //
+  // T alone only encodes the rotation: assignNodeCoordinates() projects via s = T * x, so
+  // recovering x from s additionally requires the translation, recovered here via the ambient
+  // reference point (node 0) stored at assignment time: x = x_ref + T^T * (s - T * x_ref).
+  const VectorXd referenceProjectedCoordinates = T * referenceCoordinates;
+  coordsMap = referenceCoordinates + T.transpose() * ( coordsChild - referenceProjectedCoordinates );
 
   return coords;
 }
@@ -262,12 +272,15 @@ std::vector< std::vector< double > > MarmotElementSpatialWrapper::getCoordinates
   std::vector< double >         coords( nDim );
   Eigen::Map< Eigen::VectorXd > coordsMap( &coords[0], nDim );
 
+  const VectorXd referenceProjectedCoordinates = T * referenceCoordinates;
+
   for ( const auto& coordsChild : listedChildCoords ) {
     // Each coordsChild entry is a single point in the CHILD's local (nDimChild-sized) space, not
     // an nDim-sized ambient point: mapping it with size nDim here would read past the end of a
-    // shorter (e.g. nDimChild=1) vector. Project with T (see getCoordinatesAtCenter() above).
+    // shorter (e.g. nDimChild=1) vector. Project with T, recovering the translation via the
+    // ambient reference point (see getCoordinatesAtCenter() above).
     Eigen::Map< const Eigen::VectorXd > coordsChildMap( &coordsChild[0], coordsChild.size() );
-    coordsMap = T.transpose() * coordsChildMap;
+    coordsMap = referenceCoordinates + T.transpose() * ( coordsChildMap - referenceProjectedCoordinates );
 
     listedCoords.push_back( coords );
   }

--- a/modules/core/MarmotFiniteElementCore/test.cmake
+++ b/modules/core/MarmotFiniteElementCore/test.cmake
@@ -1,0 +1,5 @@
+# add current directory to the source for the tests
+SET(CURR_TEST_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test")
+
+# Tests for MarmotFiniteElementBoundary
+add_marmot_test("TestMarmotFiniteElementBoundary" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteElementBoundary.cpp")

--- a/modules/core/MarmotFiniteElementCore/test.cmake
+++ b/modules/core/MarmotFiniteElementCore/test.cmake
@@ -12,3 +12,9 @@ add_marmot_test("TestMarmotDofLayoutTools" "${CURR_TEST_SOURCE_DIR}/TestMarmotDo
 
 # Tests for MarmotEnhancedAssumedStrain
 add_marmot_test("TestMarmotEnhancedAssumedStrain" "${CURR_TEST_SOURCE_DIR}/TestMarmotEnhancedAssumedStrain.cpp")
+
+# Tests for MarmotFiniteElement2D
+add_marmot_test("TestMarmotFiniteElement2D" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteElement2D.cpp")
+
+# Tests for MarmotGeometryElement
+add_marmot_test("TestMarmotGeometryElement" "${CURR_TEST_SOURCE_DIR}/TestMarmotGeometryElement.cpp")

--- a/modules/core/MarmotFiniteElementCore/test.cmake
+++ b/modules/core/MarmotFiniteElementCore/test.cmake
@@ -18,3 +18,6 @@ add_marmot_test("TestMarmotFiniteElement2D" "${CURR_TEST_SOURCE_DIR}/TestMarmotF
 
 # Tests for MarmotGeometryElement
 add_marmot_test("TestMarmotGeometryElement" "${CURR_TEST_SOURCE_DIR}/TestMarmotGeometryElement.cpp")
+
+# Tests for MarmotFiniteElementBasic
+add_marmot_test("TestMarmotFiniteElementBasic" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteElementBasic.cpp")

--- a/modules/core/MarmotFiniteElementCore/test.cmake
+++ b/modules/core/MarmotFiniteElementCore/test.cmake
@@ -3,3 +3,6 @@ SET(CURR_TEST_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test")
 
 # Tests for MarmotFiniteElementBoundary
 add_marmot_test("TestMarmotFiniteElementBoundary" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteElementBoundary.cpp")
+
+# Tests for MarmotFiniteElementSpatialWrapper
+add_marmot_test("TestMarmotFiniteElementSpatialWrapper" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteElementSpatialWrapper.cpp")

--- a/modules/core/MarmotFiniteElementCore/test.cmake
+++ b/modules/core/MarmotFiniteElementCore/test.cmake
@@ -6,3 +6,9 @@ add_marmot_test("TestMarmotFiniteElementBoundary" "${CURR_TEST_SOURCE_DIR}/TestM
 
 # Tests for MarmotFiniteElementSpatialWrapper
 add_marmot_test("TestMarmotFiniteElementSpatialWrapper" "${CURR_TEST_SOURCE_DIR}/TestMarmotFiniteElementSpatialWrapper.cpp")
+
+# Tests for MarmotDofLayoutTools
+add_marmot_test("TestMarmotDofLayoutTools" "${CURR_TEST_SOURCE_DIR}/TestMarmotDofLayoutTools.cpp")
+
+# Tests for MarmotEnhancedAssumedStrain
+add_marmot_test("TestMarmotEnhancedAssumedStrain" "${CURR_TEST_SOURCE_DIR}/TestMarmotEnhancedAssumedStrain.cpp")

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotDofLayoutTools.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotDofLayoutTools.cpp
@@ -1,0 +1,89 @@
+#include "Marmot/MarmotDofLayoutTools.h"
+#include "Marmot/MarmotTesting.h"
+#include <algorithm>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::FiniteElement;
+
+// ---------------------------------------------------------------------------------------------
+// These utilities have no callers anywhere in the codebase (verified by search), so there is no
+// existing usage to infer the intended semantics from. The pair<int,int> is (dofsPerNode,
+// nodesForField): this matches how the implementation actually destructures and uses it -- the
+// header's own doc comment had it backwards, and has been corrected alongside these tests.
+// ---------------------------------------------------------------------------------------------
+
+void testMakeNodeFieldLayoutSingleFieldOnAllNodes()
+{
+  const std::map< std::string, std::pair< int, int > > fieldSizes = { { "displacement", { 2, 4 } } };
+
+  const auto nodeFields = makeNodeFieldLayout( fieldSizes );
+
+  throwExceptionOnFailure( nodeFields.size() == 4, "makeNodeFieldLayout() returned the wrong number of nodes." );
+  for ( const auto& fields : nodeFields ) {
+    throwExceptionOnFailure( fields.size() == 1, "Every node should carry exactly one field." );
+    throwExceptionOnFailure( fields[0] == "displacement", "The single field must be \"displacement\"." );
+  }
+}
+
+void testMakeNodeFieldLayoutMixedOrderElement()
+{
+  // A Taylor-Hood-style mixed element: quadratic displacement (2 dofs/node) on 8 nodes, linear
+  // pressure (1 dof/node) on only the first 4 (corner) nodes.
+  const std::map< std::string, std::pair< int, int > > fieldSizes = { { "displacement", { 2, 8 } },
+                                                                      { "pressure", { 1, 4 } } };
+
+  const auto nodeFields = makeNodeFieldLayout( fieldSizes );
+
+  throwExceptionOnFailure( nodeFields.size() == 8,
+                           "makeNodeFieldLayout() must use the larger of the two fields' node counts." );
+
+  for ( int i = 0; i < 4; i++ ) {
+    throwExceptionOnFailure( nodeFields[i].size() == 2, "Corner nodes must carry both displacement and pressure." );
+    throwExceptionOnFailure( nodeFields[i][0] == "displacement" && nodeFields[i][1] == "pressure",
+                             "Field order must follow the (alphabetical) map iteration order." );
+  }
+  for ( int i = 4; i < 8; i++ ) {
+    throwExceptionOnFailure( nodeFields[i].size() == 1 && nodeFields[i][0] == "displacement",
+                             "Midside nodes must carry only displacement." );
+  }
+}
+
+void testMakeBlockedLayoutPermutationPatternGroupsDofsByField()
+{
+  // Same mixed element as above: 8 nodes x 2 displacement dofs (16) + 4 nodes x 1 pressure dof
+  // (4) = 20 total DOFs, laid out node-major as
+  // [u0x,u0y,p0, u1x,u1y,p1, u2x,u2y,p2, u3x,u3y,p3, u4x,u4y, u5x,u5y, u6x,u6y, u7x,u7y].
+  const std::map< std::string, std::pair< int, int > > fieldSizes = { { "displacement", { 2, 8 } },
+                                                                      { "pressure", { 1, 4 } } };
+  const auto                                           nodeFields = makeNodeFieldLayout( fieldSizes );
+
+  const auto pattern = makeBlockedLayoutPermutationPattern( nodeFields, fieldSizes );
+
+  const std::vector< int > expected = { 0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 2, 5, 8, 11 };
+
+  throwExceptionOnFailure( pattern.size() == expected.size(),
+                           "makeBlockedLayoutPermutationPattern() returned the wrong number of entries." );
+  for ( size_t i = 0; i < expected.size(); i++ )
+    throwExceptionOnFailure( pattern[i] == expected[i],
+                             "makeBlockedLayoutPermutationPattern()[" + std::to_string( i ) + "] mismatch." );
+
+  // The pattern must be a permutation of 0..19 (every DOF appears exactly once).
+  std::vector< int > sorted = pattern;
+  std::sort( sorted.begin(), sorted.end() );
+  for ( int i = 0; i < 20; i++ )
+    throwExceptionOnFailure( sorted[i] == i, "The permutation pattern must cover every DOF exactly once." );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testMakeNodeFieldLayoutSingleFieldOnAllNodes,
+    testMakeNodeFieldLayoutMixedOrderElement,
+    testMakeBlockedLayoutPermutationPatternGroupsDofsByField,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotEnhancedAssumedStrain.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotEnhancedAssumedStrain.cpp
@@ -1,0 +1,191 @@
+#include "Marmot/MarmotEnhancedAssumedStrain.h"
+#include "Marmot/MarmotTesting.h"
+#include <Eigen/Dense>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::FiniteElement::EAS;
+
+// ---------------------------------------------------------------------------------------------
+// F(J): the EAS transformation matrix built from the element Jacobian.
+// ---------------------------------------------------------------------------------------------
+
+void testFReducesToIdentityForIdentityJacobian2D()
+{
+  const Eigen::MatrixXd F2D = F( Eigen::Matrix2d::Identity() );
+  throwExceptionOnFailure( checkIfEqual( F2D, Eigen::MatrixXd( Eigen::Matrix3d::Identity() ), 1e-12 ),
+                           "F(Identity) must reduce to the identity for a 2D Jacobian." );
+}
+
+void testFReducesToIdentityForIdentityJacobian3D()
+{
+  const Eigen::MatrixXd F3D = F( Eigen::Matrix3d::Identity() );
+  throwExceptionOnFailure( checkIfEqual( F3D, Eigen::MatrixXd( Eigen::Matrix< double, 6, 6 >::Identity() ), 1e-12 ),
+                           "F(Identity) must reduce to the identity for a 3D Jacobian." );
+}
+
+void testFMatchesHandDerivedValuesForDiagonalJacobian2D()
+{
+  Eigen::Matrix2d J;
+  J << 2.0, 0.0, 0.0, 3.0;
+
+  const Eigen::MatrixXd F2D = F( J );
+
+  Eigen::Matrix3d expected;
+  // clang-format off
+  expected << 4.0, 0.0, 0.0,
+              0.0, 9.0, 0.0,
+              0.0, 0.0, 6.0;
+  // clang-format on
+
+  throwExceptionOnFailure( checkIfEqual( F2D, Eigen::MatrixXd( expected ), 1e-12 ),
+                           "F() does not match the hand-derived value for a diagonal 2D Jacobian." );
+}
+
+void testFThrowsForUnsupportedDimension()
+{
+  const Eigen::MatrixXd J = Eigen::MatrixXd::Identity( 4, 4 );
+
+  bool threw = false;
+  try {
+    F( J );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "F() must throw for an unsupported (non-2D/3D) Jacobian." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// EASInterpolation(): each variant's M-matrix, checked against hand-computed values at a fixed
+// natural coordinate.
+// ---------------------------------------------------------------------------------------------
+
+void testEASInterpolationDeBorstEAS2()
+{
+  Eigen::Vector2d       xi( 2.0, 3.0 );
+  const Eigen::MatrixXd E = EASInterpolation( DeBorstEAS2, xi );
+
+  Eigen::MatrixXd expected( 3, 2 );
+  // clang-format off
+  expected << 3.0, 0.0,
+              0.0, 2.0,
+              0.0, 0.0;
+  // clang-format on
+  throwExceptionOnFailure( checkIfEqual( E, expected, 1e-12 ), "DeBorstEAS2 interpolation matrix mismatch." );
+}
+
+void testEASInterpolationEAS3()
+{
+  Eigen::Vector3d       xi( 2.0, 3.0, 5.0 );
+  const Eigen::MatrixXd E = EASInterpolation( EAS3, xi );
+
+  Eigen::MatrixXd expected = Eigen::MatrixXd::Zero( 6, 3 );
+  expected( 0, 0 )         = 2.0;
+  expected( 1, 1 )         = 3.0;
+  expected( 2, 2 )         = 5.0;
+
+  throwExceptionOnFailure( checkIfEqual( E, expected, 1e-12 ), "EAS3 interpolation matrix mismatch." );
+}
+
+void testEASInterpolationDeBorstEAS9()
+{
+  Eigen::Vector3d       xi( 2.0, 3.0, 5.0 );
+  const Eigen::MatrixXd E = EASInterpolation( DeBorstEAS9, xi );
+
+  Eigen::MatrixXd expected = Eigen::MatrixXd::Zero( 6, 9 );
+  expected( 0, 0 )         = 2.0;
+  expected( 1, 1 )         = 3.0;
+  expected( 2, 2 )         = 5.0;
+  expected( 0, 3 )         = 6.0;  // xi0*xi1
+  expected( 0, 4 )         = 10.0; // xi0*xi2
+  expected( 1, 5 )         = 6.0;  // xi1*xi0
+  expected( 1, 6 )         = 15.0; // xi1*xi2
+  expected( 2, 7 )         = 10.0; // xi2*xi0
+  expected( 2, 8 )         = 15.0; // xi2*xi1
+
+  throwExceptionOnFailure( checkIfEqual( E, expected, 1e-12 ), "DeBorstEAS9 interpolation matrix mismatch." );
+}
+
+void testEASInterpolationDeBorstEAS6b()
+{
+  Eigen::Vector3d       xi( 2.0, 3.0, 5.0 );
+  const Eigen::MatrixXd E = EASInterpolation( DeBorstEAS6b, xi );
+
+  Eigen::MatrixXd expected = Eigen::MatrixXd::Zero( 6, 6 );
+  expected( 0, 0 )         = 2.0;
+  expected( 1, 1 )         = 3.0;
+  expected( 2, 2 )         = 5.0;
+  expected( 0, 3 )         = 6.0;  // xi1*xi0
+  expected( 0, 4 )         = 10.0; // xi2*xi0
+  expected( 1, 3 )         = 6.0;  // xi0*xi1
+  expected( 1, 5 )         = 15.0; // xi2*xi1
+  expected( 2, 4 )         = 10.0; // xi0*xi2
+  expected( 2, 5 )         = 15.0; // xi1*xi2
+
+  throwExceptionOnFailure( checkIfEqual( E, expected, 1e-12 ), "DeBorstEAS6b interpolation matrix mismatch." );
+}
+
+void testEASInterpolationSimoRifaiEAS5()
+{
+  Eigen::Vector2d       xi( 2.0, 3.0 );
+  const Eigen::MatrixXd E = EASInterpolation( SimoRifaiEAS5, xi );
+
+  Eigen::MatrixXd expected( 3, 5 );
+  // clang-format off
+  expected << 2.0, 0.0, 0.0, 0.0,  6.0,
+              0.0, 3.0, 0.0, 0.0, -6.0,
+              0.0, 0.0, 2.0, 3.0, -5.0; // xi0^2 - xi1^2 = 4 - 9 = -5
+  // clang-format on
+  throwExceptionOnFailure( checkIfEqual( E, expected, 1e-12 ), "SimoRifaiEAS5 interpolation matrix mismatch." );
+}
+
+void testEASInterpolationSimoRifaiEAS4()
+{
+  Eigen::Vector2d       xi( 2.0, 3.0 );
+  const Eigen::MatrixXd E = EASInterpolation( SimoRifaiEAS4, xi );
+
+  Eigen::MatrixXd expected( 3, 4 );
+  // clang-format off
+  expected << 2.0, 0.0, 0.0, 0.0,
+              0.0, 3.0, 0.0, 0.0,
+              0.0, 0.0, 2.0, 3.0;
+  // clang-format on
+  throwExceptionOnFailure( checkIfEqual( E, expected, 1e-12 ), "SimoRifaiEAS4 interpolation matrix mismatch." );
+}
+
+void testEASInterpolationThrowsForUnimplementedType()
+{
+  // DeBorstEAS2_P2 is declared in the EASType enum but has no case in EASInterpolation()'s switch.
+  Eigen::Vector2d xi( 1.0, 1.0 );
+
+  bool threw = false;
+  try {
+    EASInterpolation( DeBorstEAS2_P2, xi );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "EASInterpolation() must throw for an unimplemented EAS type." );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testFReducesToIdentityForIdentityJacobian2D,
+    testFReducesToIdentityForIdentityJacobian3D,
+    testFMatchesHandDerivedValuesForDiagonalJacobian2D,
+    testFThrowsForUnsupportedDimension,
+    testEASInterpolationDeBorstEAS2,
+    testEASInterpolationEAS3,
+    testEASInterpolationDeBorstEAS9,
+    testEASInterpolationDeBorstEAS6b,
+    testEASInterpolationSimoRifaiEAS5,
+    testEASInterpolationSimoRifaiEAS4,
+    testEASInterpolationThrowsForUnimplementedType,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElement2D.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElement2D.cpp
@@ -1,0 +1,64 @@
+#include "Marmot/MarmotFiniteElement.h"
+#include "Marmot/MarmotTesting.h"
+#include <cmath>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::FiniteElement::Quadrature::Spatial2D;
+
+// ---------------------------------------------------------------------------------------------
+// modifyCharElemLengthAbaqusLike(): has no callers anywhere in the codebase (verified by search),
+// so it is tested directly against its own documented per-integration-point scale factors for a
+// Quad8-style 3x3 (9-point) integration rule.
+// ---------------------------------------------------------------------------------------------
+
+void testModifyCharElemLengthAbaqusLikeCentralNode()
+{
+  double length = 1.0;
+  modifyCharElemLengthAbaqusLike( length, 0 );
+  throwExceptionOnFailure( checkIfEqual( length, 2.0 / 3.0, 1e-12 ),
+                           "The central integration point (0) must scale the length by 2/3." );
+}
+
+void testModifyCharElemLengthAbaqusLikeCornerNodes()
+{
+  for ( int intPoint = 1; intPoint <= 4; intPoint++ ) {
+    double length = 1.0;
+    modifyCharElemLengthAbaqusLike( length, intPoint );
+    throwExceptionOnFailure( checkIfEqual( length, 5.0 / 12.0, 1e-12 ),
+                             "Corner integration points (1-4) must scale the length by 5/12." );
+  }
+}
+
+void testModifyCharElemLengthAbaqusLikeMiddleNodes()
+{
+  for ( int intPoint = 5; intPoint <= 8; intPoint++ ) {
+    double length = 1.0;
+    modifyCharElemLengthAbaqusLike( length, intPoint );
+    throwExceptionOnFailure( checkIfEqual( length, std::sqrt( 5.0 / 18.0 ), 1e-12 ),
+                             "Middle integration points (5-8) must scale the length by sqrt(5/18)." );
+  }
+}
+
+void testModifyCharElemLengthAbaqusLikeLeavesLengthUnchangedForUnhandledIndex()
+{
+  // No default case: an out-of-range intPoint index is a documented-by-absence no-op.
+  double length = 1.0;
+  modifyCharElemLengthAbaqusLike( length, 99 );
+  throwExceptionOnFailure( checkIfEqual( length, 1.0, 1e-12 ),
+                           "An unhandled integration point index must leave the length unchanged." );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testModifyCharElemLengthAbaqusLikeCentralNode,
+    testModifyCharElemLengthAbaqusLikeCornerNodes,
+    testModifyCharElemLengthAbaqusLikeMiddleNodes,
+    testModifyCharElemLengthAbaqusLikeLeavesLengthUnchangedForUnhandledIndex,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementBasic.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementBasic.cpp
@@ -1,0 +1,162 @@
+#include "Marmot/MarmotFiniteElement.h"
+#include "Marmot/MarmotGeometryElement.h"
+#include "Marmot/MarmotTesting.h"
+#include <Eigen/Dense>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::FiniteElement;
+
+// ---------------------------------------------------------------------------------------------
+// getElementShapeByMetric()
+// ---------------------------------------------------------------------------------------------
+
+void testGetElementShapeByMetricAllValidCombinations()
+{
+  throwExceptionOnFailure( getElementShapeByMetric( 1, 2 ) == Bar2, "nDim=1, nNodes=2 must be Bar2." );
+  throwExceptionOnFailure( getElementShapeByMetric( 2, 4 ) == Quad4, "nDim=2, nNodes=4 must be Quad4." );
+  throwExceptionOnFailure( getElementShapeByMetric( 2, 8 ) == Quad8, "nDim=2, nNodes=8 must be Quad8." );
+  throwExceptionOnFailure( getElementShapeByMetric( 2, 9 ) == Quad9, "nDim=2, nNodes=9 must be Quad9." );
+  throwExceptionOnFailure( getElementShapeByMetric( 2, 16 ) == Quad16, "nDim=2, nNodes=16 must be Quad16." );
+  throwExceptionOnFailure( getElementShapeByMetric( 3, 4 ) == Tetra4, "nDim=3, nNodes=4 must be Tetra4." );
+  throwExceptionOnFailure( getElementShapeByMetric( 3, 10 ) == Tetra10, "nDim=3, nNodes=10 must be Tetra10." );
+  throwExceptionOnFailure( getElementShapeByMetric( 3, 8 ) == Hexa8, "nDim=3, nNodes=8 must be Hexa8." );
+  throwExceptionOnFailure( getElementShapeByMetric( 3, 20 ) == Hexa20, "nDim=3, nNodes=20 must be Hexa20." );
+  throwExceptionOnFailure( getElementShapeByMetric( 3, 27 ) == Hexa27, "nDim=3, nNodes=27 must be Hexa27." );
+  throwExceptionOnFailure( getElementShapeByMetric( 3, 64 ) == Hexa64, "nDim=3, nNodes=64 must be Hexa64." );
+}
+
+void testGetElementShapeByMetricThrowsForInvalidCombinations()
+{
+  const std::vector< std::pair< int, int > > invalidCombinations = {
+    { 1, 3 }, // no 3-node 1D shape
+    { 2, 5 }, // no 5-node 2D shape
+    { 3, 5 }, // no 5-node 3D shape
+    { 4, 8 }, // no 4-D shapes at all
+  };
+
+  for ( const auto& [nDim, nNodes] : invalidCombinations ) {
+    bool threw = false;
+    try {
+      getElementShapeByMetric( nDim, nNodes );
+    }
+    catch ( const std::invalid_argument& ) {
+      threw = true;
+    }
+    throwExceptionOnFailure( threw,
+                             "getElementShapeByMetric() must throw for nDim=" + std::to_string( nDim ) +
+                               ", nNodes=" + std::to_string( nNodes ) + "." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// NB() / Jacobian(): dynamic (runtime-sized) versions have no callers anywhere in the codebase --
+// every element uses the templated (compile-time-sized) overloads declared alongside them in
+// MarmotFiniteElement.h instead. Cross-validated against those already-trusted templated versions
+// for a known Quad4 configuration, rather than re-deriving expected values independently.
+// ---------------------------------------------------------------------------------------------
+
+void testDynamicNBMatchesTemplatedNBForQuad4()
+{
+  MarmotGeometryElement< 2, 4 > geo;
+  const auto                    N = geo.N( Eigen::Vector2d( 0.2, 0.3 ) ); // NSized = Matrix<double,1,4>
+
+  const auto templatedResult = Marmot::FiniteElement::NB< 2, 4 >( N );
+  const auto dynamicResult   = Marmot::FiniteElement::NB( Eigen::VectorXd( N.transpose() ), 2 );
+
+  throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( dynamicResult ), Eigen::MatrixXd( templatedResult ), 1e-12 ),
+                           "The dynamic NB() must match the templated NB<nDim,nNodes>() for the same input." );
+}
+
+void testDynamicJacobianMatchesTemplatedJacobianForQuad4()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 2.0, 0.0, 3.0, 2.0, 0.0, 1.0 }; // general quadrilateral
+
+  MarmotGeometryElement< 2, 4 > geo;
+  geo.assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const Eigen::Vector2d xi( 0.2, 0.3 );
+  const auto            dNdXi = geo.dNdXi( xi );
+
+  const auto templatedJ = geo.Jacobian( dNdXi ); // uses the templated Jacobian<2,4> internally
+
+  const Eigen::MatrixXd dynamicDNdXi = dNdXi;
+  const Eigen::VectorXd dynamicCoords( Eigen::Map< const Eigen::VectorXd >( nodeCoordsVec.data(), 8 ) );
+  const Eigen::MatrixXd dynamicJ = Marmot::FiniteElement::Jacobian( dynamicDNdXi, dynamicCoords );
+
+  throwExceptionOnFailure( checkIfEqual( dynamicJ, Eigen::MatrixXd( templatedJ ), 1e-12 ),
+                           "The dynamic Jacobian() must match the templated Jacobian<nDim,nNodes>() for the same "
+                           "input." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Quadrature::getGaussPointInfo() / getNumGaussPoints(): the branches actually reached by every
+// existing element and boundary test all use FullIntegration for Bar3/Tetra4/Tetra10 (or, for
+// Bar2/Quad4, never use ReducedIntegration) and never construct a Tetra4/Tetra10 element (there is
+// no registered element type using either shape) or pass an unsupported shape at all.
+// ---------------------------------------------------------------------------------------------
+
+void testGetGaussPointInfoReducedIntegrationBranches()
+{
+  using namespace Marmot::FiniteElement::Quadrature;
+
+  throwExceptionOnFailure( getGaussPointInfo( Bar2, ReducedIntegration ).size() == 1,
+                           "Bar2 reduced integration must use the 1-point rule." );
+  throwExceptionOnFailure( getGaussPointInfo( Bar3, ReducedIntegration ).size() == 2,
+                           "Bar3 reduced integration must use the 2-point rule." );
+  throwExceptionOnFailure( getGaussPointInfo( Quad4, ReducedIntegration ).size() == 1,
+                           "Quad4 reduced integration must use the 1x1-point rule." );
+}
+
+void testGetGaussPointInfoTetrahedralShapes()
+{
+  using namespace Marmot::FiniteElement::Quadrature;
+
+  // Tetra4/Tetra10 quadrature rules don't distinguish integration type; both calls must succeed
+  // and return a non-empty rule.
+  throwExceptionOnFailure( getGaussPointInfo( Tetra4, FullIntegration ).size() > 0,
+                           "Tetra4 must return a non-empty quadrature rule." );
+  throwExceptionOnFailure( getGaussPointInfo( Tetra10, ReducedIntegration ).size() > 0,
+                           "Tetra10 must return a non-empty quadrature rule." );
+}
+
+void testGetGaussPointInfoThrowsForUnsupportedShape()
+{
+  using namespace Marmot::FiniteElement::Quadrature;
+
+  bool threw = false;
+  try {
+    getGaussPointInfo( Quad9, FullIntegration );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "getGaussPointInfo() must throw for an unsupported shape (Quad9)." );
+}
+
+void testGetNumGaussPointsMatchesGaussPointInfoSize()
+{
+  using namespace Marmot::FiniteElement::Quadrature;
+
+  throwExceptionOnFailure( getNumGaussPoints( Hexa8, FullIntegration ) ==
+                             static_cast< int >( getGaussPointInfo( Hexa8, FullIntegration ).size() ),
+                           "getNumGaussPoints() must match getGaussPointInfo().size()." );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testGetElementShapeByMetricAllValidCombinations,
+    testGetElementShapeByMetricThrowsForInvalidCombinations,
+    testDynamicNBMatchesTemplatedNBForQuad4,
+    testDynamicJacobianMatchesTemplatedJacobianForQuad4,
+    testGetGaussPointInfoReducedIntegrationBranches,
+    testGetGaussPointInfoTetrahedralShapes,
+    testGetGaussPointInfoThrowsForUnsupportedShape,
+    testGetNumGaussPointsMatchesGaussPointInfoSize,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementBoundary.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementBoundary.cpp
@@ -1,0 +1,498 @@
+#include "Marmot/MarmotFiniteElement.h"
+#include "Marmot/MarmotTesting.h"
+#include <Eigen/Dense>
+#include <cmath>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::FiniteElement;
+
+// ---------------------------------------------------------------------------------------------
+// BoundaryElement has no public accessors for its (private) condensed boundary coordinates or its
+// parent<->boundary index maps, so the tests below never rely on them directly. Instead, expected
+// values are derived independently from the KNOWN parent element geometry (a unit square / unit
+// cube) and cross-checked against what assembleIntoParent*() actually writes into a parent-sized
+// vector -- which is the same public interface every element in this codebase uses.
+// ---------------------------------------------------------------------------------------------
+
+namespace {
+
+  const std::vector< double > unitSquareCoords = { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 };
+
+  const std::vector< double > unitCubeCoords = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+                                                 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+
+  // Assembles a boundary-sized vectorial quantity into a zeroed parent-sized vector and reports
+  // which parent nodes ended up with a nonzero entry (i.e., which nodes lie on this face).
+  struct AssembledVectorial {
+    Eigen::VectorXd    parentVector;
+    std::vector< int > activeNodes;
+  };
+
+  AssembledVectorial assembleVectorial( const Eigen::VectorXd& boundaryVector,
+                                        BoundaryElement&       boundaryEl,
+                                        int                    nNodesParent,
+                                        int                    nDim )
+  {
+    AssembledVectorial result;
+    result.parentVector = Eigen::VectorXd::Zero( nNodesParent * nDim );
+    boundaryEl.assembleIntoParentVectorial( boundaryVector, result.parentVector );
+
+    for ( int n = 0; n < nNodesParent; n++ ) {
+      bool nonzero = false;
+      for ( int d = 0; d < nDim; d++ )
+        if ( std::abs( result.parentVector( n * nDim + d ) ) > 1e-10 )
+          nonzero = true;
+      if ( nonzero )
+        result.activeNodes.push_back( n );
+    }
+    return result;
+  }
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------------------------
+
+void testConstructorThrowsForUnsupportedParentShape()
+{
+  const Eigen::VectorXd coords = Eigen::VectorXd::Zero( 12 ); // Tetra4: 4 nodes * 3 dim
+
+  bool threw = false;
+  try {
+    BoundaryElement boundaryEl( Tetra4, 0, 3, coords );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "BoundaryElement must throw for an unsupported parent shape." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeScalarLoadVector(): integrates a unit scalar field, so its total (summed via
+// assembleIntoParentScalar) must equal the physical length/area of the face, by partition of
+// unity (sum_i N_i = 1 everywhere).
+// ---------------------------------------------------------------------------------------------
+
+void testComputeScalarLoadVectorIntegratesToFaceLengthQuad4()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+
+  for ( int face = 1; face <= 4; face++ ) {
+    BoundaryElement       boundaryEl( Quad4, face, 2, parentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeScalarLoadVector();
+
+    Eigen::VectorXd parentScalar = Eigen::VectorXd::Zero( 4 ); // 4 parent nodes
+    boundaryEl.assembleIntoParentScalar( Pk, parentScalar );
+
+    throwExceptionOnFailure( checkIfEqual( parentScalar.sum(), 1.0, 1e-10 ),
+                             "computeScalarLoadVector() does not integrate to the unit square's edge "
+                             "length (face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+void testComputeScalarLoadVectorIntegratesToFaceAreaHexa8()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitCubeCoords.data(), 24 );
+
+  for ( int face = 1; face <= 6; face++ ) {
+    BoundaryElement       boundaryEl( Hexa8, face, 3, parentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeScalarLoadVector();
+
+    Eigen::VectorXd parentScalar = Eigen::VectorXd::Zero( 8 ); // 8 parent nodes
+    boundaryEl.assembleIntoParentScalar( Pk, parentScalar );
+
+    throwExceptionOnFailure( checkIfEqual( parentScalar.sum(), 1.0, 1e-10 ),
+                             "computeScalarLoadVector() does not integrate to the unit cube's face "
+                             "area (face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeVectorialLoadVector(): integrates a constant traction vector, so the resultant force
+// (summed per direction) must equal direction * face length/area.
+// ---------------------------------------------------------------------------------------------
+
+void testComputeVectorialLoadVectorIntegratesToDirectionTimesLengthQuad4()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  const Eigen::Vector2d                     direction( 2.0, -3.0 );
+
+  for ( int face = 1; face <= 4; face++ ) {
+    BoundaryElement       boundaryEl( Quad4, face, 2, parentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeVectorialLoadVector( direction );
+
+    const auto assembled = assembleVectorial( Pk, boundaryEl, 4, 2 );
+    throwExceptionOnFailure( assembled.activeNodes.size() == 2,
+                             "Exactly 2 parent nodes should lie on a Quad4 edge (face " + std::to_string( face ) +
+                               ")." );
+
+    Eigen::Vector2d resultant = Eigen::Vector2d::Zero();
+    for ( int n : assembled.activeNodes )
+      resultant += assembled.parentVector.segment< 2 >( n * 2 );
+
+    throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( resultant ), Eigen::MatrixXd( direction ), 1e-10 ),
+                             "computeVectorialLoadVector() resultant does not match direction * edge length "
+                             "(face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+void testComputeVectorialLoadVectorIntegratesToDirectionTimesAreaHexa8()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitCubeCoords.data(), 24 );
+  const Eigen::Vector3d                     direction( 1.0, 2.0, -1.5 );
+
+  for ( int face = 1; face <= 6; face++ ) {
+    BoundaryElement       boundaryEl( Hexa8, face, 3, parentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeVectorialLoadVector( direction );
+
+    const auto assembled = assembleVectorial( Pk, boundaryEl, 8, 3 );
+    throwExceptionOnFailure( assembled.activeNodes.size() == 4,
+                             "Exactly 4 parent nodes should lie on a Hexa8 face (face " + std::to_string( face ) +
+                               ")." );
+
+    Eigen::Vector3d resultant = Eigen::Vector3d::Zero();
+    for ( int n : assembled.activeNodes )
+      resultant += assembled.parentVector.segment< 3 >( n * 3 );
+
+    throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( resultant ), Eigen::MatrixXd( direction ), 1e-10 ),
+                             "computeVectorialLoadVector() resultant does not match direction * face area "
+                             "(face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeSurfaceNormalVectorialLoadVector(): the resultant must point along the OUTWARD normal
+// (determined independently here from which way the face centroid lies relative to the parent
+// element's centroid) with magnitude equal to the face length/area.
+// ---------------------------------------------------------------------------------------------
+
+void testComputeSurfaceNormalVectorialLoadVectorPointsOutwardQuad4()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  const Eigen::Vector2d                     parentCentroid( 0.5, 0.5 );
+
+  for ( int face = 1; face <= 4; face++ ) {
+    BoundaryElement       boundaryEl( Quad4, face, 2, parentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeSurfaceNormalVectorialLoadVector();
+
+    const auto assembled = assembleVectorial( Pk, boundaryEl, 4, 2 );
+    throwExceptionOnFailure( assembled.activeNodes.size() == 2,
+                             "Exactly 2 parent nodes should lie on a Quad4 edge (face " + std::to_string( face ) +
+                               ")." );
+
+    const Eigen::Vector2d P0( unitSquareCoords[assembled.activeNodes[0] * 2],
+                              unitSquareCoords[assembled.activeNodes[0] * 2 + 1] );
+    const Eigen::Vector2d P1( unitSquareCoords[assembled.activeNodes[1] * 2],
+                              unitSquareCoords[assembled.activeNodes[1] * 2 + 1] );
+
+    const Eigen::Vector2d tangent      = P1 - P0;
+    const double          edgeLength   = tangent.norm();
+    Eigen::Vector2d       candidate    = Eigen::Vector2d( tangent( 1 ), -tangent( 0 ) ).normalized();
+    const Eigen::Vector2d edgeMidpoint = 0.5 * ( P0 + P1 );
+    if ( ( edgeMidpoint - parentCentroid ).dot( candidate ) < 0.0 )
+      candidate = -candidate;
+
+    const Eigen::Vector2d expected = candidate * edgeLength;
+
+    Eigen::Vector2d resultant = Eigen::Vector2d::Zero();
+    for ( int n : assembled.activeNodes )
+      resultant += assembled.parentVector.segment< 2 >( n * 2 );
+
+    throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( resultant ), Eigen::MatrixXd( expected ), 1e-10 ),
+                             "computeSurfaceNormalVectorialLoadVector() does not point along the outward "
+                             "normal with the correct magnitude (face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+void testComputeSurfaceNormalVectorialLoadVectorPointsOutwardHexa8()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitCubeCoords.data(), 24 );
+  const Eigen::Vector3d                     parentCentroid( 0.5, 0.5, 0.5 );
+
+  for ( int face = 1; face <= 6; face++ ) {
+    BoundaryElement       boundaryEl( Hexa8, face, 3, parentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeSurfaceNormalVectorialLoadVector();
+
+    const auto assembled = assembleVectorial( Pk, boundaryEl, 8, 3 );
+    throwExceptionOnFailure( assembled.activeNodes.size() == 4,
+                             "Exactly 4 parent nodes should lie on a Hexa8 face (face " + std::to_string( face ) +
+                               ")." );
+
+    std::vector< Eigen::Vector3d > corners;
+    for ( int n : assembled.activeNodes )
+      corners.emplace_back( unitCubeCoords[n * 3], unitCubeCoords[n * 3 + 1], unitCubeCoords[n * 3 + 2] );
+
+    Eigen::Vector3d       candidate    = ( corners[1] - corners[0] ).cross( corners[2] - corners[0] ).normalized();
+    const Eigen::Vector3d faceCentroid = 0.25 * ( corners[0] + corners[1] + corners[2] + corners[3] );
+    if ( ( faceCentroid - parentCentroid ).dot( candidate ) < 0.0 )
+      candidate = -candidate;
+
+    const double          unitCubeFaceArea = 1.0;
+    const Eigen::Vector3d expected         = candidate * unitCubeFaceArea;
+
+    Eigen::Vector3d resultant = Eigen::Vector3d::Zero();
+    for ( int n : assembled.activeNodes )
+      resultant += assembled.parentVector.segment< 3 >( n * 3 );
+
+    throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( resultant ), Eigen::MatrixXd( expected ), 1e-10 ),
+                             "computeSurfaceNormalVectorialLoadVector() does not point along the outward "
+                             "normal with the correct magnitude (face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeSurfaceNormalVectorialLoadVectorForAxisymmetricElements(): for a face at CONSTANT radial
+// coordinate r (so the 2*pi*r factor is the same at every quadrature point), the result must be
+// exactly the plain surface-normal load scaled by 2*pi*r.
+// ---------------------------------------------------------------------------------------------
+
+void testComputeSurfaceNormalVectorialLoadVectorForAxisymmetricElementsScalesByTwoPiR()
+{
+  // A square with r in [1, 2], z in [0, 1]: face 1 (r=1 -> r=2 at z=0, from the node ordering
+  // below) is not constant-r, but the LEFT edge (nodes 3-0, r=1) and RIGHT edge (nodes 1-2, r=2)
+  // are. We scan all faces and only assert on the ones with constant r.
+  const std::vector< double >               coordsVec = { 1.0, 0.0, 2.0, 0.0, 2.0, 1.0, 1.0, 1.0 };
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( coordsVec.data(), 8 );
+
+  bool checkedAtLeastOneFace = false;
+
+  for ( int face = 1; face <= 4; face++ ) {
+    BoundaryElement       boundaryEl( Quad4, face, 2, parentCoords );
+    const Eigen::VectorXd plain        = boundaryEl.computeSurfaceNormalVectorialLoadVector();
+    const Eigen::VectorXd axisymmetric = boundaryEl.computeSurfaceNormalVectorialLoadVectorForAxisymmetricElements();
+
+    const auto   assembled = assembleVectorial( plain, boundaryEl, 4, 2 );
+    const double r0        = coordsVec[assembled.activeNodes[0] * 2];
+    const double r1        = coordsVec[assembled.activeNodes[1] * 2];
+
+    if ( std::abs( r0 - r1 ) > 1e-12 )
+      continue; // r varies along this face; the simple scaling relation does not hold here
+
+    checkedAtLeastOneFace = true;
+    const double factor   = 2.0 * Constants::Pi * r0;
+    throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( axisymmetric ), Eigen::MatrixXd( factor * plain ), 1e-8 ),
+                             "computeSurfaceNormalVectorialLoadVectorForAxisymmetricElements() does not equal "
+                             "2*pi*r times the plain surface-normal load for a constant-r face." );
+  }
+
+  throwExceptionOnFailure( checkedAtLeastOneFace, "Test setup error: no constant-r face was found to check." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Quad8 / Hexa20: exercise the remaining constructor branches. Only the partition-of-unity total
+// is checked here (no corner-geometry assumptions), since these boundary shapes carry midside
+// nodes.
+// ---------------------------------------------------------------------------------------------
+
+void testQuad8AndHexa20BoundariesIntegrateToFaceLengthAndArea()
+{
+  // Quad8: unit square with midside nodes at exact edge midpoints.
+  const std::vector< double > quad8Coords =
+    { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.5, 0.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0.5 };
+  const Eigen::Map< const Eigen::VectorXd > quad8ParentCoords( quad8Coords.data(), 16 );
+
+  for ( int face = 1; face <= 4; face++ ) {
+    BoundaryElement       boundaryEl( Quad8, face, 2, quad8ParentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeScalarLoadVector();
+
+    Eigen::VectorXd parentScalar = Eigen::VectorXd::Zero( 8 );
+    boundaryEl.assembleIntoParentScalar( Pk, parentScalar );
+
+    throwExceptionOnFailure( checkIfEqual( parentScalar.sum(), 1.0, 1e-10 ),
+                             "Quad8 boundary computeScalarLoadVector() does not integrate to the edge length "
+                             "(face " +
+                               std::to_string( face ) + ")." );
+  }
+
+  // Hexa20: unit cube with edge-midside nodes at exact midpoints.
+  const std::vector< double > hexa20Coords = {
+    0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, // bottom corners
+    0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, // top corners
+    0.5, 0.0, 0.0, 1.0, 0.5, 0.0, 0.5, 1.0, 0.0, 0.0, 0.5, 0.0, // bottom-face edge midsides
+    0.5, 0.0, 1.0, 1.0, 0.5, 1.0, 0.5, 1.0, 1.0, 0.0, 0.5, 1.0, // top-face edge midsides
+    0.0, 0.0, 0.5, 1.0, 0.0, 0.5, 1.0, 1.0, 0.5, 0.0, 1.0, 0.5  // vertical edge midsides
+  };
+  const Eigen::Map< const Eigen::VectorXd > hexa20ParentCoords( hexa20Coords.data(), 60 );
+
+  for ( int face = 1; face <= 6; face++ ) {
+    BoundaryElement       boundaryEl( Hexa20, face, 3, hexa20ParentCoords );
+    const Eigen::VectorXd Pk = boundaryEl.computeScalarLoadVector();
+
+    Eigen::VectorXd parentScalar = Eigen::VectorXd::Zero( 20 );
+    boundaryEl.assembleIntoParentScalar( Pk, parentScalar );
+
+    throwExceptionOnFailure( checkIfEqual( parentScalar.sum(), 1.0, 1e-10 ),
+                             "Hexa20 boundary computeScalarLoadVector() does not integrate to the face area "
+                             "(face " +
+                               std::to_string( face ) + ")." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Not-yet-implemented derivative methods
+// ---------------------------------------------------------------------------------------------
+
+void testComputeDScalarLoadVectorThrowsNotImplemented()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  BoundaryElement                           boundaryEl( Quad4, 1, 2, parentCoords );
+
+  bool threw = false;
+  try {
+    boundaryEl.computeDScalarLoadVector_dCoordinates();
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "computeDScalarLoadVector_dCoordinates() must throw (not yet implemented)." );
+}
+
+void testComputeDVectorialLoadVectorThrowsNotImplemented()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  BoundaryElement                           boundaryEl( Quad4, 1, 2, parentCoords );
+
+  bool threw = false;
+  try {
+    boundaryEl.computeDVectorialLoadVector_dCoordinates( Eigen::Vector2d( 1.0, 0.0 ) );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "computeDVectorialLoadVector_dCoordinates() must throw (not yet implemented)." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeDSurfaceNormalVectorialLoadVector_dCoordinates(): smoke test only. The analytic
+// derivative is with respect to the boundary element's OWN (private, condensed) coordinate
+// vector, which cannot be perturbed independently from outside without knowing the parent<->
+// boundary index map, so a full numerical-differentiation cross-check is not attempted here --
+// this only confirms the 2D and 3D branches run and return a finite, correctly-sized matrix.
+// ---------------------------------------------------------------------------------------------
+
+void testComputeDSurfaceNormalVectorialLoadVectorDCoordinatesReturnsFiniteMatrix()
+{
+  {
+    const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+    BoundaryElement                           boundaryEl( Quad4, 1, 2, parentCoords );
+    const Eigen::MatrixXd                     K = boundaryEl.computeDSurfaceNormalVectorialLoadVector_dCoordinates();
+    throwExceptionOnFailure( K.rows() == 4 && K.cols() == 4,
+                             "computeDSurfaceNormalVectorialLoadVector_dCoordinates() (2D) has the wrong size." );
+    throwExceptionOnFailure( K.allFinite(),
+                             "computeDSurfaceNormalVectorialLoadVector_dCoordinates() (2D) returned a "
+                             "non-finite value." );
+  }
+  {
+    const Eigen::Map< const Eigen::VectorXd > parentCoords( unitCubeCoords.data(), 24 );
+    BoundaryElement                           boundaryEl( Hexa8, 1, 3, parentCoords );
+    const Eigen::MatrixXd                     K = boundaryEl.computeDSurfaceNormalVectorialLoadVector_dCoordinates();
+    throwExceptionOnFailure( K.rows() == 12 && K.cols() == 12,
+                             "computeDSurfaceNormalVectorialLoadVector_dCoordinates() (3D) has the wrong size." );
+    throwExceptionOnFailure( K.allFinite(),
+                             "computeDSurfaceNormalVectorialLoadVector_dCoordinates() (3D) returned a "
+                             "non-finite value." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// condense*/assemble* round trips
+// ---------------------------------------------------------------------------------------------
+
+void testCondenseAndAssembleVectorialRoundTrip()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  BoundaryElement                           boundaryEl( Quad4, 1, 2, parentCoords );
+
+  const Eigen::VectorXd boundaryCoords = boundaryEl.condenseParentToBoundaryVectorial( parentCoords );
+
+  Eigen::VectorXd reconstructed = Eigen::VectorXd::Zero( 8 );
+  boundaryEl.assembleIntoParentVectorial( boundaryCoords, reconstructed );
+
+  // Every reconstructed entry that is nonzero must match the original coordinate exactly, since
+  // condense() extracted it verbatim from the same vector.
+  for ( int i = 0; i < 8; i++ )
+    if ( std::abs( reconstructed( i ) ) > 1e-12 )
+      throwExceptionOnFailure( checkIfEqual( reconstructed( i ), parentCoords( i ), 1e-12 ),
+                               "condenseParentToBoundaryVectorial()/assembleIntoParentVectorial() round trip "
+                               "does not reproduce the original coordinate." );
+}
+
+void testCondenseAndAssembleScalarRoundTrip()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  BoundaryElement                           boundaryEl( Quad4, 1, 2, parentCoords );
+
+  // An arbitrary per-node scalar field on the 4 parent nodes.
+  Eigen::VectorXd parentScalarField( 4 );
+  parentScalarField << 10.0, 20.0, 30.0, 40.0;
+
+  const Eigen::VectorXd boundaryScalar = boundaryEl.condenseParentToBoundaryScalar( parentScalarField );
+
+  Eigen::VectorXd reconstructed = Eigen::VectorXd::Zero( 4 );
+  boundaryEl.assembleIntoParentScalar( boundaryScalar, reconstructed );
+
+  for ( int i = 0; i < 4; i++ )
+    if ( std::abs( reconstructed( i ) ) > 1e-12 )
+      throwExceptionOnFailure( checkIfEqual( reconstructed( i ), parentScalarField( i ), 1e-12 ),
+                               "condenseParentToBoundaryScalar()/assembleIntoParentScalar() round trip does "
+                               "not reproduce the original scalar value." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// assembleIntoParentStiffness{Scalar,Vectorial}(): the assembly negates the boundary matrix (see
+// the "mind the negative sign" comment in the implementation).
+// ---------------------------------------------------------------------------------------------
+
+void testAssembleIntoParentStiffnessVectorialAppliesNegativeSign()
+{
+  const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+  BoundaryElement                           boundaryEl( Quad4, 1, 2, parentCoords );
+
+  const Eigen::VectorXd boundaryCoords = boundaryEl.condenseParentToBoundaryVectorial( parentCoords );
+  const int             nBoundaryDof   = static_cast< int >( boundaryCoords.size() );
+
+  const Eigen::MatrixXd KBoundary = Eigen::MatrixXd::Identity( nBoundaryDof, nBoundaryDof );
+  Eigen::MatrixXd       KParent   = Eigen::MatrixXd::Zero( 8, 8 );
+  boundaryEl.assembleIntoParentStiffnessVectorial( KBoundary, KParent );
+
+  // The trace over the (unknown) mapped block must equal -trace(KBoundary), regardless of the
+  // exact index mapping, since assembly only ever touches diagonal-preserving (i,i)->(map(i),map(i))
+  // entries for an identity input.
+  throwExceptionOnFailure( checkIfEqual( KParent.trace(), -KBoundary.trace(), 1e-12 ),
+                           "assembleIntoParentStiffnessVectorial() does not apply the documented negative "
+                           "sign." );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testConstructorThrowsForUnsupportedParentShape,
+    testComputeScalarLoadVectorIntegratesToFaceLengthQuad4,
+    testComputeScalarLoadVectorIntegratesToFaceAreaHexa8,
+    testComputeVectorialLoadVectorIntegratesToDirectionTimesLengthQuad4,
+    testComputeVectorialLoadVectorIntegratesToDirectionTimesAreaHexa8,
+    testComputeSurfaceNormalVectorialLoadVectorPointsOutwardQuad4,
+    testComputeSurfaceNormalVectorialLoadVectorPointsOutwardHexa8,
+    testComputeSurfaceNormalVectorialLoadVectorForAxisymmetricElementsScalesByTwoPiR,
+    testQuad8AndHexa20BoundariesIntegrateToFaceLengthAndArea,
+    testComputeDScalarLoadVectorThrowsNotImplemented,
+    testComputeDVectorialLoadVectorThrowsNotImplemented,
+    testComputeDSurfaceNormalVectorialLoadVectorDCoordinatesReturnsFiniteMatrix,
+    testCondenseAndAssembleVectorialRoundTrip,
+    testCondenseAndAssembleScalarRoundTrip,
+    testAssembleIntoParentStiffnessVectorialAppliesNegativeSign,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementBoundary.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementBoundary.cpp
@@ -70,6 +70,37 @@ void testConstructorThrowsForUnsupportedParentShape()
   throwExceptionOnFailure( threw, "BoundaryElement must throw for an unsupported parent shape." );
 }
 
+void testConstructorThrowsForOutOfRangeFaceIdOnSupportedParentShapes()
+{
+  // Quad4/Quad8 faces are 1..4; Hexa8/Hexa20 faces are 1..6. Face 99 is out of range for all of
+  // them, and each shape's own getBoundaryElementIndices() throws independently of the other
+  // (unrelated to the parent-shape switch tested above).
+  {
+    const Eigen::Map< const Eigen::VectorXd > parentCoords( unitSquareCoords.data(), 8 );
+    bool                                      threw = false;
+    try {
+      BoundaryElement boundaryEl( Quad4, 99, 2, parentCoords );
+    }
+    catch ( const std::invalid_argument& ) {
+      threw = true;
+    }
+    throwExceptionOnFailure( threw, "BoundaryElement must throw for an out-of-range Quad4 face ID." );
+  }
+  {
+    const std::vector< double > quad8Coords =
+      { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.5, 0.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0.5 };
+    const Eigen::Map< const Eigen::VectorXd > parentCoords( quad8Coords.data(), 16 );
+    bool                                      threw = false;
+    try {
+      BoundaryElement boundaryEl( Quad8, 99, 2, parentCoords );
+    }
+    catch ( const std::invalid_argument& ) {
+      threw = true;
+    }
+    throwExceptionOnFailure( threw, "BoundaryElement must throw for an out-of-range Quad8 face ID." );
+  }
+}
+
 // ---------------------------------------------------------------------------------------------
 // computeScalarLoadVector(): integrates a unit scalar field, so its total (summed via
 // assembleIntoParentScalar) must equal the physical length/area of the face, by partition of
@@ -476,6 +507,7 @@ int main()
 {
   auto tests = std::vector< std::function< void() > >{
     testConstructorThrowsForUnsupportedParentShape,
+    testConstructorThrowsForOutOfRangeFaceIdOnSupportedParentShapes,
     testComputeScalarLoadVectorIntegratesToFaceLengthQuad4,
     testComputeScalarLoadVectorIntegratesToFaceAreaHexa8,
     testComputeVectorialLoadVectorIntegratesToDirectionTimesLengthQuad4,

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementSpatialWrapper.cpp
@@ -320,7 +320,10 @@ void testGetStateViewReturnsTransformationMatrixAndDelegatesOtherwise()
 
 void testGetCoordinatesAtCenterMatchesChildCoordinatesInAmbientSpace()
 {
-  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 }; // length-5 truss
+  // Truss from (2,1) to (5,5): same 3-4-5 geometry as a truss from the origin, but translated away
+  // from it, so a fix that only re-applies the rotation (and drops the translation) would still
+  // pass a truss-through-the-origin test while failing here.
+  const std::vector< double > nodeCoordsVec = { 2.0, 1.0, 5.0, 5.0 }; // length-5 truss
   const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
   std::vector< double >       stateVars;
 
@@ -328,16 +331,17 @@ void testGetCoordinatesAtCenterMatchesChildCoordinatesInAmbientSpace()
 
   const auto center = wrapper->getCoordinatesAtCenter();
 
-  // The truss midpoint in ambient space is the average of its two endpoints: (1.5, 2.0).
+  // The truss midpoint in ambient space is the average of its two endpoints: (3.5, 3.0).
   throwExceptionOnFailure( static_cast< int >( center.size() ) == 2,
                            "getCoordinatesAtCenter() returned the wrong dimension." );
-  throwExceptionOnFailure( checkIfEqual( center[0], 1.5, 1e-10 ) && checkIfEqual( center[1], 2.0, 1e-10 ),
+  throwExceptionOnFailure( checkIfEqual( center[0], 3.5, 1e-10 ) && checkIfEqual( center[1], 3.0, 1e-10 ),
                            "getCoordinatesAtCenter() does not return the truss midpoint in ambient space." );
 }
 
 void testGetCoordinatesAtQuadraturePointsMatchesChildCoordinatesInAmbientSpace()
 {
-  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  // Same translated-away-from-the-origin truss as above, for the same reason.
+  const std::vector< double > nodeCoordsVec = { 2.0, 1.0, 5.0, 5.0 };
   const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
   std::vector< double >       stateVars;
 
@@ -350,11 +354,11 @@ void testGetCoordinatesAtQuadraturePointsMatchesChildCoordinatesInAmbientSpace()
   for ( const auto& coords : qpCoords ) {
     throwExceptionOnFailure( static_cast< int >( coords.size() ) == 2,
                              "getCoordinatesAtQuadraturePoints() returned the wrong dimension." );
-    // Every quadrature point must lie exactly on the line from (0,0) to (3,4), i.e. y/x = 4/3
-    // (equivalently 4*x - 3*y == 0), and within the segment's bounding box.
-    throwExceptionOnFailure( checkIfEqual( 4.0 * coords[0] - 3.0 * coords[1], 0.0, 1e-8 ),
+    // Every quadrature point must lie exactly on the line from (2,1) to (5,5), i.e.
+    // 4*(x-2) == 3*(y-1) (equivalently 4*x - 3*y - 5 == 0), and within the segment's bounding box.
+    throwExceptionOnFailure( checkIfEqual( 4.0 * coords[0] - 3.0 * coords[1] - 5.0, 0.0, 1e-8 ),
                              "getCoordinatesAtQuadraturePoints() point does not lie on the truss axis." );
-    throwExceptionOnFailure( coords[0] >= -1e-8 && coords[0] <= 3.0 + 1e-8,
+    throwExceptionOnFailure( coords[0] >= 2.0 - 1e-8 && coords[0] <= 5.0 + 1e-8,
                              "getCoordinatesAtQuadraturePoints() point lies outside the truss segment." );
   }
 }

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementSpatialWrapper.cpp
@@ -394,6 +394,67 @@ void testComputeDistributedLoadDelegatesAndThrowsForUnsupported1DChild()
                            "child has no boundary-element support)." );
 }
 
+// ---------------------------------------------------------------------------------------------
+// MarmotElementSpatialWrapper does not override computeLumpedInertia(), computeConsistentInertia(),
+// computeCriticalTimeStepForExplicitDynamics(), or computeInternalEnergy(), so calling any of them
+// falls through to MarmotElement's default (throwing) implementation -- otherwise untested,
+// since every OTHER element in this codebase does override all four.
+// ---------------------------------------------------------------------------------------------
+
+void testUnoverriddenOptionalMethodsFallBackToBaseClassDefaults()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const int nDof = wrapper->getNDofPerElement();
+
+  bool threw = false;
+  try {
+    std::vector< double > M( nDof, 0.0 );
+    wrapper->computeLumpedInertia( M.data() );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "computeLumpedInertia() must fall back to the base class default (throwing)." );
+
+  threw = false;
+  try {
+    std::vector< double > M( nDof * nDof, 0.0 );
+    wrapper->computeConsistentInertia( M.data() );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "computeConsistentInertia() must fall back to the base class default (throwing)." );
+
+  threw = false;
+  try {
+    double                      criticalTimeStep = 0.0;
+    const std::vector< double > QTotal( nDof, 0.0 );
+    wrapper->computeCriticalTimeStepForExplicitDynamics( criticalTimeStep, QTotal.data() );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computeCriticalTimeStepForExplicitDynamics() must fall back to the base class "
+                           "default (throwing)." );
+
+  threw = false;
+  try {
+    double internalEnergy = 0.0;
+    wrapper->computeInternalEnergy( internalEnergy );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "computeInternalEnergy() must fall back to the base class default (throwing)." );
+}
+
 int main()
 {
   auto tests = std::vector< std::function< void() > >{
@@ -408,6 +469,7 @@ int main()
     testGetCoordinatesAtCenterMatchesChildCoordinatesInAmbientSpace,
     testGetCoordinatesAtQuadraturePointsMatchesChildCoordinatesInAmbientSpace,
     testComputeDistributedLoadDelegatesAndThrowsForUnsupported1DChild,
+    testUnoverriddenOptionalMethodsFallBackToBaseClassDefaults,
   };
 
   executeTestsAndCollectExceptions( tests );

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementSpatialWrapper.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotFiniteElementSpatialWrapper.cpp
@@ -1,0 +1,416 @@
+#include "Marmot/DisplacementFiniteElement.h"
+#include "Marmot/MarmotElementProperty.h"
+#include "Marmot/MarmotFiniteElement.h"
+#include "Marmot/MarmotFiniteElementSpatialWrapper.h"
+#include "Marmot/MarmotNumericalDifferentiation.h"
+#include "Marmot/MarmotTesting.h"
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+
+using namespace Marmot;
+using namespace Marmot::Elements;
+using namespace Marmot::Testing;
+namespace NumDiff = Marmot::NumericalAlgorithms::Differentiation;
+
+// ---------------------------------------------------------------------------------------------
+// All tests below embed a 2-node 1D truss (DisplacementFiniteElement<1,2>, UniaxialStress) into
+// 2D ambient space, exactly matching the production "T2D2" element registered in
+// DisplacementFiniteElementRegistration.cpp: MarmotElementSpatialWrapper(nDim=2, nDimChild=1,
+// nNodes=2, nRhsChild=2, rhsIndicesToBeWrapped={0,1}, nIndicesToBeWrapped=2, child).
+// ---------------------------------------------------------------------------------------------
+
+namespace {
+
+  std::unique_ptr< MarmotElementSpatialWrapper > makeT2D2( const std::vector< double >& nodeCoordsVec,
+                                                           const std::vector< double >& matProps,
+                                                           std::vector< double >&       stateVarsOut )
+  {
+    auto child = std::make_unique<
+      DisplacementFiniteElement< 1, 2 > >( 1,
+                                           FiniteElement::Quadrature::IntegrationTypes::FullIntegration,
+                                           DisplacementFiniteElement< 1, 2 >::SectionType::UniaxialStress );
+
+    static constexpr int indicesToBeWrapped[] = { 0, 1 };
+
+    auto wrapper = std::make_unique< MarmotElementSpatialWrapper >( 2,
+                                                                    1,
+                                                                    2,
+                                                                    2,
+                                                                    indicesToBeWrapped,
+                                                                    2,
+                                                                    std::move( child ) );
+
+    wrapper->assignNodeCoordinates( nodeCoordsVec.data() );
+
+    MarmotMaterialSection materialSection( "LINEARELASTIC", matProps.data(), matProps.size() );
+    // assignProperty(ElementProperties&) stores a zero-copy view into this array (see
+    // DisplacementFiniteElement::assignProperty), so it must outlive the element; `static`
+    // gives it program lifetime rather than dangling once this factory function returns.
+    static const std::vector< double > elPropsVec = { 1.0 }; // cross-section area
+    ElementProperties                  elProps( elPropsVec.data(), elPropsVec.size() );
+    wrapper->assignProperty( elProps );
+    wrapper->assignProperty( materialSection );
+
+    const int nStateVarsTotal = wrapper->getNumberOfRequiredStateVars();
+    stateVarsOut.assign( nStateVarsTotal, 0.0 );
+    wrapper->assignStateVars( stateVarsOut.data(), nStateVarsTotal );
+    wrapper->initializeYourself();
+
+    return wrapper;
+  }
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// Simple pass-through accessors
+// ---------------------------------------------------------------------------------------------
+
+void testBasicAccessorsDelegateToChild()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 }; // length-5 truss
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  throwExceptionOnFailure( wrapper->getNNodes() == 2, "getNNodes() must delegate to the wrapper's own nNodes." );
+  throwExceptionOnFailure( wrapper->getNSpatialDimensions() == 2,
+                           "getNSpatialDimensions() must return the ambient dimension." );
+  throwExceptionOnFailure( wrapper->getNDofPerElement() == 4,
+                           "getNDofPerElement() must return the ambient (unprojected) DOF count." );
+  throwExceptionOnFailure( wrapper->getElementShape() == "bar2", "getElementShape() must delegate to the child." );
+  throwExceptionOnFailure( wrapper->getNumberOfQuadraturePoints() > 0,
+                           "getNumberOfQuadraturePoints() must delegate to the child." );
+
+  const auto nodeFields = wrapper->getNodeFields();
+  throwExceptionOnFailure( static_cast< int >( nodeFields.size() ) == 2,
+                           "getNodeFields() must delegate to the child." );
+
+  throwExceptionOnFailure( wrapper->getPropertyNames().empty(),
+                           "getPropertyNames() must delegate to the child (empty by default)." );
+
+  bool threw = false;
+  try {
+    const double dummy = 1.0;
+    wrapper->assignProperty( "nonexistent property", &dummy );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "assignProperty(name, ...) must delegate to the child and throw." );
+}
+
+void testDofIndicesPermutationPatternExpandsChildPattern()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const auto pattern = wrapper->getDofIndicesPermutationPattern();
+  throwExceptionOnFailure( static_cast< int >( pattern.size() ) == 4,
+                           "getDofIndicesPermutationPattern() must have one entry per ambient DOF." );
+
+  // Every projected (both, here) child DOF expands into nDim=2 consecutive ambient entries; the
+  // pattern must at least be a valid permutation of 0..3 (no repeats, all indices in range).
+  std::vector< int > sorted = pattern;
+  std::sort( sorted.begin(), sorted.end() );
+  for ( int i = 0; i < 4; i++ )
+    throwExceptionOnFailure( sorted[i] == i, "getDofIndicesPermutationPattern() must be a permutation of 0..nDof-1." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeKernels(): tangent consistency, using the same "reset quadrature-point state, apply the
+// full vector as dQ=Q from a zero baseline" convention as the incremental hypoelastic child
+// element itself requires (see TestDisplacementFiniteElement.cpp).
+// ---------------------------------------------------------------------------------------------
+
+void testComputeKernelsTangentMatchesNumericalDifferentiation()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const int  nDof       = wrapper->getNDofPerElement();
+  const auto resetState = [&]() { std::fill( stateVars.begin(), stateVars.end(), 0.0 ); };
+
+  Eigen::VectorXd Q0( nDof );
+  for ( int i = 0; i < nDof; i++ )
+    Q0[i] = 0.01 * std::sin( 1.3 * ( i + 1 ) );
+
+  resetState();
+  Eigen::VectorXd P( nDof );
+  Eigen::MatrixXd K( nDof, nDof );
+  P.setZero();
+  K.setZero();
+  wrapper->computeKernels( Q0.data(), Q0.data(), P.data(), K.data(), 0.0, 1.0 );
+
+  NumDiff::vector_to_vector_function_type residual = [&]( const Eigen::VectorXd& Q ) -> Eigen::VectorXd {
+    resetState();
+    Eigen::VectorXd Ptmp( nDof );
+    Eigen::MatrixXd Ktmp( nDof, nDof );
+    Ptmp.setZero();
+    Ktmp.setZero();
+    wrapper->computeKernels( Q.data(), Q.data(), Ptmp.data(), Ktmp.data(), 0.0, 1.0 );
+    return Ptmp;
+  };
+
+  const Eigen::MatrixXd numK = NumDiff::centralDifference( residual, Q0 );
+
+  throwExceptionOnFailure( checkIfEqual( K, numK, 1e-6 ),
+                           "MarmotElementSpatialWrapper::computeKernels() stiffness matrix does not match "
+                           "the numerical tangent." );
+}
+
+void testComputeKernelsMatchesAnalyticAxialStiffnessForAxisAlignedTruss()
+{
+  // A truss along the x-axis reduces to a textbook 1D bar: K = EA/L * [[1,-1],[-1,1]] in the
+  // AXIAL direction, and zero stiffness transverse to it (since UniaxialStress ignores lateral
+  // displacement entirely).
+  constexpr double            length        = 2.0;
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, length, 0.0 };
+  constexpr double            E = 10000.0, A = 1.0;
+  const std::vector< double > matProps = { E, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const int                   nDof = wrapper->getNDofPerElement();
+  const std::vector< double > Q( nDof, 0.0 );
+  std::vector< double >       P( nDof, 0.0 );
+  std::vector< double >       K( nDof * nDof, 0.0 );
+  wrapper->computeKernels( Q.data(), Q.data(), P.data(), K.data(), 0.0, 1.0 );
+
+  Eigen::Map< Eigen::MatrixXd > Kmat( K.data(), nDof, nDof );
+
+  const double axialStiffness = E * A / length;
+  // DOF layout: [node0_x, node0_y, node1_x, node1_y]
+  throwExceptionOnFailure( checkIfEqual( Kmat( 0, 0 ), axialStiffness, 1e-6 ),
+                           "Axial stiffness K(0,0) does not match EA/L for an axis-aligned truss." );
+  throwExceptionOnFailure( checkIfEqual( Kmat( 2, 2 ), axialStiffness, 1e-6 ),
+                           "Axial stiffness K(2,2) does not match EA/L for an axis-aligned truss." );
+  throwExceptionOnFailure( checkIfEqual( Kmat( 0, 2 ), -axialStiffness, 1e-6 ),
+                           "Axial stiffness K(0,2) does not match -EA/L for an axis-aligned truss." );
+  throwExceptionOnFailure( checkIfEqual( Kmat( 1, 1 ), 0.0, 1e-8 ),
+                           "Transverse stiffness K(1,1) must be zero for a UniaxialStress truss." );
+}
+
+void testComputeKernelsExplicitThrowsNotImplemented()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const int                   nDof = wrapper->getNDofPerElement();
+  const std::vector< double > Q( nDof, 0.0 );
+  std::vector< double >       P( nDof, 0.0 );
+
+  bool threw = false;
+  try {
+    wrapper->computeKernelsExplicit( Q.data(), Q.data(), P.data(), 0.0, 1.0 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computeKernelsExplicit() is not overridden by the wrapper, so it must fall back to "
+                           "MarmotElement's default (throwing) implementation." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeBodyForce(): a body force applied in the ambient frame, projected onto the truss axis
+// and back, must still integrate to the ambient-frame total force times the truss length (the
+// wrapper's P/P^T round trip should be exact for a linear, single-child-element case).
+// ---------------------------------------------------------------------------------------------
+
+void testComputeBodyForceConservesTotalForce()
+{
+  constexpr double            length        = 2.0;
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, length, 0.0 }; // axis-aligned truss
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const int                   nDof = wrapper->getNDofPerElement();
+  const std::vector< double > load = { 3.0, 0.0 }; // force per unit length, along the truss axis
+  const std::vector< double > QTotal( nDof, 0.0 );
+  std::vector< double >       P( nDof, 0.0 );
+  std::vector< double >       K( nDof * nDof, 0.0 );
+
+  wrapper->computeBodyForce( P.data(), K.data(), load.data(), QTotal.data(), 0.0, 1.0 );
+
+  // Cross-section area = 1, so total axial force = load[0] * length.
+  const double totalForceX = P[0] + P[2];
+  const double totalForceY = P[1] + P[3];
+  throwExceptionOnFailure( checkIfEqual( totalForceX, load[0] * length, 1e-8 ),
+                           "computeBodyForce() through the wrapper does not integrate to load * length in x." );
+  throwExceptionOnFailure( checkIfEqual( totalForceY, 0.0, 1e-8 ),
+                           "computeBodyForce() through the wrapper introduced a spurious transverse force." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// setInitialConditions(): must delegate to the child.
+// ---------------------------------------------------------------------------------------------
+
+void testSetInitialConditionsDelegatesToChild()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  // DisplacementFiniteElement<1,...>::setInitialConditions only handles
+  // MarmotMaterialInitialization and MarmotMaterialStateVars (throws) and rejects GeostaticStress
+  // implicitly via its default branch, since nDim=1 there. MarmotMaterialInitialization must not
+  // throw.
+  wrapper->setInitialConditions( MarmotElement::MarmotMaterialInitialization, nullptr );
+
+  bool threw = false;
+  try {
+    wrapper->setInitialConditions( MarmotElement::MarmotMaterialStateVars, nullptr );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, "setInitialConditions() must delegate to the child and propagate its throw." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// getStateView(): "MarmotElementSpatialWrapper.T" is handled directly by the wrapper; anything
+// else must delegate to the child.
+// ---------------------------------------------------------------------------------------------
+
+void testGetStateViewReturnsTransformationMatrixAndDelegatesOtherwise()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 }; // direction (0.6, 0.8)
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const auto tView = wrapper->getStateView( "MarmotElementSpatialWrapper.T", 0 );
+  throwExceptionOnFailure( tView.stateSize == 2, "getStateView(\"...T\") returned the wrong size." );
+  throwExceptionOnFailure( checkIfEqual( tView.stateLocation[0], 0.6, 1e-10 ) &&
+                             checkIfEqual( tView.stateLocation[1], 0.8, 1e-10 ),
+                           "getStateView(\"...T\") does not return the truss's direction cosines." );
+
+  // Any other name must delegate to the child (e.g. "stress", which DisplacementFiniteElement
+  // manages itself).
+  const int                   nDof = wrapper->getNDofPerElement();
+  const std::vector< double > Q( nDof, 0.0 );
+  std::vector< double >       P( nDof, 0.0 );
+  std::vector< double >       K( nDof * nDof, 0.0 );
+  wrapper->computeKernels( Q.data(), Q.data(), P.data(), K.data(), 0.0, 1.0 );
+
+  const auto stressView = wrapper->getStateView( "stress", 0 );
+  throwExceptionOnFailure( stressView.stateSize == 6, "getStateView(\"stress\") did not delegate to the child." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// getCoordinatesAtCenter() / getCoordinatesAtQuadraturePoints()
+// ---------------------------------------------------------------------------------------------
+
+void testGetCoordinatesAtCenterMatchesChildCoordinatesInAmbientSpace()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 }; // length-5 truss
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const auto center = wrapper->getCoordinatesAtCenter();
+
+  // The truss midpoint in ambient space is the average of its two endpoints: (1.5, 2.0).
+  throwExceptionOnFailure( static_cast< int >( center.size() ) == 2,
+                           "getCoordinatesAtCenter() returned the wrong dimension." );
+  throwExceptionOnFailure( checkIfEqual( center[0], 1.5, 1e-10 ) && checkIfEqual( center[1], 2.0, 1e-10 ),
+                           "getCoordinatesAtCenter() does not return the truss midpoint in ambient space." );
+}
+
+void testGetCoordinatesAtQuadraturePointsMatchesChildCoordinatesInAmbientSpace()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const auto qpCoords = wrapper->getCoordinatesAtQuadraturePoints();
+  throwExceptionOnFailure( static_cast< int >( qpCoords.size() ) == wrapper->getNumberOfQuadraturePoints(),
+                           "getCoordinatesAtQuadraturePoints() returned the wrong number of entries." );
+
+  for ( const auto& coords : qpCoords ) {
+    throwExceptionOnFailure( static_cast< int >( coords.size() ) == 2,
+                             "getCoordinatesAtQuadraturePoints() returned the wrong dimension." );
+    // Every quadrature point must lie exactly on the line from (0,0) to (3,4), i.e. y/x = 4/3
+    // (equivalently 4*x - 3*y == 0), and within the segment's bounding box.
+    throwExceptionOnFailure( checkIfEqual( 4.0 * coords[0] - 3.0 * coords[1], 0.0, 1e-8 ),
+                             "getCoordinatesAtQuadraturePoints() point does not lie on the truss axis." );
+    throwExceptionOnFailure( coords[0] >= -1e-8 && coords[0] <= 3.0 + 1e-8,
+                             "getCoordinatesAtQuadraturePoints() point lies outside the truss segment." );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeDistributedLoad(): forwards to the child (with load/QTotal in the correct order --
+// verified by inspection against MarmotElement's declared signature, since the only production
+// child of this wrapper is a 1D bar, and DisplacementFiniteElement<1,...>::computeDistributedLoad
+// always throws before it would ever read those arguments -- see
+// FiniteElement::BoundaryElement's constructor, which has no 1D "Bar2" parent-shape branch).
+// ---------------------------------------------------------------------------------------------
+
+void testComputeDistributedLoadDelegatesAndThrowsForUnsupported1DChild()
+{
+  const std::vector< double > nodeCoordsVec = { 0.0, 0.0, 3.0, 4.0 };
+  const std::vector< double > matProps      = { 10000.0, 0.2, 1.0 };
+  std::vector< double >       stateVars;
+
+  auto wrapper = makeT2D2( nodeCoordsVec, matProps, stateVars );
+
+  const int                   nDof = wrapper->getNDofPerElement();
+  const std::vector< double > load( 1, 1.0 );
+  const std::vector< double > QTotal( nDof, 0.0 );
+  std::vector< double >       P( nDof, 0.0 );
+  std::vector< double >       K( nDof * nDof, 0.0 );
+
+  bool threw = false;
+  try {
+    wrapper
+      ->computeDistributedLoad( MarmotElement::Pressure, P.data(), K.data(), 0, load.data(), QTotal.data(), 0.0, 1.0 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computeDistributedLoad() must delegate to the child and propagate its throw (a 1D "
+                           "child has no boundary-element support)." );
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testBasicAccessorsDelegateToChild,
+    testDofIndicesPermutationPatternExpandsChildPattern,
+    testComputeKernelsTangentMatchesNumericalDifferentiation,
+    testComputeKernelsMatchesAnalyticAxialStiffnessForAxisAlignedTruss,
+    testComputeKernelsExplicitThrowsNotImplemented,
+    testComputeBodyForceConservesTotalForce,
+    testSetInitialConditionsDelegatesToChild,
+    testGetStateViewReturnsTransformationMatrixAndDelegatesOtherwise,
+    testGetCoordinatesAtCenterMatchesChildCoordinatesInAmbientSpace,
+    testGetCoordinatesAtQuadraturePointsMatchesChildCoordinatesInAmbientSpace,
+    testComputeDistributedLoadDelegatesAndThrowsForUnsupported1DChild,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotFiniteElementCore/test/TestMarmotGeometryElement.cpp
+++ b/modules/core/MarmotFiniteElementCore/test/TestMarmotGeometryElement.cpp
@@ -1,0 +1,220 @@
+#include "Marmot/MarmotGeometryElement.h"
+#include "Marmot/MarmotNumericalDifferentiation.h"
+#include "Marmot/MarmotTesting.h"
+#include <Eigen/Dense>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+namespace NumDiff = Marmot::NumericalAlgorithms::Differentiation;
+
+// ---------------------------------------------------------------------------------------------
+// Tetra4 / Tetra10: neither is used by any element tested elsewhere in this codebase, so their
+// shape functions have never been exercised. Rather than trust a hand-transcribed formula (this
+// file's Tetra10 dNdXi in particular is a long hand-expanded product-rule derivative, exactly the
+// kind of code most prone to a transcription slip), correctness is checked two ways that need no
+// prior knowledge of nodal coordinates: N must partition unity (and reduce to the Kronecker delta
+// at each of Tetra4's easily-derived nodal points), and dNdXi must equal the numerical derivative
+// of N with respect to the same natural coordinates.
+// ---------------------------------------------------------------------------------------------
+
+void testTetra4PartitionOfUnityAndKroneckerDeltaAtNodes()
+{
+  using namespace Marmot::FiniteElement::Spatial3D;
+
+  // Derived directly from N: N0=1-xi0-xi1-xi2, N1=xi0, N2=xi1, N3=xi2.
+  const std::vector< Eigen::Vector3d > nodalXi = { { 0.0, 0.0, 0.0 },
+                                                   { 1.0, 0.0, 0.0 },
+                                                   { 0.0, 1.0, 0.0 },
+                                                   { 0.0, 0.0, 1.0 } };
+
+  for ( int i = 0; i < 4; i++ ) {
+    const auto N = Tetra4::N( nodalXi[i] );
+    throwExceptionOnFailure( checkIfEqual( N.sum(), 1.0, 1e-12 ), "Tetra4::N() does not partition unity." );
+    for ( int j = 0; j < 4; j++ ) {
+      const double expected = ( i == j ) ? 1.0 : 0.0;
+      throwExceptionOnFailure( checkIfEqual( N( j ), expected, 1e-12 ),
+                               "Tetra4::N() does not reduce to the Kronecker delta at its own nodes." );
+    }
+  }
+}
+
+void testTetra4DNdXiMatchesNumericalDifferentiationOfN()
+{
+  using namespace Marmot::FiniteElement::Spatial3D;
+
+  const Eigen::Vector3d xi( 0.2, 0.3, 0.1 );
+
+  NumDiff::vector_to_vector_function_type Nfunc = []( const Eigen::VectorXd& xiVec ) -> Eigen::VectorXd {
+    return Tetra4::N( Eigen::Vector3d( xiVec ) );
+  };
+
+  const Eigen::MatrixXd numJacobian = NumDiff::centralDifference( Nfunc, xi ); // (dN_i/dXi_j), 4x3
+
+  const auto analyticDNdXi = Tetra4::dNdXi( xi ); // (dN_i/dXi_j) stored as (nDim x nNodes) = dNdXi(j,i)
+
+  throwExceptionOnFailure( checkIfEqual( numJacobian, Eigen::MatrixXd( analyticDNdXi.transpose() ), 1e-6 ),
+                           "Tetra4::dNdXi() does not match the numerical derivative of Tetra4::N()." );
+}
+
+void testTetra10PartitionOfUnityAtSamplePoints()
+{
+  using namespace Marmot::FiniteElement::Spatial3D;
+
+  const std::vector< Eigen::Vector3d > samples = { { 0.0, 0.0, 0.0 },
+                                                   { 1.0, 0.0, 0.0 },
+                                                   { 0.0, 1.0, 0.0 },
+                                                   { 0.0, 0.0, 1.0 },
+                                                   { 0.2, 0.3, 0.1 },
+                                                   { 0.25, 0.25, 0.25 } };
+
+  for ( const auto& xi : samples ) {
+    const auto N = Tetra10::N( xi );
+    throwExceptionOnFailure( checkIfEqual( N.sum(), 1.0, 1e-10 ), "Tetra10::N() does not partition unity." );
+  }
+}
+
+void testTetra10DNdXiMatchesNumericalDifferentiationOfN()
+{
+  using namespace Marmot::FiniteElement::Spatial3D;
+
+  const Eigen::Vector3d xi( 0.2, 0.3, 0.1 );
+
+  NumDiff::vector_to_vector_function_type Nfunc = []( const Eigen::VectorXd& xiVec ) -> Eigen::VectorXd {
+    return Tetra10::N( Eigen::Vector3d( xiVec ) );
+  };
+
+  const Eigen::MatrixXd numJacobian   = NumDiff::centralDifference( Nfunc, xi );
+  const auto            analyticDNdXi = Tetra10::dNdXi( xi );
+
+  throwExceptionOnFailure( checkIfEqual( numJacobian, Eigen::MatrixXd( analyticDNdXi.transpose() ), 1e-6 ),
+                           "Tetra10::dNdXi() does not match the numerical derivative of Tetra10::N() -- likely "
+                           "a transcription error in the hand-expanded derivative." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// BGreen(dNdX, F): at F = Identity, the Green-Lagrange strain operator reduces algebraically to
+// the standard linear B-operator (every cross term multiplies a zero off-diagonal entry of F, and
+// every retained term multiplies F's unit diagonal) -- an exact identity, not an approximation,
+// and one that exercises MarmotGeometryElement's BGreen() specialization (which has no callers
+// anywhere in the codebase) for every shape.
+// ---------------------------------------------------------------------------------------------
+
+template < int nDim, int nNodes >
+void checkBGreenAtIdentityMatchesB( const std::vector< double >&            nodeCoordsVec,
+                                    const Eigen::Matrix< double, nDim, 1 >& xi,
+                                    const std::string&                      label )
+{
+  MarmotGeometryElement< nDim, nNodes > geo;
+  geo.assignNodeCoordinates( nodeCoordsVec.data() );
+
+  const auto dNdXi = geo.dNdXi( xi );
+  const auto J     = geo.Jacobian( dNdXi );
+  const auto dNdX  = geo.dNdX( dNdXi, J.inverse() );
+
+  const auto B      = geo.B( dNdX );
+  const auto BGreen = geo.BGreen( dNdX, Eigen::Matrix< double, nDim, nDim >::Identity() );
+
+  throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( BGreen ), Eigen::MatrixXd( B ), 1e-10 ),
+                           label + ": BGreen(dNdX, Identity) must equal B(dNdX)." );
+}
+
+void testBGreenAtIdentityMatchesBForEveryShape()
+{
+  const std::vector< double > quad4Coords = { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 };
+  checkBGreenAtIdentityMatchesB< 2, 4 >( quad4Coords, Eigen::Vector2d( 0.2, 0.3 ), "Quad4" );
+
+  const std::vector< double > quad8Coords =
+    { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.5, 0.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0.5 };
+  checkBGreenAtIdentityMatchesB< 2, 8 >( quad8Coords, Eigen::Vector2d( 0.2, 0.3 ), "Quad8" );
+
+  const std::vector< double > hexa8Coords = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+                                              0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+  checkBGreenAtIdentityMatchesB< 3, 8 >( hexa8Coords, Eigen::Vector3d( 0.2, 0.3, 0.1 ), "Hexa8" );
+
+  const std::vector< double > hexa20Coords = {
+    0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, // bottom corners
+    0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, // top corners
+    0.5, 0.0, 0.0, 1.0, 0.5, 0.0, 0.5, 1.0, 0.0, 0.0, 0.5, 0.0, // bottom-face edge midsides
+    0.5, 0.0, 1.0, 1.0, 0.5, 1.0, 0.5, 1.0, 1.0, 0.0, 0.5, 1.0, // top-face edge midsides
+    0.0, 0.0, 0.5, 1.0, 0.0, 0.5, 1.0, 1.0, 0.5, 0.0, 1.0, 0.5  // vertical edge midsides
+  };
+  checkBGreenAtIdentityMatchesB< 3, 20 >( hexa20Coords, Eigen::Vector3d( 0.2, 0.3, 0.1 ), "Hexa20" );
+
+  const std::vector< double > tetra4Coords = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
+  checkBGreenAtIdentityMatchesB< 3, 4 >( tetra4Coords, Eigen::Vector3d( 0.2, 0.2, 0.2 ), "Tetra4" );
+}
+
+// ---------------------------------------------------------------------------------------------
+// B_bar(dNdX, dNdX0): when evaluated at the SAME point (dNdX0 == dNdX), the B-bar correction terms
+// (B4, B6, B8) vanish identically and B_bar algebraically collapses to the standard B operator --
+// again an exact identity, not an approximation.
+// ---------------------------------------------------------------------------------------------
+
+void testBBarAtEqualPointsMatchesBForHexa8()
+{
+  const std::vector< double > hexa8Coords = { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+                                              0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+
+  MarmotGeometryElement< 3, 8 > geo;
+  geo.assignNodeCoordinates( hexa8Coords.data() );
+
+  const Eigen::Vector3d xi( 0.2, 0.3, 0.1 );
+  const auto            dNdXi = geo.dNdXi( xi );
+  const auto            J     = geo.Jacobian( dNdXi );
+  const auto            dNdX  = geo.dNdX( dNdXi, J.inverse() );
+
+  const auto B     = geo.B( dNdX );
+  const auto B_bar = geo.B_bar( dNdX, dNdX );
+
+  throwExceptionOnFailure( checkIfEqual( Eigen::MatrixXd( B_bar ), Eigen::MatrixXd( B ), 1e-10 ),
+                           "B_bar(dNdX, dNdX) must equal B(dNdX) when evaluated at the same point." );
+}
+
+// ---------------------------------------------------------------------------------------------
+// B_axisymmetric: no algebraic identity collapses this to the standard B operator (it introduces
+// a genuinely new N/r hoop-strain term), so it is checked against hand-computed values instead.
+// ---------------------------------------------------------------------------------------------
+
+void testBAxisymmetricMatchesHandDerivedValuesQuad4()
+{
+  MarmotGeometryElement< 2, 4 >::dNdXiSized dNdX;
+  dNdX << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0; // arbitrary but fixed 2x4 values
+
+  MarmotGeometryElement< 2, 4 >::NSized N;
+  N << 0.1, 0.2, 0.3, 0.4;
+
+  const Eigen::Vector2d x_gauss( 2.0, 0.0 ); // r = 2
+
+  MarmotGeometryElement< 2, 4 > geo;
+  const auto                    B = geo.B_axisymmetric( dNdX, N, x_gauss );
+
+  throwExceptionOnFailure( B.rows() == 4 && B.cols() == 8, "B_axisymmetric() returned the wrong size." );
+
+  for ( int i = 0; i < 4; i++ ) {
+    throwExceptionOnFailure( checkIfEqual( B( 0, 2 * i ), dNdX( 0, i ), 1e-12 ), "B_axisymmetric row 0 mismatch." );
+    throwExceptionOnFailure( checkIfEqual( B( 0, 2 * i + 1 ), 0.0, 1e-12 ), "B_axisymmetric row 0 mismatch." );
+    throwExceptionOnFailure( checkIfEqual( B( 1, 2 * i + 1 ), dNdX( 1, i ), 1e-12 ), "B_axisymmetric row 1 mismatch." );
+    throwExceptionOnFailure( checkIfEqual( B( 1, 2 * i ), 0.0, 1e-12 ), "B_axisymmetric row 1 mismatch." );
+    throwExceptionOnFailure( checkIfEqual( B( 2, 2 * i ), N( i ) / x_gauss( 0 ), 1e-12 ),
+                             "B_axisymmetric row 2 (hoop strain N/r) mismatch." );
+    throwExceptionOnFailure( checkIfEqual( B( 3, 2 * i ), dNdX( 1, i ), 1e-12 ), "B_axisymmetric row 3 mismatch." );
+    throwExceptionOnFailure( checkIfEqual( B( 3, 2 * i + 1 ), dNdX( 0, i ), 1e-12 ), "B_axisymmetric row 3 mismatch." );
+  }
+}
+
+int main()
+{
+  auto tests = std::vector< std::function< void() > >{
+    testTetra4PartitionOfUnityAndKroneckerDeltaAtNodes,
+    testTetra4DNdXiMatchesNumericalDifferentiationOfN,
+    testTetra10PartitionOfUnityAtSamplePoints,
+    testTetra10DNdXiMatchesNumericalDifferentiationOfN,
+    testBGreenAtIdentityMatchesBForEveryShape,
+    testBBarAtEqualPointsMatchesBForHexa8,
+    testBAxisymmetricMatchesHandDerivedValuesQuad4,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
+++ b/modules/elements/DisplacementFiniteElement/include/Marmot/DisplacementFiniteElement.h
@@ -575,6 +575,7 @@ namespace Marmot::Elements {
         Eigen::VectorXd stress1D( 1 );
         stress1D( 0 )               = state.stress;
         qp.managedStateVars->stress = make3DVoigt< ParentGeometryElement::voigtSize >( stress1D );
+        S                           = stress1D;
         elasticEnergyDensity        = state.elasticEnergyDensity;
         dissipation                 = state.dissipation;
       }


### PR DESCRIPTION
## Summary

Adds test infrastructure and tests for `MarmotFiniteElementCore` -- the next-worst-covered module after `elements` (29.5% at the start of this work, worse than any single file tackled in #85). The module had **no dedicated `test/` directory or `test.cmake` at all**; every bit of its prior coverage came indirectly from element-level tests exercising a handful of shape functions.

| File | Coverage before → after | Bugs found & fixed |
|---|---|---|
| `MarmotFiniteElementBoundary.cpp` | 0% → 91.2% | Out-of-bounds Eigen access (`condenseParentToBoundaryScalar()` allocated `nNodes*nDim` but only filled `nNodes`, feeding a stale oversized `.size()` into `assembleIntoParentScalar()`'s index-map loop); `BoundaryElement`'s constructor declaration listed parameters in a different order than the implementation and every caller actually use |
| `MarmotElementSpatialWrapper.cpp` | 0% → 92.1% | Carried the same `DisplacementFiniteElement` `nDim==1` internal-force bug fixed in #85 (this branch forked before that merged); `getCoordinatesAtCenter()`/`getCoordinatesAtQuadraturePoints()` projected with the wrong matrix (`P`, sized for DOF vectors, instead of `T`, the geometric transform), crashing via an Eigen "invalid matrix product" assertion for any multi-node embedded element; `computeDistributedLoad()` forwards `load`/`QTotal` to the child swapped (fixed by inspection -- currently unreachable, since the only functional configuration always throws first) |
| `MarmotDofLayoutTools.cpp` | 0% → 92.9% | Unused (no callers anywhere); header doc comment described the `pair<int,int>` backwards from what the self-consistent implementation actually does -- corrected the docs |
| `MarmotEnhancedAssumedStrain.cpp` | 0% → 100% | None found |
| `MarmotFiniteElement2D.cpp` | 77.1% → 97.1% | `modifyCharElemLengthAbaqusLike()` was defined one namespace level too shallow (`Marmot::FiniteElement::Spatial2D` instead of `Marmot::FiniteElement::Quadrature::Spatial2D`), so it could never link against its own header declaration -- unreachable even if it had a caller |
| `MarmotGeometryElement.cpp` | 48.4% → 77.4% | None found |
| `MarmotFiniteElementBasic.cpp` | 71.1% → 95.2% | None found |

**Module total: 29.5% → 92.6%.**

Six real bugs across two coverage efforts now (three more in #85), all in code paths that had zero prior test coverage. Several of the untested functions here (`BGreen`, `B_bar`, `B_axisymmetric`, the dynamic `NB()`/`Jacobian()`, `MarmotDofLayoutTools`) turned out to have no callers anywhere in the codebase; those are tested against exact algebraic identities (e.g. `BGreen(dNdX, Identity) == B(dNdX)`) or cross-validated against their already-trusted templated/sibling counterparts rather than independently hand-derived values, since there's no existing usage to infer intent from.

## Test plan
- [x] `ctest --output-on-failure` -- all 55 tests pass
- [x] Coverage verified locally with `gcovr`
- [x] Each bug fix verified by re-running the corresponding test after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA