### PR TITLE
fix(core): HughesWinget rotation bug + cover MarmotMaterialFiniteStrain defaults

### DIFF
--- a/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
@@ -18,3 +18,6 @@ add_marmot_test("TestMarmotFiniteStrainViscoelasticity" "${CURR_TEST_SOURCE_DIR}
 
 # Tests for the Hughes-Winget small-strain wrapper
 add_marmot_test("TestMarmotMaterialHughesWinget" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialHughesWinget.cpp")
+
+# Tests for MarmotMaterialFiniteStrain
+add_marmot_test("TestMarmotMaterialFiniteStrain" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialFiniteStrain.cpp")

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialFiniteStrain.cpp
@@ -1,0 +1,118 @@
+#include "Marmot/MarmotFastorTensorBasics.h"
+#include "Marmot/MarmotMaterialFiniteStrain.h"
+#include "Marmot/MarmotTesting.h"
+#include <cmath>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::FastorStandardTensors;
+
+namespace {
+
+  // A minimal, linear-elastic (isotropic Kirchhoff = C:small-strain), test-only material with a
+  // single state variable. No shipped material derived from MarmotMaterialFiniteStrain both (a)
+  // has state variables and (b) leaves getMaximumWaveSpeed() at its base-class default, so this is
+  // needed to exercise that default's non-null/non-empty state-variable-copying branch.
+  class LinearElasticFiniteStrainMaterialWithStateVar : public MarmotMaterialFiniteStrain {
+  public:
+    LinearElasticFiniteStrainMaterialWithStateVar( const double* matProperties_,
+                                                   int           nMaterialProperties_,
+                                                   int           materialNumber_ )
+      : MarmotMaterialFiniteStrain( matProperties_, nMaterialProperties_, materialNumber_ )
+    {
+      stateLayout.add( "dummy", 1 );
+      stateLayout.finalize();
+    }
+
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&    deformation,
+                        const TimeIncrement& ) const override
+    {
+      const double& E      = materialProperties[0];
+      const double& nu     = materialProperties[1];
+      const double  mu     = E / ( 2. * ( 1. + nu ) );
+      const double  lambda = E * nu / ( ( 1. + nu ) * ( 1. - 2. * nu ) );
+
+      Tensor33d eps( 0.0 );
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ )
+          eps( i, j ) = 0.5 * ( deformation.F( i, j ) + deformation.F( j, i ) ) - ( i == j ? 1.0 : 0.0 );
+
+      const double trEps = eps( 0, 0 ) + eps( 1, 1 ) + eps( 2, 2 );
+
+      Tensor33d tau( 0.0 );
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ )
+          tau( i, j ) = 2. * mu * eps( i, j ) + ( i == j ? lambda * trEps : 0.0 );
+
+      response.tau                  = tau;
+      response.elasticEnergyDensity = 0.0;
+      response.dissipation          = 0.0;
+
+      tangents.dTau_dF = Tensor3333d( 0.0 );
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ )
+          for ( int k = 0; k < 3; k++ )
+            for ( int l = 0; l < 3; l++ )
+              tangents.dTau_dF( i, j, k, l ) = mu * ( ( i == k ? 1. : 0. ) * ( j == l ? 1. : 0. ) +
+                                                      ( i == l ? 1. : 0. ) * ( j == k ? 1. : 0. ) ) +
+                                               ( i == j && k == l ? lambda : 0.0 );
+
+      if ( response.stateVars != nullptr )
+        response.stateVars[0] = trEps;
+    }
+
+    double getDensity( const double* ) const override { return materialProperties[2]; }
+  };
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// getMaximumWaveSpeed() (base class default): when the material has state variables and a valid
+// (non-null) stateVars pointer is supplied, the perturbed evaluations must be performed on
+// *copies* of the state, and must reproduce the P-wave modulus sqrt((lambda+2*mu)/rho) for this
+// isotropic linear-elastic material.
+// ---------------------------------------------------------------------------------------------
+void testGetMaximumWaveSpeedCopiesNonEmptyStateVars()
+{
+  const double                                  E = 20000., nu = 0.25, rho = 2400.;
+  const std::vector< double >                   props = { E, nu, rho };
+  LinearElasticFiniteStrainMaterialWithStateVar mat( props.data(), 3, 1 );
+
+  std::vector< double > stateVars( mat.getNumberOfRequiredStateVars(), -1.0 );
+
+  MarmotMaterialFiniteStrain::ConstitutiveResponse< 3 > res;
+  res.stateVars = stateVars.data();
+
+  const Tensor33d F = Marmot::FastorStandardTensors::Spatial3D::I;
+
+  const double waveSpeed = mat.getMaximumWaveSpeed( stateVars.data(), F );
+
+  const double mu       = E / ( 2. * ( 1. + nu ) );
+  const double lambda   = E * nu / ( ( 1. + nu ) * ( 1. - 2. * nu ) );
+  const double expected = std::sqrt( ( lambda + 2. * mu ) / rho );
+
+  throwExceptionOnFailure( checkIfEqual( waveSpeed, expected, 1e-5 ),
+                           "getMaximumWaveSpeed() does not match sqrt((lambda+2*mu)/rho) for an isotropic "
+                           "linear-elastic material in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // getMaximumWaveSpeed() must operate on a *copy* of the state variables, not mutate the
+  // caller's array.
+  throwExceptionOnFailure( stateVars[0] == -1.0,
+                           "getMaximumWaveSpeed() must not mutate the caller's state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testGetMaximumWaveSpeedCopiesNonEmptyStateVars,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotMechanicsCore/src/HughesWinget.cpp
+++ b/modules/core/MarmotMechanicsCore/src/HughesWinget.cpp
@@ -26,7 +26,7 @@ namespace Marmot::NumericalAlgorithms {
 
   Matrix3d HughesWinget::getRotationIncrement()
   {
-    return dOmega;
+    return dR;
   }
 
   Marmot::Vector6d HughesWinget::rotateTensor( const Marmot::Vector6d& tensor )

--- a/modules/core/MarmotMechanicsCore/test.cmake
+++ b/modules/core/MarmotMechanicsCore/test.cmake
@@ -4,6 +4,9 @@ SET(CURR_TEST_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test")
 # Tests for HaighWestergaard
 add_marmot_test("TestHaighWestergaard" "${CURR_TEST_SOURCE_DIR}/TestHaighWestergaard.cpp")
 
+# Tests for HughesWinget
+add_marmot_test("TestHughesWinget" "${CURR_TEST_SOURCE_DIR}/TestHughesWinget.cpp")
+
 # Tests for MarmotElasticity
 add_marmot_test("TestMarmotElasticity" "${CURR_TEST_SOURCE_DIR}/TestMarmotElasticity.cpp")
 

--- a/modules/core/MarmotMechanicsCore/test/TestHughesWinget.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestHughesWinget.cpp
@@ -1,0 +1,242 @@
+#include "Marmot/HughesWinget.h"
+#include "Marmot/MarmotKinematics.h"
+#include "Marmot/MarmotTesting.h"
+#include "Marmot/MarmotVoigt.h"
+#include <Eigen/Dense>
+#include <cmath>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::NumericalAlgorithms;
+
+// ---------------------------------------------------------------------------------------------
+// No callers anywhere in the codebase currently use this class (HughesWingetWrapper in
+// MarmotMaterialHughesWinget.h reimplements the same corotational algorithm independently rather
+// than delegating to it), so there is no production usage pattern to reuse for these tests --
+// verified instead against physical/algebraic identities and, for the tangent helpers, against
+// the fixed projector tensors from MarmotKinematics.h that they are built from.
+// ---------------------------------------------------------------------------------------------
+
+void testPureStretchHasNoRotation()
+{
+  // FOld = I, FNew = a small symmetric (diagonal) stretch: no rotation should be detected.
+  Eigen::Matrix3d FOld = Eigen::Matrix3d::Identity();
+  Eigen::Matrix3d FNew = Eigen::Matrix3d::Identity();
+  FNew( 0, 0 )         = 1.002;
+  FNew( 1, 1 )         = 0.999;
+
+  HughesWinget hw( FOld, FNew, HughesWinget::AbaqusLike );
+
+  throwExceptionOnFailure( checkIfEqual< double >( hw.getRotationIncrement(),
+                                                   Eigen::Matrix3d::Identity().eval(),
+                                                   1e-12 ),
+                           "A pure stretch (no rotation) must give an identity rotation increment in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // The strain increment (Voigt) must match the documented formula (l = (FNew-FOld)*FMidStep^-1,
+  // dEps = symmetric part of l, in Voigt notation), recomputed here independently.
+  const Eigen::Matrix3d  FMidStep     = 0.5 * ( FNew + FOld );
+  const Eigen::Matrix3d  lMat         = ( FNew - FOld ) * FMidStep.inverse();
+  const Eigen::Matrix3d  dEpsMat      = 0.5 * ( lMat + lMat.transpose() );
+  const Marmot::Vector6d dEpsExpected = ContinuumMechanics::VoigtNotation::voigtFromStrainMatrix< 3 >( dEpsMat );
+
+  Marmot::Vector6d dEps = hw.getStrainIncrement();
+  throwExceptionOnFailure( checkIfEqual< double >( dEps, dEpsExpected, 1e-12 ),
+                           "Pure-stretch strain increment does not match the documented l = "
+                           "(FNew-FOld)*FMidStep^-1 formula in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // With no rotation, rotateTensor() must be the identity map.
+  Marmot::Vector6d someStress = Marmot::Vector6d::Zero();
+  someStress << 10., 20., 30., 4., 5., 6.;
+  throwExceptionOnFailure( checkIfEqual< double >( hw.rotateTensor( someStress ), someStress, 1e-10 ),
+                           "rotateTensor() must be the identity map when there is no rotation increment in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testPureRotationPreservesIsotropicStress()
+{
+  // FOld = I, FNew = a small rotation about the z-axis: no stretching should be detected, and an
+  // isotropic (spherical) stress -- invariant under any rotation -- must be returned unchanged.
+  const double    phi  = 0.01; // rad
+  Eigen::Matrix3d FOld = Eigen::Matrix3d::Identity();
+  Eigen::Matrix3d FNew = Eigen::Matrix3d::Identity();
+  FNew( 0, 0 )         = std::cos( phi );
+  FNew( 0, 1 )         = -std::sin( phi );
+  FNew( 1, 0 )         = std::sin( phi );
+  FNew( 1, 1 )         = std::cos( phi );
+
+  HughesWinget hw( FOld, FNew, HughesWinget::AbaqusLike );
+
+  throwExceptionOnFailure( checkIfEqual< double >( hw.getStrainIncrement(), Marmot::Vector6d::Zero().eval(), 1e-10 ),
+                           "A pure rotation must give a zero strain increment in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // For a small rotation, the Hughes-Winget (Cayley-transform) incremental rotation must
+  // approximate the exact rotation matrix.
+  throwExceptionOnFailure( checkIfEqual< double >( hw.getRotationIncrement(), FNew, 1e-4 ),
+                           "The incremental rotation does not approximate the applied small rotation in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  Marmot::Vector6d isotropicStress = Marmot::Vector6d::Zero();
+  isotropicStress( 0 ) = isotropicStress( 1 ) = isotropicStress( 2 ) = -100.0; // hydrostatic pressure
+  throwExceptionOnFailure( checkIfEqual< double >( hw.rotateTensor( isotropicStress ), isotropicStress, 1e-8 ),
+                           "An isotropic stress state must be invariant under rotateTensor() in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testRotateTensorMatchesDirectSimilarityTransform()
+{
+  // General (non-trivial) FOld/FNew, so dR is neither the identity nor a simple z-rotation.
+  Eigen::Matrix3d FOld = Eigen::Matrix3d::Identity();
+  Eigen::Matrix3d FNew( 3, 3 );
+  // clang-format off
+  FNew << 1.02,  0.03, -0.01,
+          0.04,  0.98,  0.02,
+         -0.02,  0.01,  1.01;
+  // clang-format on
+
+  HughesWinget hw( FOld, FNew, HughesWinget::AbaqusLike );
+
+  Marmot::Vector6d stress = Marmot::Vector6d::Zero();
+  stress << 50., -20., 10., 5., -3., 2.;
+
+  const Marmot::Vector6d rotated = hw.rotateTensor( stress );
+
+  // Recompute the same similarity transform independently via the plain 3x3 matrices, rather than
+  // by re-deriving rotateTensor()'s own Voigt-conversion internals.
+  const Eigen::Matrix3d  dR                 = hw.getRotationIncrement();
+  const Eigen::Matrix3d  stressMat          = ContinuumMechanics::VoigtNotation::voigtToStress< double >( stress );
+  const Eigen::Matrix3d  rotatedMatExpected = dR * stressMat * dR.transpose();
+  const Marmot::Vector6d rotatedExpected    = ContinuumMechanics::VoigtNotation::stressToVoigt< double >(
+    rotatedMatExpected );
+
+  throwExceptionOnFailure( checkIfEqual< double >( rotated, rotatedExpected, 1e-10 ),
+                           "rotateTensor() does not match dR * stress * dR^T in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // dR must be a proper rotation (orthogonal, unit determinant), as returned by a Cayley transform
+  // of a skew matrix.
+  throwExceptionOnFailure( checkIfEqual< double >( ( dR.transpose() * dR ).eval(),
+                                                   Eigen::Matrix3d::Identity().eval(),
+                                                   1e-10 ) &&
+                             checkIfEqual( dR.determinant(), 1.0, 1e-10 ),
+                           "The incremental rotation matrix must be orthogonal with unit determinant in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// compute_dS_dF() / compute_dScalar_dF(): both are, for fixed inputs, purely linear combinations
+// of the caller-supplied tensors with the *fixed* (state-independent) projector tensors
+// dOmega_dVelocityGradient / dStretchingRate_dVelocityGradient from MarmotKinematics.h. Choosing
+// FOld = FNew = I makes FInv = I and isolates each term in turn (zero stress isolates the
+// Jaumann/material term; zero dChauchydEps isolates the rotational term), so both can be checked
+// against a closed-form reference built directly from those same public projector tensors --
+// without needing to re-derive or duplicate the (approximate, Abaqus-UMAT-style) tangent formula.
+// ---------------------------------------------------------------------------------------------
+
+void testComputeDScalarDFMatchesProjectorContraction()
+{
+  Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
+  HughesWinget    hw( I, I, HughesWinget::AbaqusLike );
+
+  Marmot::Vector6d dScalarDEps = Marmot::Vector6d::Zero();
+  dScalarDEps << 1., 2., 3., 4., 5., 6.;
+
+  const Eigen::Matrix3d result = hw.compute_dScalar_dF( I, dScalarDEps );
+
+  using namespace Marmot::ContinuumMechanics::Kinematics::VelocityGradient;
+  Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
+  for ( int k = 0; k < 3; k++ )
+    for ( int l = 0; l < 3; l++ )
+      for ( int ij = 0; ij < 6; ij++ )
+        expected( k, l ) += dScalarDEps( ij ) * dStretchingRate_dVelocityGradient( ij, k, l );
+
+  throwExceptionOnFailure( checkIfEqual< double >( result, expected, 1e-12 ),
+                           "compute_dScalar_dF() does not match the direct contraction with "
+                           "dStretchingRate_dVelocityGradient in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputeDSDFJaumannTermMatchesProjectorContraction()
+{
+  // Zero stress isolates the Jaumann (material-tangent-driven) term.
+  Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
+  HughesWinget    hw( I, I, HughesWinget::AbaqusLike );
+
+  Marmot::Vector6d zeroStress = Marmot::Vector6d::Zero();
+
+  Marmot::Matrix6d dChauchydEps = Marmot::Matrix6d::Zero();
+  for ( int i = 0; i < 6; i++ )
+    for ( int j = 0; j < 6; j++ )
+      dChauchydEps( i, j ) = 1.0 + i + 2.0 * j;
+
+  const EigenTensors::Tensor633d result = hw.compute_dS_dF( zeroStress, I, dChauchydEps );
+
+  using namespace Marmot::ContinuumMechanics::Kinematics::VelocityGradient;
+  bool matches = true;
+  for ( int ij = 0; ij < 6 && matches; ij++ )
+    for ( int k = 0; k < 3 && matches; k++ )
+      for ( int l = 0; l < 3 && matches; l++ ) {
+        double expected = 0.0;
+        for ( int mn = 0; mn < 6; mn++ )
+          expected += dChauchydEps( ij, mn ) * dStretchingRate_dVelocityGradient( mn, k, l );
+        matches = matches && checkIfEqual( result( ij, k, l ), expected, 1e-10 );
+      }
+
+  throwExceptionOnFailure( matches,
+                           "compute_dS_dF() (Jaumann term, zero stress) does not match the direct contraction "
+                           "with dStretchingRate_dVelocityGradient in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputeDSDFRotationalTermMatchesProjectorContraction()
+{
+  // Zero dChauchydEps isolates the rotational (stress-spin) term.
+  Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
+  HughesWinget    hw( I, I, HughesWinget::AbaqusLike );
+
+  Marmot::Vector6d stress = Marmot::Vector6d::Zero();
+  stress << 10., 20., 30., 4., 5., 6.;
+  const Eigen::Matrix3d stressMat = ContinuumMechanics::VoigtNotation::voigtToStress< double >( stress );
+
+  Marmot::Matrix6d zeroTangent = Marmot::Matrix6d::Zero();
+
+  const EigenTensors::Tensor633d result = hw.compute_dS_dF( stress, I, zeroTangent );
+
+  using namespace Marmot::ContinuumMechanics::Kinematics::VelocityGradient;
+  using namespace Marmot::ContinuumMechanics::TensorUtility;
+  bool matches = true;
+  for ( int ij = 0; ij < 6 && matches; ij++ ) {
+    auto [i, j] = IndexNotation::fromVoigt< 3 >( ij );
+    for ( int k = 0; k < 3 && matches; k++ )
+      for ( int l = 0; l < 3 && matches; l++ ) {
+        double expected = 0.0;
+        for ( int m = 0; m < 3; m++ )
+          expected += dOmega_dVelocityGradient( i, m, k, l ) * stressMat( m, j ) +
+                      dOmega_dVelocityGradient( j, m, k, l ) * stressMat( i, m );
+        matches = matches && checkIfEqual( result( ij, k, l ), expected, 1e-10 );
+      }
+  }
+
+  throwExceptionOnFailure( matches,
+                           "compute_dS_dF() (rotational term, zero tangent) does not match the direct "
+                           "contraction with dOmega_dVelocityGradient in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testPureStretchHasNoRotation,
+    testPureRotationPreservesIsotropicStress,
+    testRotateTensorMatchesDirectSimilarityTransform,
+    testComputeDScalarDFMatchesProjectorContraction,
+    testComputeDSDFJaumannTermMatchesProjectorContraction,
+    testComputeDSDFRotationalTermMatchesProjectorContraction,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/materials/CompressibleNeoHooke/test/test.cpp
+++ b/modules/materials/CompressibleNeoHooke/test/test.cpp
@@ -340,14 +340,288 @@ void testWithMPSolver()
                            "I-5: Material Point Solver simple shear test failed for CompressibleNeoHooke material in " +
                              std::string( __PRETTY_FUNCTION__ ) );
 }
+// ─────────────────────────────────────────────────────────────────────────────
+// The following tests exercise MarmotMaterialFiniteStrain's default (base-class)
+// implementations, none of which CompressibleNeoHooke overrides: computeStressExplicit,
+// computeStress(..., eigenDeformation), computePlaneStrain(Explicit) (with and without
+// eigenDeformation), computePlaneStress(Explicit), getStateView, getMaximumWaveSpeed,
+// setCharacteristicElementLength and findEigenDeformationForEigenStress.
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+  std::array< double, 2 > materialProperties_ = { 3500, 1500 };
+  CompressibleNeoHooke    makeMaterial()
+  {
+    return CompressibleNeoHooke( &materialProperties_[0], 2, 1 );
+  }
+} // namespace
+
+void testComputeStressExplicitMatchesComputeStress()
+{
+  CompressibleNeoHooke matA = makeMaterial();
+  CompressibleNeoHooke matB = makeMaterial();
+
+  Tensor33d inputF = Marmot::FastorStandardTensors::Spatial3D::I;
+  inputF( 0, 1 ) += 0.05;
+
+  CompressibleNeoHooke::Deformation< 3 >          def     = { inputF };
+  CompressibleNeoHooke::TimeIncrement             timeInc = { 0, 0.1 };
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resA( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tanA = { Tensor3333d( 0.0 ) };
+  matA.computeStress( resA, tanA, def, timeInc );
+
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resB( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  matB.computeStressExplicit( resB, def, timeInc );
+
+  throwExceptionOnFailure( checkIfEqual( resA.tau, resB.tau, 1e-14 ) &&
+                             checkIfEqual( resA.elasticEnergyDensity, resB.elasticEnergyDensity, 1e-14 ),
+                           "computeStressExplicit() must match computeStress() ignoring the tangent in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputeStressWithEigenDeformation()
+{
+  CompressibleNeoHooke mat = makeMaterial();
+
+  Tensor33d inputF = Marmot::FastorStandardTensors::Spatial3D::I;
+  inputF( 0, 0 )   = 1.01;
+  inputF( 1, 1 )   = 1.02;
+  inputF( 2, 2 )   = 0.95;
+
+  const double F0_XX = 1.03, F0_YY = 0.98, F0_ZZ = 1.01;
+
+  // Reference: compute directly at the eigen-deformation-scaled F (only the diagonal is scaled).
+  Tensor33d fRef = inputF;
+  fRef( 0, 0 ) *= F0_XX;
+  fRef( 1, 1 ) *= F0_YY;
+  fRef( 2, 2 ) *= F0_ZZ;
+
+  CompressibleNeoHooke::Deformation< 3 >          defRef  = { fRef };
+  CompressibleNeoHooke::TimeIncrement             timeInc = { 0, 0.1 };
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resRef( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tanRef = { Tensor3333d( 0.0 ) };
+  mat.computeStress( resRef, tanRef, defRef, timeInc );
+
+  CompressibleNeoHooke::Deformation< 3 >          def = { inputF };
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > res( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tan = { Tensor3333d( 0.0 ) };
+  // CompressibleNeoHooke's own 4-arg computeStress() override hides the base class's 5-arg
+  // (eigenDeformation) overload for a concretely-typed instance -- call through an explicit
+  // base-class reference, as production code does (always via a MarmotMaterialFiniteStrain*).
+  MarmotMaterialFiniteStrain& matBase = mat;
+  matBase.computeStress( res, tan, def, timeInc, { F0_XX, F0_YY, F0_ZZ } );
+
+  throwExceptionOnFailure( checkIfEqual( res.tau, resRef.tau, 1e-10 ),
+                           "computeStress() with eigenDeformation must match computing directly at the "
+                           "eigen-deformation-scaled F in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // The tangent's diagonal-vs-diagonal blocks are additionally chain-ruled by F0 (dF'_kk/dF_kk = F0_kk);
+  // the remaining entries are unaffected, since only the diagonal of F is rescaled.
+  const double F0[3]     = { F0_XX, F0_YY, F0_ZZ };
+  bool         tangentOk = true;
+  for ( int i = 0; i < 3; i++ )
+    for ( int j = 0; j < 3; j++ )
+      for ( int k = 0; k < 3; k++ )
+        tangentOk = tangentOk && checkIfEqual( tan.dTau_dF( i, j, k, k ), tanRef.dTau_dF( i, j, k, k ) * F0[k], 1e-8 );
+
+  throwExceptionOnFailure( tangentOk,
+                           "computeStress() with eigenDeformation did not chain-rule the tangent's diagonal "
+                           "blocks by F0 in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputePlaneStrainMatchesComputeStress()
+{
+  CompressibleNeoHooke mat = makeMaterial();
+
+  Tensor33d inputF = Marmot::FastorStandardTensors::Spatial3D::I;
+  inputF( 0, 0 )   = 1.02;
+  inputF( 1, 1 )   = 0.99;
+  inputF( 2, 2 )   = 1.0; // plane strain: no out-of-plane stretch
+
+  CompressibleNeoHooke::Deformation< 3 > def     = { inputF };
+  CompressibleNeoHooke::TimeIncrement    timeInc = { 0, 0.1 };
+
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resStress( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tanStress = { Tensor3333d( 0.0 ) };
+  mat.computeStress( resStress, tanStress, def, timeInc );
+
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resStrain( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tanStrain = { Tensor3333d( 0.0 ) };
+  mat.computePlaneStrain( resStrain, tanStrain, def, timeInc );
+
+  throwExceptionOnFailure( checkIfEqual( resStress.tau, resStrain.tau, 1e-14 ) &&
+                             checkIfEqual( tanStress.dTau_dF, tanStrain.dTau_dF, 1e-14 ),
+                           "computePlaneStrain() must match computeStress() for MarmotMaterialFiniteStrain's "
+                           "default (pass-through) implementation in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // ... and the eigen-deformation overload must match computeStress(..., eigenDeformation) likewise.
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resStressEigen( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tanStressEigen  = { Tensor3333d( 0.0 ) };
+  MarmotMaterialFiniteStrain&                     matBaseForEigen = mat;
+  matBaseForEigen.computeStress( resStressEigen, tanStressEigen, def, timeInc, { 1.01, 0.99, 1.02 } );
+
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resStrainEigen( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tanStrainEigen = { Tensor3333d( 0.0 ) };
+  mat.computePlaneStrain( resStrainEigen, tanStrainEigen, def, timeInc, { 1.01, 0.99, 1.02 } );
+
+  throwExceptionOnFailure( checkIfEqual( resStressEigen.tau, resStrainEigen.tau, 1e-14 ),
+                           "computePlaneStrain() with eigenDeformation must match computeStress() with "
+                           "eigenDeformation in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // computePlaneStrainExplicit (both overloads) must match computePlaneStrain ignoring the tangent.
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resExplicit( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  mat.computePlaneStrainExplicit( resExplicit, def, timeInc );
+  throwExceptionOnFailure( checkIfEqual( resExplicit.tau, resStrain.tau, 1e-14 ),
+                           "computePlaneStrainExplicit() must match computePlaneStrain() in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > resExplicitEigen( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  mat.computePlaneStrainExplicit( resExplicitEigen, def, timeInc, { 1.01, 0.99, 1.02 } );
+  throwExceptionOnFailure( checkIfEqual( resExplicitEigen.tau, resStrainEigen.tau, 1e-14 ),
+                           "computePlaneStrainExplicit() with eigenDeformation must match computePlaneStrain() "
+                           "with eigenDeformation in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputePlaneStressIsNotYetImplemented()
+{
+  CompressibleNeoHooke mat = makeMaterial();
+
+  Fastor::Tensor< double, 2, 2 > inputF2D( 0.0 );
+  inputF2D( 0, 0 )                                        = 1.0;
+  inputF2D( 1, 1 )                                        = 1.0;
+  CompressibleNeoHooke::Deformation< 2 >          def2D   = { inputF2D };
+  CompressibleNeoHooke::TimeIncrement             timeInc = { 0, 0.1 };
+  CompressibleNeoHooke::ConstitutiveResponse< 2 > res2D( Fastor::Tensor< double, 2, 2 >( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 2 >    tan2D = { Fastor::Tensor< double, 2, 2, 2, 2 >( 0.0 ) };
+
+  bool threw = false;
+  try {
+    mat.computePlaneStress( res2D, tan2D, def2D, timeInc );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computePlaneStress() (base class default) must throw std::invalid_argument in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // computePlaneStressExplicit() delegates to computePlaneStress() and must propagate the throw.
+  bool threwExplicit = false;
+  try {
+    mat.computePlaneStressExplicit( res2D, def2D, timeInc );
+  }
+  catch ( const std::invalid_argument& ) {
+    threwExplicit = true;
+  }
+  throwExceptionOnFailure( threwExplicit,
+                           "computePlaneStressExplicit() must propagate computePlaneStress()'s throw in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testGetStateViewThrowsForMaterialWithNoStateVars()
+{
+  // CompressibleNeoHooke requires no state variables, so any name lookup on its (empty)
+  // state layout is necessarily unknown -- this documents that behaviour rather than
+  // asserting a specific state variable exists.
+  CompressibleNeoHooke mat = makeMaterial();
+
+  bool threw = false;
+  try {
+    mat.getStateView( "anything", nullptr );
+  }
+  catch ( const std::runtime_error& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "getStateView() must throw for a material with no registered state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testGetMaximumWaveSpeedMatchesAnalyticalTangentAtIdentity()
+{
+  // getDensity() requires a 3rd material property (density), unlike the K,G-only materials used
+  // elsewhere in this file.
+  std::array< double, 3 > propsWithDensity = { 3500, 1500, 2400 };
+  CompressibleNeoHooke    mat( propsWithDensity.data(), 3, 1 );
+
+  Tensor33d inputF = Marmot::FastorStandardTensors::Spatial3D::I;
+
+  CompressibleNeoHooke::Deformation< 3 >          def     = { inputF };
+  CompressibleNeoHooke::TimeIncrement             timeInc = { 0, 0.1 };
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > res( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tan = { Tensor3333d( 0.0 ) };
+  mat.computeStress( res, tan, def, timeInc );
+
+  const double maxDiag = std::max(
+    { tan.dTau_dF( 0, 0, 0, 0 ), tan.dTau_dF( 1, 1, 1, 1 ), tan.dTau_dF( 2, 2, 2, 2 ) } );
+  const double density  = mat.getDensity( nullptr );
+  const double expected = std::sqrt( maxDiag / density );
+
+  const double waveSpeed = mat.getMaximumWaveSpeed( nullptr, inputF );
+  throwExceptionOnFailure( checkIfEqual( waveSpeed, expected, 1e-5 ),
+                           "getMaximumWaveSpeed() does not match sqrt(max(C_ii)/rho) from the analytical tangent "
+                           "at F=I in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSetCharacteristicElementLengthIsANoOp()
+{
+  CompressibleNeoHooke mat = makeMaterial();
+  // The base class default does nothing; this call exists purely to exercise that no-op body.
+  mat.setCharacteristicElementLength( 0.5 );
+}
+
+void testFindEigenDeformationForEigenStressReproducesTargetStress()
+{
+  CompressibleNeoHooke mat = makeMaterial();
+
+  const std::tuple< double, double, double > initialGuess = { 1.0, 1.0, 1.0 };
+  const std::tuple< double, double, double > targetStress = { 100.0, 150.0, 200.0 };
+
+  const auto [F0_XX, F0_YY, F0_ZZ] = mat.findEigenDeformationForEigenStress( initialGuess, targetStress, nullptr );
+
+  Tensor33d fFound( 0.0 );
+  fFound( 0, 0 ) = F0_XX;
+  fFound( 1, 1 ) = F0_YY;
+  fFound( 2, 2 ) = F0_ZZ;
+
+  CompressibleNeoHooke::Deformation< 3 >          def     = { fFound };
+  CompressibleNeoHooke::TimeIncrement             timeInc = { 0, 0.1 };
+  CompressibleNeoHooke::ConstitutiveResponse< 3 > res( Tensor33d( 0.0 ), 0.0, 0.0, nullptr );
+  CompressibleNeoHooke::AlgorithmicModuli< 3 >    tan = { Tensor3333d( 0.0 ) };
+  mat.computeStress( res, tan, def, timeInc );
+
+  throwExceptionOnFailure( checkIfEqual( res.tau( 0, 0 ), std::get< 0 >( targetStress ), 1e-6 ) &&
+                             checkIfEqual( res.tau( 1, 1 ), std::get< 1 >( targetStress ), 1e-6 ) &&
+                             checkIfEqual( res.tau( 2, 2 ), std::get< 2 >( targetStress ), 1e-6 ),
+                           "findEigenDeformationForEigenStress() did not converge to a deformation reproducing "
+                           "the target diagonal stress in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
 int main()
 {
 
-  auto tests = std::vector< std::function< void() > >{ testUndeformedResponse,
-                                                       testDeformationResponse,
-                                                       testAlgorithmicTangent,
-                                                       testRotation,
-                                                       testWithMPSolver };
+  auto tests = std::vector< std::function< void() > >{
+    testUndeformedResponse,
+    testDeformationResponse,
+    testAlgorithmicTangent,
+    testRotation,
+    testWithMPSolver,
+    testComputeStressExplicitMatchesComputeStress,
+    testComputeStressWithEigenDeformation,
+    testComputePlaneStrainMatchesComputeStress,
+    testComputePlaneStressIsNotYetImplemented,
+    testGetStateViewThrowsForMaterialWithNoStateVars,
+    testGetMaximumWaveSpeedMatchesAnalyticalTangentAtIdentity,
+    testSetCharacteristicElementLengthIsANoOp,
+    testFindEigenDeformationForEigenStressReproducesTargetStress,
+  };
 
   executeTestsAndCollectExceptions( tests );
 


### PR DESCRIPTION
## Summary
- **Bug fix**: `Marmot::NumericalAlgorithms::HughesWinget::getRotationIncrement()` returned `dOmega` (the raw spin increment) instead of `dR` (the Cayley-transformed incremental rotation matrix actually used internally by `rotateTensor()`). For any non-trivial rotation these differ substantially, and `dOmega` isn't even a proper rotation matrix. Found while adding coverage — this class has zero callers anywhere in the codebase (`HughesWingetWrapper` in `MarmotMaterialHughesWinget.h` reimplements the same corotational algorithm independently rather than delegating to it), so the bug went undetected.
- `HughesWinget.cpp` was entirely untested (0%). Added tests verifying the strain increment against the documented `l = (FNew-FOld)*FMidStep^-1` formula, the rotation increment via pure-stretch (identity) and pure-rotation (approximates the applied rotation) cases, `rotateTensor()` against an independently-computed `R*sigma*R^T`, and `compute_dS_dF()`/`compute_dScalar_dF()` against the fixed (state-independent) projector tensors from `MarmotKinematics.h` that they're built from.
- `MarmotMaterialFiniteStrain.h`/`.cpp` (32.65%/0% patch coverage): none of `CompressibleNeoHooke`'s overrides touch the base class's default `computeStressExplicit`, `computeStress`/`computePlaneStrain(Explicit)` with `eigenDeformation`, `computePlaneStress(Explicit)` (always "not yet implemented"), `getStateView`, or `findEigenDeformationForEigenStress`. Extended its existing test suite to exercise all of them.
- `getMaximumWaveSpeed()`'s non-empty-state-variable-copy branch needs a material that both has state variables and leaves this method at its base-class default — no shipped material does, so added a minimal linear-elastic test-only material and verified the result against the closed-form P-wave modulus `sqrt((lambda+2*mu)/rho)`.

Known minor gaps, left undone rather than overclaimed: the unused `Tensor<3,3>` overload of `applyEigenDeformationToTangent_` (there's also a `Tensor<3,3,3,3>` overload, which `computeStress`'s only call site uses) and `findEigenDeformationForEigenStress`'s iteration-exhausted throw both have no natural trigger through a well-posed material's Newton iteration.

## Test plan
- [x] `ctest` — 50/50 tests pass locally (Debug build)
- [x] Local `gcovr` (max-merged across translation units): `HughesWinget.cpp` 0% → 100%; `MarmotMaterialFiniteStrain.cpp` 0% → 89.9%; `MarmotMaterialFiniteStrain.h` 32.65% → 93.1%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA