### PR TITLE
test(core): cover material factory throw paths and PronySeries::updateStateVars

### DIFF
--- a/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
@@ -18,3 +18,6 @@ add_marmot_test("TestMarmotFiniteStrainViscoelasticity" "${CURR_TEST_SOURCE_DIR}
 
 # Tests for the Hughes-Winget small-strain wrapper
 add_marmot_test("TestMarmotMaterialHughesWinget" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialHughesWinget.cpp")
+
+# Tests for MarmotMaterialFiniteStrainFactory
+add_marmot_test("TestMarmotMaterialFiniteStrainFactory" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialFiniteStrainFactory.cpp")

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialFiniteStrainFactory.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialFiniteStrainFactory.cpp
@@ -1,0 +1,53 @@
+#include "Marmot/MarmotMaterialFiniteStrainFactory.h"
+#include "Marmot/MarmotTesting.h"
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+using namespace Marmot::Testing;
+using namespace MarmotLibrary;
+
+// ---------------------------------------------------------------------------------------------
+// createMaterial(): the success path is exercised elsewhere (e.g. CompressibleNeoHooke's own
+// tests), but the throw branch for an unregistered material name is not. "COMPRESSIBLENEOHOOKE"
+// is genuinely registered (by CompressibleNeoHookeRegistration.cpp, linked into every test
+// executable via libMarmot), so a name guaranteed not to collide with it proves the throw path
+// specifically, not just "any unknown name".
+// ---------------------------------------------------------------------------------------------
+void testCreateMaterialThrowsForUnregisteredName()
+{
+  bool threw = false;
+  try {
+    MarmotMaterialFiniteStrainFactory::createMaterial( "DEFINITELY_NOT_REGISTERED", nullptr, 0, 1 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "createMaterial() must throw std::invalid_argument for an unregistered material name "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCreateMaterialSucceedsForRegisteredName()
+{
+  const double                                  properties[2] = { 3500., 1500. };
+  std::unique_ptr< MarmotMaterialFiniteStrain > mat(
+    MarmotMaterialFiniteStrainFactory::createMaterial( "COMPRESSIBLENEOHOOKE", properties, 2, 7 ) );
+
+  throwExceptionOnFailure( mat != nullptr && mat->materialNumber == 7,
+                           "createMaterial() did not return a correctly constructed instance in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testCreateMaterialThrowsForUnregisteredName,
+    testCreateMaterialSucceedsForRegisteredName,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotMechanicsCore/test.cmake
+++ b/modules/core/MarmotMechanicsCore/test.cmake
@@ -42,3 +42,6 @@ add_marmot_test("TestNewmarkBetaIntegrator" "${CURR_TEST_SOURCE_DIR}/TestNewmark
 
 # Tests for MarmotGeostaticStress
 add_marmot_test("TestMarmotGeostaticStress" "${CURR_TEST_SOURCE_DIR}/TestMarmotGeostaticStress.cpp")
+
+# Tests for MarmotMaterialHypoElasticFactory
+add_marmot_test("TestMarmotMaterialHypoElasticFactory" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialHypoElasticFactory.cpp")

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotMaterialHypoElasticFactory.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotMaterialHypoElasticFactory.cpp
@@ -1,0 +1,53 @@
+#include "Marmot/MarmotMaterialHypoElasticFactory.h"
+#include "Marmot/MarmotTesting.h"
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+using namespace Marmot::Testing;
+using namespace MarmotLibrary;
+
+// ---------------------------------------------------------------------------------------------
+// createMaterial(): the success path is exercised elsewhere (e.g. LinearElastic's own tests, via
+// the material point solver), but the throw branch for an unregistered material name is not.
+// "LINEARELASTIC" is genuinely registered (by LinearElasticRegistration.cpp, linked into every
+// test executable via libMarmot), so a name guaranteed not to collide with it proves the throw
+// path specifically, not just "any unknown name".
+// ---------------------------------------------------------------------------------------------
+void testCreateMaterialThrowsForUnregisteredName()
+{
+  bool threw = false;
+  try {
+    MarmotMaterialHypoElasticFactory::createMaterial( "DEFINITELY_NOT_REGISTERED", nullptr, 0, 1 );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "createMaterial() must throw std::invalid_argument for an unregistered material name "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCreateMaterialSucceedsForRegisteredName()
+{
+  const double                                 properties[3] = { 20000., 0.25, 10. };
+  std::unique_ptr< MarmotMaterialHypoElastic > mat(
+    MarmotMaterialHypoElasticFactory::createMaterial( "LINEARELASTIC", properties, 3, 7 ) );
+
+  throwExceptionOnFailure( mat != nullptr && mat->materialNumber == 7,
+                           "createMaterial() did not return a correctly constructed instance in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testCreateMaterialThrowsForUnregisteredName,
+    testCreateMaterialSucceedsForRegisteredName,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotPronySeries.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotPronySeries.cpp
@@ -110,12 +110,62 @@ void testPronySeriesWithOneMaxwellElement()
                            MakeString() << __PRETTY_FUNCTION__ << "stress computation failed (relaxation)" );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// updateStateVars(): a free function with no callers anywhere in the codebase, duplicating the
+// same state-variable update formula already embedded (and tested above) inside
+// evaluatePronySeries()'s `if (updateStateVars)` branch. Verified via that duplication: starting
+// from identical state, calling updateStateVars() directly must produce exactly the same updated
+// state as evaluatePronySeries(..., updateStateVars=true).
+// ─────────────────────────────────────────────────────────────────────────────
+
+void testUpdateStateVarsMatchesEvaluatePronySeries()
+{
+  const int nMaxwell = 1;
+
+  using namespace Marmot::ContinuumMechanics;
+  const auto C0 = Elasticity::Isotropic::stiffnessTensor( 100, 0.0 );
+
+  using namespace Marmot::ContinuumMechanics::Viscoelasticity::PronySeries;
+
+  Marmot::Matrix6d relaxationTimes = Matrix6d::Zero();
+  relaxationTimes.setConstant( 1.0 );
+  const Marmot::Matrix6d C1 = C0 * 0.1;
+
+  Properties props           = { nMaxwell, C0, Marmot::Vector6d::Zero(), Marmot::Matrix6d::Zero() };
+  props.pronyRelaxationTimes = relaxationTimes;
+  props.pronyStiffnesses     = C1;
+
+  Marmot::Vector6d dStrain = Vector6d::Zero();
+  dStrain( 0 )             = 1.0e-3;
+  dStrain( 3 )             = 4.0e-3;
+  const double dt          = 0.2;
+
+  // Give both starting points the same non-trivial initial state (as if a previous increment had
+  // already been applied), rather than the all-zero initial state used above.
+  StateVarMatrix initialStateVars = StateVarMatrix::Zero( 6, 6 );
+  initialStateVars.setConstant( 0.01 );
+
+  StateVarMatrix   stateVarsViaEvaluate = initialStateVars;
+  Marmot::Vector6d stress               = Vector6d::Zero();
+  Marmot::Matrix6d stiffness            = Matrix6d::Zero();
+  evaluatePronySeries( props, stress, stiffness, stateVarsViaEvaluate, dStrain, dt, true );
+
+  StateVarMatrix stateVarsViaUpdate = initialStateVars;
+  updateStateVars( props, stateVarsViaUpdate, dStrain, dt );
+
+  throwExceptionOnFailure( checkIfEqual< double >( stateVarsViaUpdate, stateVarsViaEvaluate, 1e-12 ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " updateStateVars() does not match evaluatePronySeries()'s own "
+                                           "state-variable update" );
+}
+
 int main()
 {
 
   auto tests = std::vector< std::function< void() > >{
     testPronySeriesWithZeroMaxwellElements,
     testPronySeriesWithOneMaxwellElement,
+    testUpdateStateVarsMatchesEvaluatePronySeries,
   };
 
   executeTestsAndCollectExceptions( tests );


### PR DESCRIPTION
## Summary
- `MarmotMaterialHypoElasticFactory::createMaterial()` and `MarmotMaterialFiniteStrainFactory::createMaterial()` each only had their success path exercised (transitively, via `LinearElastic`/`CompressibleNeoHooke` tests going through the material point solver); the "material name not registered" throw branch was never hit directly. Added a small dedicated test file per factory covering both the throw path (a name guaranteed not to collide with the genuinely-registered `LINEARELASTIC`/`COMPRESSIBLENEOHOOKE`) and an explicit direct-construction success path.
- `PronySeries::updateStateVars()` is a free function with no callers anywhere in the codebase, duplicating the same state-variable update formula already embedded (and tested) inside `evaluatePronySeries()`'s `updateStateVars=true` branch. Verified it via that duplication: starting from identical non-trivial state, calling `updateStateVars()` directly must produce exactly the same updated state as `evaluatePronySeries()`.

## Test plan
- [x] `ctest` — 50/50 tests pass locally (Debug build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA