### PR TITLE
test(core): cover MarmotMaterialHypoElastic's base-class defaults

### DIFF
--- a/modules/core/MarmotMechanicsCore/test.cmake
+++ b/modules/core/MarmotMechanicsCore/test.cmake
@@ -42,3 +42,6 @@ add_marmot_test("TestNewmarkBetaIntegrator" "${CURR_TEST_SOURCE_DIR}/TestNewmark
 
 # Tests for MarmotGeostaticStress
 add_marmot_test("TestMarmotGeostaticStress" "${CURR_TEST_SOURCE_DIR}/TestMarmotGeostaticStress.cpp")
+
+# Tests for MarmotMaterialHypoElastic
+add_marmot_test("TestMarmotMaterialHypoElastic" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialHypoElastic.cpp")

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotMaterialHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotMaterialHypoElastic.cpp
@@ -1,0 +1,138 @@
+#include "Marmot/MarmotExceptions.h"
+#include "Marmot/MarmotMaterialHypoElastic.h"
+#include "Marmot/MarmotTesting.h"
+#include <utility>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+
+namespace {
+
+  // A minimal test-only material whose out-of-plane/lateral stress components are positive
+  // constants, independent of strain, with correspondingly zero tangent entries for those
+  // components. No real, registered hypoelastic material behaves like this (dStress/dStrain is
+  // always non-singular for a physically sound law), so this is the only practical way to
+  // deterministically exercise computePlaneStress()'s and computeUniaxialStress()'s robustness
+  // branches: the near-singular-tangent compliance cap, and the cutback/failure throw.
+  class NeverConvergingHypoElasticMaterial : public MarmotMaterialHypoElastic {
+  public:
+    NeverConvergingHypoElasticMaterial() : MarmotMaterialHypoElastic( nullptr, 0, 1 )
+    {
+      stateLayout.add( "dummy", 1 );
+      stateLayout.finalize();
+    }
+
+    void computeStress( state3D&          state,
+                        Marmot::Matrix6d& dStress_dStrain,
+                        const Marmot::Vector6d&,
+                        const timeInfo& ) const override
+    {
+      state.stress      = Marmot::Vector6d::Zero();
+      state.stress( 1 ) = 5.0; // never zero, and independent of dStrain
+      state.stress( 2 ) = 5.0;
+
+      dStress_dStrain.setZero(); // dSigma_yy/dEps_yy == dSigma_zz/dEps_zz == 0
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  std::pair< NeverConvergingHypoElasticMaterial, std::vector< double > > makeNeverConvergingMaterial()
+  {
+    NeverConvergingHypoElasticMaterial mat;
+    std::vector< double >              stateVars( mat.getNumberOfRequiredStateVars(), 0.0 );
+    return { std::move( mat ), std::move( stateVars ) };
+  }
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// computePlaneStress(): must throw StressUpdateFailed after exhausting its cutback attempts when
+// the out-of-plane stress can never be driven to zero, hitting the near-singular tangent
+// (dStress_dStrain(2,2) == 0) "cap the compliance instead of dividing by zero" branch first.
+// ---------------------------------------------------------------------------------------------
+void testComputePlaneStressThrowsWhenItCannotConverge()
+{
+  auto [mat, stateVars] = makeNeverConvergingMaterial();
+
+  Marmot::Vector3d dStrain2D = Marmot::Vector3d::Zero();
+  dStrain2D( 0 )             = 1e-3;
+  MarmotMaterialHypoElastic::timeInfo timeInfo{ 0.0, 1.0 };
+  MarmotMaterialHypoElastic::state2D  state2D;
+  state2D.stateVars = stateVars.data();
+  Marmot::Matrix3d tan2D;
+
+  bool threw = false;
+  try {
+    mat.computePlaneStress( state2D, tan2D, dStrain2D, timeInfo );
+  }
+  catch ( const Marmot::StressUpdateFailed& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computePlaneStress() must throw StressUpdateFailed when it cannot converge in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// computeUniaxialStress(): same robustness requirement as computePlaneStress(), but condensing
+// both lateral stress components (indices 1 and 2) simultaneously via a 2x2 solve.
+// ---------------------------------------------------------------------------------------------
+void testComputeUniaxialStressThrowsWhenItCannotConverge()
+{
+  auto [mat, stateVars] = makeNeverConvergingMaterial();
+
+  const double                        dStrain1D = 1e-3;
+  MarmotMaterialHypoElastic::timeInfo timeInfo{ 0.0, 1.0 };
+  MarmotMaterialHypoElastic::state1D  state1D;
+  state1D.stateVars = stateVars.data();
+  double tan1D;
+
+  bool threw = false;
+  try {
+    mat.computeUniaxialStress( state1D, tan1D, dStrain1D, timeInfo );
+  }
+  catch ( const Marmot::StressUpdateFailed& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "computeUniaxialStress() must throw StressUpdateFailed when it cannot converge in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// getMaximumWaveSpeed(): when the material has state variables and a valid (non-null) stateVars
+// pointer is supplied, the perturbed evaluation must be performed on a *copy* of the state.
+// ---------------------------------------------------------------------------------------------
+void testGetMaximumWaveSpeedCopiesNonEmptyStateVars()
+{
+  auto [mat, stateVars] = makeNeverConvergingMaterial();
+  stateVars[0]          = -1.0;
+
+  MarmotMaterialHypoElastic::state3D state;
+  state.stateVars = stateVars.data();
+
+  const double waveSpeed = mat.getMaximumWaveSpeed( state );
+
+  // dStress_dStrain is identically zero for this material, so the max stiffness diagonal is 0.
+  throwExceptionOnFailure( waveSpeed == 0.0,
+                           "getMaximumWaveSpeed() did not return 0 for a zero tangent in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( stateVars[0] == -1.0,
+                           "getMaximumWaveSpeed() must not mutate the caller's state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testComputePlaneStressThrowsWhenItCannotConverge,
+    testComputeUniaxialStressThrowsWhenItCannotConverge,
+    testGetMaximumWaveSpeedCopiesNonEmptyStateVars,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/materials/LinearElastic/test/test.cpp
+++ b/modules/materials/LinearElastic/test/test.cpp
@@ -2,6 +2,8 @@
 #include "Marmot/MarmotMaterialPointSolverHypoElastic.h"
 #include "Marmot/MarmotTesting.h"
 #include <Eigen/Dense>
+#include <algorithm>
+#include <array>
 
 // Use namespaces for brevity
 using namespace Marmot::Testing;
@@ -383,6 +385,156 @@ void testGetDensityOrthotropic()
                            "Density retrieval failed for isotropic material in " + std::string( __PRETTY_FUNCTION__ ) );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// The following tests exercise MarmotMaterialHypoElastic's default (base-class)
+// implementations, none of which LinearElastic overrides: computeStressExplicit,
+// computePlaneStress, computeUniaxialStress, getMaximumWaveSpeed, getStateView,
+// initializeYourself and setCharacteristicElementLength.
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+  std::array< double, 2 >          isotropicProps_ = { 20000., 0.25 };
+  Marmot::Materials::LinearElastic makeIsotropicMaterial()
+  {
+    return { isotropicProps_.data(), 2, 1 };
+  }
+} // namespace
+
+void testComputeStressExplicitMatchesComputeStress()
+{
+  using namespace Marmot;
+  auto matA = makeIsotropicMaterial();
+  auto matB = makeIsotropicMaterial();
+
+  Vector6d dStrain = Vector6d::Zero();
+  dStrain( 0 )     = 1e-3;
+  dStrain( 3 )     = 2e-4;
+
+  MarmotMaterialHypoElastic::timeInfo timeInfo{ 0., 1. };
+
+  MarmotMaterialHypoElastic::state3D stateA;
+  Matrix6d                           tanA;
+  // LinearElastic re-declares computeStress() under `protected`, so call it through the base
+  // class (as production code always does, via a MarmotMaterialHypoElastic*).
+  MarmotMaterialHypoElastic& matABase = matA;
+  matABase.computeStress( stateA, tanA, dStrain, timeInfo );
+
+  MarmotMaterialHypoElastic::state3D stateB;
+  matB.computeStressExplicit( stateB, dStrain, timeInfo );
+
+  throwExceptionOnFailure( checkIfEqual< double >( stateA.stress, stateB.stress, 1e-12 ),
+                           "computeStressExplicit() must match computeStress() ignoring the tangent in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputePlaneStressMatchesClassicalPlaneStressLaw()
+{
+  using namespace Marmot;
+  auto mat = makeIsotropicMaterial();
+
+  const double E = isotropicProps_[0], nu = isotropicProps_[1];
+
+  Vector3d dStrain2D;
+  dStrain2D << 1e-3, 0.5e-3, 2e-4; // eps_xx, eps_yy, gamma_xy
+
+  MarmotMaterialHypoElastic::timeInfo timeInfo{ 0., 1. };
+  MarmotMaterialHypoElastic::state2D  state2D;
+  Matrix3d                            tan2D;
+
+  mat.computePlaneStress( state2D, tan2D, dStrain2D, timeInfo );
+
+  // Classical isotropic plane-stress law (sigma_zz = 0, both eps_xx and eps_yy prescribed):
+  //   sigma_xx = E/(1-nu^2) * (eps_xx + nu*eps_yy)
+  //   sigma_yy = E/(1-nu^2) * (eps_yy + nu*eps_xx)
+  //   sigma_xy = G * gamma_xy
+  const double planeStressModulus = E / ( 1. - nu * nu );
+  const double G                  = E / ( 2. * ( 1. + nu ) );
+  Vector3d     expected;
+  expected << planeStressModulus * ( dStrain2D( 0 ) + nu * dStrain2D( 1 ) ),
+    planeStressModulus * ( dStrain2D( 1 ) + nu * dStrain2D( 0 ) ), G * dStrain2D( 2 );
+
+  throwExceptionOnFailure( checkIfEqual< double >( state2D.stress, expected, 1e-6 ),
+                           "computePlaneStress() does not match the classical isotropic plane-stress law in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testComputeUniaxialStressMatchesE()
+{
+  using namespace Marmot;
+  auto mat = makeIsotropicMaterial();
+
+  const double E         = isotropicProps_[0];
+  const double dStrain1D = 1e-3;
+
+  MarmotMaterialHypoElastic::timeInfo timeInfo{ 0., 1. };
+  MarmotMaterialHypoElastic::state1D  state1D;
+  double                              tan1D;
+
+  mat.computeUniaxialStress( state1D, tan1D, dStrain1D, timeInfo );
+
+  throwExceptionOnFailure( checkIfEqual( state1D.stress, E * dStrain1D, 1e-6 ),
+                           "computeUniaxialStress() does not reduce to sigma = E*eps in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( tan1D, E, 1e-6 ),
+                           "computeUniaxialStress() tangent does not reduce to E in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testGetMaximumWaveSpeedMatchesPWaveModulus()
+{
+  using namespace Marmot;
+  const std::array< double, 3 > props = { 20000., 0.25, 2400. };
+  auto                          mat   = Marmot::Materials::LinearElastic( props.data(), 3, 1 );
+
+  const double E = props[0], nu = props[1], rho = props[2];
+  const double mu       = E / ( 2. * ( 1. + nu ) );
+  const double lambda   = E * nu / ( ( 1. + nu ) * ( 1. - 2. * nu ) );
+  const double expected = std::sqrt( ( lambda + 2. * mu ) / rho );
+
+  MarmotMaterialHypoElastic::state3D state;
+  const double                       waveSpeed = mat.getMaximumWaveSpeed( state );
+
+  throwExceptionOnFailure( checkIfEqual( waveSpeed, expected, 1e-5 ),
+                           "getMaximumWaveSpeed() does not match sqrt((lambda+2*mu)/rho) in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testGetStateViewThrowsForMaterialWithNoStateVars()
+{
+  auto mat = makeIsotropicMaterial();
+
+  bool threw = false;
+  try {
+    mat.getStateView( "anything", nullptr );
+  }
+  catch ( const std::runtime_error& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "getStateView() must throw for a material with no registered state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testInitializeYourselfZeroesStateVars()
+{
+  auto                  mat = makeIsotropicMaterial();
+  std::vector< double > stateVars( 3, 42.0 );
+  mat.initializeYourself( stateVars.data(), static_cast< int >( stateVars.size() ) );
+
+  throwExceptionOnFailure( std::all_of( stateVars.begin(), stateVars.end(), []( double v ) { return v == 0.0; } ),
+                           "initializeYourself() must zero all state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSetCharacteristicElementLengthIsStored()
+{
+  auto mat = makeIsotropicMaterial();
+  mat.setCharacteristicElementLength( 0.5 );
+  throwExceptionOnFailure( mat.characteristicElementLength == 0.5,
+                           "setCharacteristicElementLength() must store the given length in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
 int main()
 {
 
@@ -396,7 +548,14 @@ int main()
     testOrthotropicMaterialResponseRotation,      // test for orthotropic normal strain with rotation
     testGetDensityIsotropic,                      // test for density retrieval for isotropic case
     testGetDensityTransverselyIsotropic,          // test for density retrieval for transversely isotropic case
-    testGetDensityOrthotropic                     // test for density retrieval for orthotropic case
+    testGetDensityOrthotropic,                    // test for density retrieval for orthotropic case
+    testComputeStressExplicitMatchesComputeStress,
+    testComputePlaneStressMatchesClassicalPlaneStressLaw,
+    testComputeUniaxialStressMatchesE,
+    testGetMaximumWaveSpeedMatchesPWaveModulus,
+    testGetStateViewThrowsForMaterialWithNoStateVars,
+    testInitializeYourselfZeroesStateVars,
+    testSetCharacteristicElementLengthIsStored,
   };
 
   executeTestsAndCollectExceptions( tests );


### PR DESCRIPTION
## Summary
- `MarmotMaterialHypoElastic.cpp` (53.75% patch coverage) implements `computePlaneStress`, `computeUniaxialStress` and `getMaximumWaveSpeed` as base-class defaults for hypoelastic materials, but `LinearElastic` — the simplest registered material — only overrides `computeStress` and `getDensity`, so none of these were ever exercised through it.
- Extended `LinearElastic`'s existing test suite to call these directly: `computePlaneStress` against the classical isotropic plane-stress law (`sigma_xx = E/(1-nu^2)*(eps_xx+nu*eps_yy)`, etc. — both `eps_xx` and `eps_yy` are prescribed here, unlike the `eps_yy`-fixed condensation tested for `MarmotMaterialFiniteStrain` in an earlier PR), `computeUniaxialStress` against `sigma=E*eps`, `computeStressExplicit` against `computeStress`, and `getMaximumWaveSpeed` against the closed-form P-wave modulus `sqrt((lambda+2*mu)/rho)`. Also covered `getStateView`, `initializeYourself` and `setCharacteristicElementLength`.
- `computePlaneStress`'s/`computeUniaxialStress`'s near-singular-tangent compliance cap and cutback-failure throw, and `getMaximumWaveSpeed`'s non-empty-state-variable-copy branch, are unreachable through any real material's well-posed tangent (`LinearElastic`'s is constant and non-singular) — added a minimal test-only material with strain-independent, always-nonzero lateral/out-of-plane stress components to exercise them deterministically, the same technique used for `MarmotMaterialGeneralGradientEnhancedHypoElastic`'s equivalent branches in an earlier PR.

## Test plan
- [x] `ctest` — 49/49 tests pass locally (Debug build)
- [x] Local `gcovr` (both new test binaries combined): `MarmotMaterialHypoElastic.cpp` 53.75% → 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA