### PR TITLE
test(core): cover MarmotMaterialGeneralGradientEnhancedHypoElastic and its factory

### DIFF
--- a/modules/core/MarmotGradientMechanicsCore/test.cmake
+++ b/modules/core/MarmotGradientMechanicsCore/test.cmake
@@ -6,3 +6,9 @@ add_marmot_test("TestMarmotPhaseFieldEnergyDegradation" "${CURR_TEST_SOURCE_DIR}
 
 # Tests for MarmotDecreasingInteractions
 add_marmot_test("TestMarmotDecreasingInteractions" "${CURR_TEST_SOURCE_DIR}/TestMarmotDecreasingInteractions.cpp")
+
+# Tests for MarmotMaterialGeneralGradientEnhancedHypoElastic
+add_marmot_test("TestMarmotMaterialGeneralGradientEnhancedHypoElastic" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialGeneralGradientEnhancedHypoElastic.cpp")
+
+# Tests for MarmotMaterialGeneralGradientEnhancedHypoElasticFactory
+add_marmot_test("TestMarmotMaterialGeneralGradientEnhancedHypoElasticFactory" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp")

--- a/modules/core/MarmotGradientMechanicsCore/test/TestMarmotMaterialGeneralGradientEnhancedHypoElastic.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/test/TestMarmotMaterialGeneralGradientEnhancedHypoElastic.cpp
@@ -1,0 +1,156 @@
+#include "Marmot/MarmotExceptions.h"
+#include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElastic.h"
+#include "Marmot/MarmotTesting.h"
+#include "Marmot/MarmotTypedefs.h"
+#include <Eigen/Dense>
+#include <utility>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+
+namespace {
+
+  using Mat1 = MarmotMaterialGeneralGradientEnhancedHypoElastic< 1 >;
+
+  // ---------------------------------------------------------------------------------------------
+  // A minimal test-only material whose out-of-plane stress component (index 2) is a positive
+  // constant, independent of strain, with a correspondingly zero tangent for that component. No
+  // real, registered material behaves like this (dStress/dStrain is always non-singular for a
+  // physically sound hypoelastic law), so this stand-in is the only practical way to deterministically
+  // exercise computePlaneStress()'s robustness branches: the near-singular-tangent compliance cap,
+  // and the cutback/failure throw when the iteration cannot drive sigma_zz to zero.
+  // ---------------------------------------------------------------------------------------------
+  class NeverConvergingPlaneStressMaterial : public Mat1 {
+  public:
+    using Mat1::Mat1;
+
+    void initializeStateLayout()
+    {
+      stateLayout.add( "dummy", 1 );
+      stateLayout.finalize();
+    }
+
+    void computeStress( response& res, tangents& tan, const increment& inc ) const override
+    {
+      res.stress      = Marmot::Vector6d::Zero();
+      res.stress( 2 ) = 5.0; // never zero, and independent of inc.dStrain
+      res.KLocal( 0 ) = 0.0;
+      res.c( 0 )      = 1.0;
+
+      tan.dStressddStrain.setZero(); // dSigma_zz/dEps_zz == 0 -> forces the near-singular branch
+      tan.dStressddK.setZero();
+      tan.dKLocalddStrain.setZero();
+      tan.dKLocalddK.setZero();
+      tan.dcddK.setZero();
+      tan.d2cddK2.setZero();
+    }
+
+    double getDensity( const double* ) const override { return 0.0; }
+
+    std::vector< double > getNonlocalViscosity( const double* ) const override { return { 0.0 }; }
+  };
+
+  std::pair< NeverConvergingPlaneStressMaterial, std::vector< double > > makeNeverConvergingMaterial()
+  {
+    NeverConvergingPlaneStressMaterial mat( nullptr, 0, 1 );
+    mat.initializeStateLayout();
+    std::vector< double > stateVars( mat.getNumberOfRequiredStateVars(), 0.0 );
+    return { std::move( mat ), std::move( stateVars ) };
+  }
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// computePlaneStress(): must throw StressUpdateFailed after exhausting its cutback attempts when
+// the out-of-plane stress can never be driven to zero. Along the way, the near-singular tangent
+// (dStressddStrain(2,2) == 0) must hit the "cap the compliance instead of dividing by zero" branch
+// rather than propagating a NaN/inf strain correction.
+// ---------------------------------------------------------------------------------------------
+void testComputePlaneStressThrowsWhenItCannotConverge()
+{
+  auto [mat, stateVars] = makeNeverConvergingMaterial();
+
+  Mat1::increment inc;
+  inc.dStrain      = Marmot::Vector6d::Zero();
+  inc.dStrain( 0 ) = 1e-3;
+  inc.K( 0 )       = 0.0;
+  inc.dK( 0 )      = 0.0;
+  inc.time         = 0.0;
+  inc.dT           = 1.0;
+
+  Mat1::response res;
+  Mat1::tangents tan;
+  res.stress    = Marmot::Vector6d::Zero();
+  res.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  res.c         = Eigen::Vector< double, 1 >::Zero();
+  res.stateVars = stateVars.data();
+
+  bool threw = false;
+  try {
+    mat.computePlaneStress( res, tan, inc );
+  }
+  catch ( const Marmot::StressUpdateFailed& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computePlaneStress() must throw StressUpdateFailed when it cannot converge in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// getMaximumWaveSpeed(): must return 0 (rather than dividing by zero / returning NaN) when the
+// material reports zero density.
+// ---------------------------------------------------------------------------------------------
+void testGetMaximumWaveSpeedReturnsZeroForZeroDensity()
+{
+  auto [mat, stateVars] = makeNeverConvergingMaterial();
+
+  Mat1::response res;
+  res.stress    = Marmot::Vector6d::Zero();
+  res.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  res.c         = Eigen::Vector< double, 1 >::Zero();
+  res.stateVars = stateVars.data();
+
+  const double waveSpeed = mat.getMaximumWaveSpeed( res );
+  throwExceptionOnFailure( waveSpeed == 0.0,
+                           "getMaximumWaveSpeed() must return 0 for zero density in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// getMaximumWaveSpeed(): must tolerate a null state-variable pointer / zero state-variable count
+// (e.g. a material with no state variables at all) rather than attempting to copy through it.
+// ---------------------------------------------------------------------------------------------
+void testGetMaximumWaveSpeedToleratesNullStateVars()
+{
+  NeverConvergingPlaneStressMaterial mat( nullptr, 0, 1 );
+  // Deliberately skip initializeStateLayout(): zero state variables, matching a null stateVars
+  // pointer in the response, which is the scenario the null-pointer guard in getMaximumWaveSpeed()
+  // is there to handle.
+  mat.stateLayout.finalize();
+
+  Mat1::response res;
+  res.stress    = Marmot::Vector6d::Zero();
+  res.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  res.c         = Eigen::Vector< double, 1 >::Zero();
+  res.stateVars = nullptr;
+
+  const double waveSpeed = mat.getMaximumWaveSpeed( res );
+  throwExceptionOnFailure( waveSpeed == 0.0,
+                           "getMaximumWaveSpeed() must tolerate a null state-variable pointer in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testComputePlaneStressThrowsWhenItCannotConverge,
+    testGetMaximumWaveSpeedReturnsZeroForZeroDensity,
+    testGetMaximumWaveSpeedToleratesNullStateVars,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+  return 0;
+}

--- a/modules/core/MarmotGradientMechanicsCore/test/TestMarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
+++ b/modules/core/MarmotGradientMechanicsCore/test/TestMarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp
@@ -1,0 +1,153 @@
+#include "Marmot/MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.h"
+#include "Marmot/MarmotTesting.h"
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace MarmotLibrary;
+
+namespace {
+
+  // Minimal, registerable material used only to exercise the factory's registration/creation
+  // machinery for nNonlocalVariables values (2 and 6) that no shipped material currently uses --
+  // the factory itself is a general template over nNonlocalVariables, explicitly instantiated for
+  // 1, 2 and 6, so this is genuine, reachable library code, not dead code.
+  template < int nNonlocalVariables >
+  class DummyMaterial : public MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables > {
+  public:
+    using Base = MarmotMaterialGeneralGradientEnhancedHypoElastic< nNonlocalVariables >;
+    using Base::Base;
+
+    void computeStress( typename Base::response&,
+                        typename Base::tangents&,
+                        const typename Base::increment& ) const override
+    {
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+
+    std::vector< double > getNonlocalViscosity( const double* ) const override
+    {
+      return std::vector< double >( nNonlocalVariables, 0.0 );
+    }
+  };
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// createMaterial<1>(): the throw branch (unregistered material name) is never exercised by
+// production code, since every caller only ever requests materials it just confirmed are
+// registered. "AT2PHASEFIELD" is genuinely registered (by AT2PhaseFieldRegistration.cpp, linked
+// into every test executable via libMarmot), so a name guaranteed not to collide with it proves
+// the throw path specifically, not just "any unknown name".
+// ---------------------------------------------------------------------------------------------
+void testCreateMaterialN1ThrowsForUnregisteredName()
+{
+  bool threw = false;
+  try {
+    MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 1 >::createMaterial( "DEFINITELY_NOT_REGISTERED",
+                                                                                  nullptr,
+                                                                                  0,
+                                                                                  1 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "createMaterial<1>() must throw std::invalid_argument for an unregistered material name "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// registerMaterial<2>() / createMaterial<2>(): round-trip registration and creation for the
+// nNonlocalVariables=2 specialization.
+// ---------------------------------------------------------------------------------------------
+void testRegisterAndCreateMaterialN2()
+{
+  MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 2 >::registerMaterial< DummyMaterial< 2 > >(
+    "TESTDUMMYMATERIALN2" );
+
+  std::unique_ptr< MarmotMaterialGeneralGradientEnhancedHypoElastic< 2 > > mat(
+    MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 2 >::createMaterial( "TESTDUMMYMATERIALN2",
+                                                                                  nullptr,
+                                                                                  0,
+                                                                                  7 ) );
+
+  throwExceptionOnFailure( mat != nullptr && mat->materialNumber == 7,
+                           "createMaterial<2>() did not return a correctly constructed instance in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCreateMaterialN2ThrowsForUnregisteredName()
+{
+  bool threw = false;
+  try {
+    MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 2 >::createMaterial( "SOME_OTHER_UNKNOWN_NAME",
+                                                                                  nullptr,
+                                                                                  0,
+                                                                                  1 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "createMaterial<2>() must throw std::invalid_argument for an unregistered material name "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// registerMaterial<6>() / createMaterial<6>(): round-trip registration and creation for the
+// nNonlocalVariables=6 specialization.
+// ---------------------------------------------------------------------------------------------
+void testRegisterAndCreateMaterialN6()
+{
+  MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 6 >::registerMaterial< DummyMaterial< 6 > >(
+    "TESTDUMMYMATERIALN6" );
+
+  std::unique_ptr< MarmotMaterialGeneralGradientEnhancedHypoElastic< 6 > > mat(
+    MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 6 >::createMaterial( "TESTDUMMYMATERIALN6",
+                                                                                  nullptr,
+                                                                                  0,
+                                                                                  3 ) );
+
+  throwExceptionOnFailure( mat != nullptr && mat->materialNumber == 3,
+                           "createMaterial<6>() did not return a correctly constructed instance in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCreateMaterialN6ThrowsForUnregisteredName()
+{
+  bool threw = false;
+  try {
+    MarmotMaterialGeneralGradientEnhancedHypoElasticFactory< 6 >::createMaterial( "SOME_OTHER_UNKNOWN_NAME",
+                                                                                  nullptr,
+                                                                                  0,
+                                                                                  1 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "createMaterial<6>() must throw std::invalid_argument for an unregistered material name "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testCreateMaterialN1ThrowsForUnregisteredName,
+    testRegisterAndCreateMaterialN2,
+    testCreateMaterialN2ThrowsForUnregisteredName,
+    testRegisterAndCreateMaterialN6,
+    testCreateMaterialN6ThrowsForUnregisteredName,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+  return 0;
+}

--- a/modules/materials/AT2PhaseField/test/test.cpp
+++ b/modules/materials/AT2PhaseField/test/test.cpp
@@ -3,6 +3,7 @@
 #include "Marmot/MarmotTesting.h"
 #include "Marmot/MarmotTypedefs.h"
 #include <Eigen/Dense>
+#include <algorithm>
 #include <vector>
 
 using namespace Marmot::Testing;
@@ -297,6 +298,211 @@ void testTangentConsistency()
   }
 }
 // ─────────────────────────────────────────────────────────────────────────────
+// Test 5 – computeStressExplicit() (base class default): must match computeStress()
+// with the tangents discarded, for the very same increment and starting state.
+// ─────────────────────────────────────────────────────────────────────────────
+void testComputeStressExplicitMatchesComputeStress()
+{
+  const double                E = 20000., nu = 0.25, Gc = 2.7, l = 0.01;
+  const std::vector< double > properties = std::vector< double >{ E, nu, Gc, l };
+
+  auto [matA, stateVarsA] = makeMaterial( properties );
+  auto [matB, stateVarsB] = makeMaterial( properties );
+
+  Vector6d dEps = Vector6d::Zero();
+  dEps( 0 )     = 1e-3;
+  dEps( 3 )     = 2e-4;
+
+  Inc1 inc;
+  inc.dStrain = dEps;
+  inc.K( 0 )  = 0.2;
+  inc.dK( 0 ) = 0.0;
+  inc.time    = 0.0;
+  inc.dT      = 1.0;
+
+  Res1 resA;
+  Tan1 tanA;
+  resA.stress    = Vector6d::Zero();
+  resA.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  resA.c         = Eigen::Vector< double, 1 >::Zero();
+  resA.stateVars = stateVarsA.data();
+  matA.computeStress( resA, tanA, inc );
+
+  Res1 resB;
+  resB.stress    = Vector6d::Zero();
+  resB.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  resB.c         = Eigen::Vector< double, 1 >::Zero();
+  resB.stateVars = stateVarsB.data();
+  matB.computeStressExplicit( resB, inc );
+
+  throwExceptionOnFailure( checkIfEqual< double >( resA.stress, resB.stress, 1e-14 ) &&
+                             checkIfEqual( resA.KLocal( 0 ), resB.KLocal( 0 ), 1e-14 ) &&
+                             checkIfEqual( resA.c( 0 ), resB.c( 0 ), 1e-14 ),
+                           "computeStressExplicit() must match computeStress() ignoring the tangents in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( stateVarsA[0], stateVarsB[0], 1e-14 ),
+                           "computeStressExplicit() must update state variables identically to computeStress() in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6 – computePlaneStress()/computePlaneStressExplicit() (base class default):
+// for this material, dStress/dStrain = g(phi)*C is constant throughout the
+// iteration (phi is held fixed), so the plane-stress condensation is an exactly
+// linear problem and must converge to sigma_zz == 0 with the classical plane-
+// stress-condensed stiffness relating sigma_xx to eps_xx.
+// ─────────────────────────────────────────────────────────────────────────────
+void testComputePlaneStressConvergesToZeroOutOfPlaneStress()
+{
+  const double                E = 20000., nu = 0.25, Gc = 2.7, l = 0.01;
+  const std::vector< double > properties = std::vector< double >{ E, nu, Gc, l };
+  auto [mat, stateVars]                  = makeMaterial( properties );
+
+  Vector6d dEps = Vector6d::Zero();
+  dEps( 0 )     = 1e-3; // eps_xx only; eps_yy stays fixed at 0, eps_zz (index 2) is solved for
+
+  Inc1 inc;
+  inc.dStrain = dEps;
+  inc.K( 0 )  = 0.0; // phi = 0 (undamaged)
+  inc.dK( 0 ) = 0.0;
+  inc.time    = 0.0;
+  inc.dT      = 1.0;
+
+  Res1 res;
+  Tan1 tan;
+  res.stress    = Vector6d::Zero();
+  res.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  res.c         = Eigen::Vector< double, 1 >::Zero();
+  res.stateVars = stateVars.data();
+
+  mat.computePlaneStress( res, tan, inc );
+
+  throwExceptionOnFailure( std::abs( res.stress( 2 ) ) < 1e-8,
+                           "computePlaneStress() did not converge to sigma_zz == 0 in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // Static condensation of the elastic stiffness (eliminating eps_zz via sigma_zz=0, with eps_yy
+  // held fixed at 0): sigma_xx = (C_xx,xx - C_xx,zz^2/C_zz,zz) * eps_xx. This is *not* the familiar
+  // E*eps_xx plane-stress modulus, since that additionally assumes eps_yy is free rather than fixed.
+  const Matrix6d C                = ContinuumMechanics::Elasticity::Isotropic::stiffnessTensor( E, nu );
+  const double   condensedModulus = C( 0, 0 ) - C( 0, 2 ) * C( 2, 0 ) / C( 2, 2 );
+  const double   sigmaXXExpected  = condensedModulus * dEps( 0 );
+  throwExceptionOnFailure( checkIfEqual( res.stress( 0 ), sigmaXXExpected, 1e-6 ),
+                           "computePlaneStress() sigma_xx does not match the statically condensed stiffness in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputePlaneStressExplicitMatchesComputePlaneStress()
+{
+  const double                E = 20000., nu = 0.25, Gc = 2.7, l = 0.01;
+  const std::vector< double > properties = std::vector< double >{ E, nu, Gc, l };
+
+  auto [matA, stateVarsA] = makeMaterial( properties );
+  auto [matB, stateVarsB] = makeMaterial( properties );
+
+  Vector6d dEps = Vector6d::Zero();
+  dEps( 0 )     = 1e-3;
+
+  Inc1 inc;
+  inc.dStrain = dEps;
+  inc.K( 0 )  = 0.0;
+  inc.dK( 0 ) = 0.0;
+  inc.time    = 0.0;
+  inc.dT      = 1.0;
+
+  Res1 resA;
+  Tan1 tanA;
+  resA.stress    = Vector6d::Zero();
+  resA.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  resA.c         = Eigen::Vector< double, 1 >::Zero();
+  resA.stateVars = stateVarsA.data();
+  matA.computePlaneStress( resA, tanA, inc );
+
+  Res1 resB;
+  resB.stress    = Vector6d::Zero();
+  resB.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  resB.c         = Eigen::Vector< double, 1 >::Zero();
+  resB.stateVars = stateVarsB.data();
+  matB.computePlaneStressExplicit( resB, inc );
+
+  throwExceptionOnFailure( checkIfEqual< double >( resA.stress, resB.stress, 1e-10 ),
+                           "computePlaneStressExplicit() must match computePlaneStress() ignoring the tangents in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 7 – getMaximumWaveSpeed() (base class default): sqrt(max(C_ii)/rho), with
+// C_ii the diagonal of the algorithmic tangent at zero strain increment (i.e. the
+// undamaged elastic stiffness, since AT2PhaseField's tangent doesn't depend on
+// the (zero) strain increment itself).
+// ─────────────────────────────────────────────────────────────────────────────
+void testGetMaximumWaveSpeedMatchesClosedForm()
+{
+  const double                E = 20000., nu = 0.25, Gc = 2.7, l = 0.01, rho = 2400.;
+  const std::vector< double > properties = std::vector< double >{ E, nu, Gc, l, rho };
+  auto [mat, stateVars]                  = makeMaterial( properties );
+
+  const Matrix6d C = ContinuumMechanics::Elasticity::Isotropic::stiffnessTensor( E, nu );
+
+  Res1 res;
+  res.stress    = Vector6d::Zero();
+  res.KLocal    = Eigen::Vector< double, 1 >::Zero();
+  res.c         = Eigen::Vector< double, 1 >::Zero();
+  res.stateVars = stateVars.data();
+
+  const double waveSpeed = mat.getMaximumWaveSpeed( res );
+
+  const double maxDiag  = C.diagonal().maxCoeff();
+  const double expected = std::sqrt( maxDiag / rho );
+  throwExceptionOnFailure( checkIfEqual( waveSpeed, expected, 1e-8 ),
+                           "getMaximumWaveSpeed() does not match sqrt(max(C_ii)/rho) in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // getMaximumWaveSpeed() must not mutate the caller's state variables (it operates on a copy).
+  throwExceptionOnFailure( stateVars[0] == 0.0,
+                           "getMaximumWaveSpeed() must not mutate the caller's state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 8 – initializeYourself() (base class default): zeroes all state variables.
+// ─────────────────────────────────────────────────────────────────────────────
+void testInitializeYourselfZeroesStateVars()
+{
+  const double                E = 20000., nu = 0.25, Gc = 2.7, l = 0.01;
+  const std::vector< double > properties = std::vector< double >{ E, nu, Gc, l };
+  auto [mat, stateVars]                  = makeMaterial( properties );
+
+  std::fill( stateVars.begin(), stateVars.end(), 42.0 );
+  mat.initializeYourself( stateVars.data(), static_cast< int >( stateVars.size() ) );
+
+  throwExceptionOnFailure( std::all_of( stateVars.begin(), stateVars.end(), []( double v ) { return v == 0.0; } ),
+                           "initializeYourself() must zero all state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 9 – getStateView() (base class default): delegates to the state layout
+// and must return a view aliasing the correct slice of the state vector.
+// ─────────────────────────────────────────────────────────────────────────────
+void testGetStateViewReturnsAliasingView()
+{
+  const double                E = 20000., nu = 0.25, Gc = 2.7, l = 0.01;
+  const std::vector< double > properties = std::vector< double >{ E, nu, Gc, l };
+  auto [mat, stateVars]                  = makeMaterial( properties );
+
+  const StateView view = mat.getStateView( "maxCrackDrivingForce", stateVars.data() );
+
+  throwExceptionOnFailure( view.stateSize == 1,
+                           "getStateView() returned the wrong size in " + std::string( __PRETTY_FUNCTION__ ) );
+
+  *view.stateLocation = 7.5;
+  throwExceptionOnFailure( stateVars[0] == 7.5,
+                           "getStateView() must alias the underlying state vector, not copy it, in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 int main()
 {
   const std::vector< std::function< void() > > tests = {
@@ -304,6 +510,12 @@ int main()
     testDegradedStress,
     testIrreversibility,
     testTangentConsistency,
+    testComputeStressExplicitMatchesComputeStress,
+    testComputePlaneStressConvergesToZeroOutOfPlaneStress,
+    testComputePlaneStressExplicitMatchesComputePlaneStress,
+    testGetMaximumWaveSpeedMatchesClosedForm,
+    testInitializeYourselfZeroesStateVars,
+    testGetStateViewReturnsAliasingView,
   };
 
   executeTestsAndCollectExceptions( tests );


### PR DESCRIPTION
## Summary
- `MarmotMaterialGeneralGradientEnhancedHypoElastic.h` was the worst-covered file in `modules/core` at 8.57% patch coverage (only the constructor/destructor were exercised), since `AT2PhaseField` — the only registered concrete material — overrides `computeStress`/`getDensity`/`getNonlocalViscosity` but never exercises the base class's default `computeStressExplicit`, `computePlaneStress(Explicit)`, `getMaximumWaveSpeed`, `initializeYourself`, or `getStateView`.
- Extended `AT2PhaseField`'s existing test suite to exercise all of those defaults against a real material, including verifying `computePlaneStress`'s iterative sigma_zz=0 condensation against the closed-form statically-condensed stiffness (not the plain plane-stress modulus, which doesn't apply here since eps_yy is held fixed rather than free).
- `computePlaneStress()`'s near-singular-tangent compliance cap and cutback-failure throw, and `getMaximumWaveSpeed()`'s zero-density/null-state guards, are unreachable through any real material's well-posed tangent — added a minimal test-only material with a strain-independent, always-nonzero out-of-plane stress to exercise them deterministically.
- `MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp` (20.51%) is a template explicitly instantiated for `nNonlocalVariables` in `{1,2,6}`, but only the `<1>` happy path (via the finite-element test) was ever exercised. Added round-trip register/create tests for the `<2>` and `<6>` specializations (via a minimal dummy material) and the unregistered-name throw path for all three.

## Test plan
- [x] `ctest` — 50/50 tests pass locally (Debug build)
- [x] Local `gcovr` (max-merged across translation units, since these are header-templates instantiated per-TU): `MarmotMaterialGeneralGradientEnhancedHypoElastic.h` 8.57% → 100%; `MarmotMaterialGeneralGradientEnhancedHypoElasticFactory.cpp` 20.51% → 92.9% (remaining 3 "missing" lines are a gcov line-attribution artifact on a multi-line `throw` statement, confirmed reached via the caught exception in the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA