### PR TITLE
fix(core): malformed CSV export for state-var-free materials + cover both material point solvers

### DIFF
--- a/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test.cmake
@@ -18,3 +18,6 @@ add_marmot_test("TestMarmotFiniteStrainViscoelasticity" "${CURR_TEST_SOURCE_DIR}
 
 # Tests for the Hughes-Winget small-strain wrapper
 add_marmot_test("TestMarmotMaterialHughesWinget" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialHughesWinget.cpp")
+
+# Tests for MarmotMaterialPointSolverFiniteStrain
+add_marmot_test("TestMarmotMaterialPointSolverFiniteStrain" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialPointSolverFiniteStrain.cpp")

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialPointSolverFiniteStrain.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotMaterialPointSolverFiniteStrain.cpp
@@ -1,0 +1,593 @@
+#include "Marmot/MarmotExceptions.h"
+#include "Marmot/MarmotFastorTensorBasics.h"
+#include "Marmot/MarmotMaterialFiniteStrainFactory.h"
+#include "Marmot/MarmotMaterialPointSolverFiniteStrain.h"
+#include "Marmot/MarmotTesting.h"
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::Solvers;
+using namespace Marmot::FastorStandardTensors;
+
+namespace {
+
+  // A material that always fails to update its stress, used to exercise solveStep()'s
+  // cutback-retry-then-give-up logic deterministically (no real material fails unconditionally).
+  class AlwaysFailingFiniteStrainMaterial : public MarmotMaterialFiniteStrain {
+  public:
+    using MarmotMaterialFiniteStrain::MarmotMaterialFiniteStrain;
+
+    void computeStress( ConstitutiveResponse< 3 >&,
+                        AlgorithmicModuli< 3 >&,
+                        const Deformation< 3 >&,
+                        const TimeIncrement& ) const override
+    {
+      throw Marmot::StressUpdateFailed( "test-only material always fails" );
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  // A material whose Kirchhoff stress output is constant (independent of deformation) with a
+  // singular (zero) tangent, used to force a NaN out of the Newton-loop's linear solve.
+  class SingularTangentMaterial : public MarmotMaterialFiniteStrain {
+  public:
+    using MarmotMaterialFiniteStrain::MarmotMaterialFiniteStrain;
+
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&,
+                        const TimeIncrement& ) const override
+    {
+      response.tau                  = Tensor33d( 0.0 );
+      response.tau( 0, 0 )          = 5.0;
+      response.elasticEnergyDensity = 0.0;
+      response.dissipation          = 0.0;
+      tangents.dTau_dF              = Tensor3333d( 0.0 ); // singular
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  // A material whose Kirchhoff stress output is constant (independent of deformation), but with a
+  // well-conditioned (identity) tangent, so the Newton loop computes well-defined, non-NaN
+  // corrections every iteration without the residual ever actually shrinking.
+  class WellConditionedNeverConvergingMaterial : public MarmotMaterialFiniteStrain {
+  public:
+    using MarmotMaterialFiniteStrain::MarmotMaterialFiniteStrain;
+
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&,
+                        const TimeIncrement& ) const override
+    {
+      response.tau                  = Tensor33d( 0.0 );
+      response.tau( 0, 0 )          = 5.0;
+      response.elasticEnergyDensity = 0.0;
+      response.dissipation          = 0.0;
+
+      tangents.dTau_dF = Tensor3333d( 0.0 );
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ )
+          tangents.dTau_dF( i, j, i, j ) = 1.0; // identity operator: well-conditioned, invertible
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  // A material that fails only for a genuinely nonzero time increment. solveStep() always
+  // resolves its very first increment with dT == 0 (a trivial pass before dTStart is assigned on
+  // the first successful increment), so this succeeds once before it starts failing -- letting a
+  // subsequent retry actually halve an already-nonzero dT, rather than immediately hitting the
+  // "dT already at or below dTMin" exhaustion check with the still-zero initial dT.
+  class FailsForNonzeroTimeIncrementMaterial : public MarmotMaterialFiniteStrain {
+  public:
+    using MarmotMaterialFiniteStrain::MarmotMaterialFiniteStrain;
+
+    void computeStress( ConstitutiveResponse< 3 >& response,
+                        AlgorithmicModuli< 3 >&    tangents,
+                        const Deformation< 3 >&,
+                        const TimeIncrement& timeIncrement ) const override
+    {
+      if ( timeIncrement.dT > 0.0 )
+        throw Marmot::StressUpdateFailed( "test-only material fails for any nonzero time increment" );
+      response.tau                  = Tensor33d( 0.0 );
+      response.elasticEnergyDensity = 0.0;
+      response.dissipation          = 0.0;
+      tangents.dTau_dF              = Tensor3333d( 0.0 );
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  const bool alwaysFailingRegistered = MarmotLibrary::MarmotMaterialFiniteStrainFactory::registerMaterial<
+    AlwaysFailingFiniteStrainMaterial >( "TESTALWAYSFAILINGFINITESTRAIN" );
+  const bool failsForNonzeroDTRegistered = MarmotLibrary::MarmotMaterialFiniteStrainFactory::registerMaterial<
+    FailsForNonzeroTimeIncrementMaterial >( "TESTFAILSFORNONZERODTFINITESTRAIN" );
+  const bool singularTangentRegistered = MarmotLibrary::MarmotMaterialFiniteStrainFactory::registerMaterial<
+    SingularTangentMaterial >( "TESTSINGULARTANGENTFINITESTRAIN" );
+  const bool neverConvergingRegistered = MarmotLibrary::MarmotMaterialFiniteStrainFactory::registerMaterial<
+    WellConditionedNeverConvergingMaterial >( "TESTNEVERCONVERGINGFINITESTRAINSOLVER" );
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// setInitialState() / resetToInitialState()
+// ---------------------------------------------------------------------------------------------
+void testResetToInitialStateUndoesAccumulatedDeformation()
+{
+  // CompressibleNeoHooke is hyperelastic (path-independent): its stress is a pure function of the
+  // current deformation gradient, not of the solver's "previous stress" -- so resetToInitialState()
+  // is verified here by its actual load-bearing effect, undoing the internally accumulated
+  // displacement gradient (gradU), rather than by an (inapplicable) stress-persistence check.
+  std::vector< double > materialProperties = { 3500., 1500. };
+  std::string           matName            = "COMPRESSIBLENEOHOOKE";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-3;
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+
+  solver.addStep( step );
+  solver.solve();
+  const Tensor33d stressAfterFirstSolve = solver.getHistory().back().stress;
+
+  solver.resetToInitialState();
+  throwExceptionOnFailure( solver.getHistory().empty(),
+                           "resetToInitialState() must clear the recorded history in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // resetToInitialState() does not clear queued steps, so avoid re-solving the (already-queued)
+  // first step on top of itself.
+  solver.clearSteps();
+  solver.addStep( step );
+  solver.solve();
+  const Tensor33d stressAfterSecondSolve = solver.getHistory().back().stress;
+
+  throwExceptionOnFailure( checkIfEqual( stressAfterFirstSolve( 0, 0 ), stressAfterSecondSolve( 0, 0 ), 1e-10 ),
+                           "resetToInitialState() did not undo the internally accumulated displacement gradient "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSetInitialStateSeedsStateVariables()
+{
+  // Unlike stress (recomputed fresh from the deformation gradient for a hyperelastic law), state
+  // variables genuinely persist: use a plastic material and verify that a custom initial hardening
+  // variable is what ends up in the recorded history after a (near-)elastic step that doesn't
+  // itself change it.
+  std::vector< double > materialProperties = { 175000., 80800., 260., 580., 9., 70., 3. };
+  std::string           matName            = "FINITESTRAINJ2PLASTICITY";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  const int nStateVars = solver.getNumberOfStateVariables();
+  throwExceptionOnFailure( nStateVars == 10, // Fp (9) + alphaP (1)
+                           "Unexpected number of state variables for FiniteStrainJ2Plasticity in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  Eigen::VectorXd initialStateVars = Eigen::VectorXd::Zero( nStateVars );
+  // Fp = identity (indices 0,4,8 of the flattened 3x3 plastic deformation gradient)
+  initialStateVars( 0 ) = initialStateVars( 4 ) = initialStateVars( 8 ) = 1.0;
+  initialStateVars( 9 )                                                 = 12.5; // alphaP
+
+  solver.setInitialState( Tensor33d( 0.0 ), initialStateVars );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-6; // tiny: stays elastic, so alphaP is not itself modified
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+
+  solver.addStep( step );
+  solver.solve();
+
+  throwExceptionOnFailure( checkIfEqual( solver.getHistory().back().stateVars( 9 ), 12.5, 1e-10 ),
+                           "setInitialState() did not seed the solver's initial state variables in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveStep(): retries with a halved time step on StressUpdateFailed, then gives up with
+// SolverTimestepExhausted once the time step can no longer be halved below dTMin.
+// ---------------------------------------------------------------------------------------------
+void testSolveStepRetriesThenThrowsSolverTimestepExhausted()
+{
+  std::vector< double > materialProperties = { 0.0 };
+  std::string           matName            = "TESTALWAYSFAILINGFINITESTRAIN";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-3;
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+  step.dTStart                      = 0.1;
+  step.dTMin                        = 0.05;
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverTimestepExhausted& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveStep() must throw SolverTimestepExhausted once the time step cannot be halved "
+                           "below dTMin in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveStep(): throws SolverIncrementsExhausted when maxIncrements is reached before timeEnd.
+// ---------------------------------------------------------------------------------------------
+void testSolveStepThrowsSolverIncrementsExhausted()
+{
+  std::vector< double > materialProperties = { 3500., 1500. };
+  std::string           matName            = "COMPRESSIBLENEOHOOKE";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-3;
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+  step.timeStart                    = 0.0;
+  step.timeEnd                      = 1.0;
+  step.dTStart                      = 0.1; // 10 increments needed to reach timeEnd
+  step.maxIncrements                = 2;   // but only 3 are allowed (counter <= maxIncrements)
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverIncrementsExhausted& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveStep() must throw SolverIncrementsExhausted when maxIncrements is reached "
+                           "before timeEnd in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveStep(): the very first attempted increment always uses dT == 0 (a trivial pass, before
+// dTStart is assigned on the first successful increment); if dTStart itself would overshoot
+// timeEnd, that overshoot must be capped independently of the general (dT-already-set) overshoot
+// check earlier in the loop, which ran before dT was reassigned to dTStart.
+// ---------------------------------------------------------------------------------------------
+void testSolveStepCapsNewlyAssignedDTStartToAvoidOvershoot()
+{
+  std::vector< double > materialProperties = { 3500., 1500. };
+  std::string           matName            = "COMPRESSIBLENEOHOOKE";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-4;
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+  step.timeStart                    = 0.0;
+  step.timeEnd                      = 0.05; // shorter than dTStart
+  step.dTStart                      = 0.1;  // would overshoot timeEnd if not capped
+
+  solver.addStep( step );
+  solver.solve(); // must not throw
+
+  throwExceptionOnFailure( checkIfEqual( solver.getHistory().back().time, step.timeEnd, 1e-12 ),
+                           "solveStep() did not reach timeEnd exactly after capping the newly-assigned dTStart in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveStep(): a StressUpdateFailed on a genuinely nonzero time increment must halve that
+// (already-nonzero) dT and retry, rather than immediately hitting dTMin -- unlike a material that
+// fails even on the trivial dT==0 first pass.
+// ---------------------------------------------------------------------------------------------
+void testSolveStepHalvesDTOnRetryBeforeExhaustingIt()
+{
+  std::vector< double > materialProperties = { 0.0 };
+  std::string           matName            = "TESTFAILSFORNONZERODTFINITESTRAIN";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget        = Tensor33d( 0.0 );
+  step.stressIncrementTarget       = Tensor33d( 0.0 );
+  step.isGradUComponentControlled  = Tensor33t< bool >( true );
+  step.isStressComponentControlled = Tensor33t< bool >( false );
+  step.dTStart                     = 0.1;
+  step.dTMin                       = 0.05; // exactly one halving (0.1 -> 0.05) before exhaustion
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverTimestepExhausted& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveStep() must throw SolverTimestepExhausted after halving dT once it is exhausted "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveIncrement(): throws SolverConvergenceFailed with a "NaN encountered" message when the
+// tangent is singular.
+// ---------------------------------------------------------------------------------------------
+void testSolveIncrementThrowsOnNaN()
+{
+  std::vector< double > materialProperties = { 0.0 };
+  std::string           matName            = "TESTSINGULARTANGENTFINITESTRAIN";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget          = Tensor33d( 0.0 );
+  step.stressIncrementTarget         = Tensor33d( 0.0 );
+  step.stressIncrementTarget( 0, 0 ) = 100.0; // the material always reports tau(0,0) == 5.0
+  step.isGradUComponentControlled    = Tensor33t< bool >( false );
+  step.isStressComponentControlled   = Tensor33t< bool >( true );
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverConvergenceFailed& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveIncrement() must throw SolverConvergenceFailed for a singular tangent in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveIncrement(): throws SolverConvergenceFailed after exhausting maxIterations when the
+// residual can never be driven to zero, even with a well-conditioned (non-singular) tangent.
+// ---------------------------------------------------------------------------------------------
+void testSolveIncrementThrowsWhenIterationsExhausted()
+{
+  std::vector< double > materialProperties = { 0.0 };
+  std::string           matName            = "TESTNEVERCONVERGINGFINITESTRAINSOLVER";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  solveropts.maxIterations                 = 3; // keep the test fast
+  auto solver                              = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget          = Tensor33d( 0.0 );
+  step.stressIncrementTarget         = Tensor33d( 0.0 );
+  step.stressIncrementTarget( 0, 0 ) = 100.0; // the material always reports tau(0,0) == 5.0
+  step.isGradUComponentControlled    = Tensor33t< bool >( false );
+  step.isStressComponentControlled   = Tensor33t< bool >( true );
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverConvergenceFailed& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveIncrement() must throw SolverConvergenceFailed when the residual can never be "
+                           "driven to zero in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// printHistory() / exportHistoryToCSV()
+// ---------------------------------------------------------------------------------------------
+void testPrintHistoryDoesNotThrow()
+{
+  std::vector< double > materialProperties = { 3500., 1500. };
+  std::string           matName            = "COMPRESSIBLENEOHOOKE";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-3;
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+
+  solver.addStep( step );
+  solver.solve();
+
+  solver.printHistory(); // purely a coverage/smoke check: must not throw
+}
+
+void testExportHistoryToCSVWritesExpectedContentWithNoStateVars()
+{
+  std::vector< double > materialProperties = { 3500., 1500. };
+  std::string           matName            = "COMPRESSIBLENEOHOOKE"; // no state variables
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-3;
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+  step.dTStart                      = 0.5; // 2 increments
+
+  solver.addStep( step );
+  solver.solve();
+
+  const std::string filename = "test_export_history_finitestrain.csv";
+  solver.exportHistoryToCSV( filename );
+
+  std::ifstream file( filename );
+  throwExceptionOnFailure( file.is_open(),
+                           "exportHistoryToCSV() did not create the expected file in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  std::string headerLine;
+  std::getline( file, headerLine );
+  throwExceptionOnFailure( headerLine.find( "Time" ) != std::string::npos &&
+                             headerLine.find( "tau11" ) != std::string::npos &&
+                             headerLine.find( "F11" ) != std::string::npos &&
+                             headerLine.find( "SV1" ) == std::string::npos,
+                           "exportHistoryToCSV() header does not match the expected columns in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  int         dataLines = 0;
+  std::string line;
+  while ( std::getline( file, line ) )
+    if ( !line.empty() )
+      dataLines++;
+
+  throwExceptionOnFailure( dataLines == static_cast< int >( solver.getHistory().size() ),
+                           "exportHistoryToCSV() did not write one line per history entry in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  file.close();
+  std::remove( filename.c_str() );
+}
+
+void testExportHistoryToCSVWritesStateVarColumnsForAMaterialWithStateVars()
+{
+  std::vector< double > materialProperties = { 175000., 80800., 260., 580., 9., 70., 3. }; // purely elastic step
+  std::string           matName            = "FINITESTRAINJ2PLASTICITY";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  throwExceptionOnFailure( solver.getNumberOfStateVariables() > 0,
+                           "FiniteStrainJ2Plasticity must require at least one state variable in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  MarmotMaterialPointSolverFiniteStrain::Step step;
+  step.gradUIncrementTarget         = Tensor33d( 0.0 );
+  step.gradUIncrementTarget( 0, 0 ) = 1e-6; // tiny: stays elastic
+  step.stressIncrementTarget        = Tensor33d( 0.0 );
+  step.isGradUComponentControlled   = Tensor33t< bool >( true );
+  step.isStressComponentControlled  = Tensor33t< bool >( false );
+
+  solver.addStep( step );
+  solver.solve();
+
+  const std::string filename = "test_export_history_finitestrain_j2.csv";
+  solver.exportHistoryToCSV( filename );
+
+  std::ifstream file( filename );
+  throwExceptionOnFailure( file.is_open(),
+                           "exportHistoryToCSV() did not create the expected file in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  std::string headerLine;
+  std::getline( file, headerLine );
+  throwExceptionOnFailure( headerLine.find( "SV1" ) != std::string::npos,
+                           "exportHistoryToCSV() header is missing the state-variable columns in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  std::string dataLine;
+  std::getline( file, dataLine );
+  throwExceptionOnFailure( !dataLine.empty(),
+                           "exportHistoryToCSV() did not write a data row in " + std::string( __PRETTY_FUNCTION__ ) );
+
+  file.close();
+  std::remove( filename.c_str() );
+}
+
+void testExportHistoryToCSVThrowsForInvalidPath()
+{
+  std::vector< double > materialProperties = { 3500., 1500. };
+  std::string           matName            = "COMPRESSIBLENEOHOOKE";
+  auto                  solveropts         = MarmotMaterialPointSolverFiniteStrain::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverFiniteStrain( matName,
+                                                       materialProperties.data(),
+                                                       materialProperties.size(),
+                                                       solveropts );
+
+  bool threw = false;
+  try {
+    solver.exportHistoryToCSV( "/nonexistent_directory_xyz/out.csv" );
+  }
+  catch ( const std::runtime_error& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "exportHistoryToCSV() must throw for a path that cannot be opened for writing in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testResetToInitialStateUndoesAccumulatedDeformation,
+    testSetInitialStateSeedsStateVariables,
+    testSolveStepRetriesThenThrowsSolverTimestepExhausted,
+    testSolveStepThrowsSolverIncrementsExhausted,
+    testSolveStepCapsNewlyAssignedDTStartToAvoidOvershoot,
+    testSolveStepHalvesDTOnRetryBeforeExhaustingIt,
+    testSolveIncrementThrowsOnNaN,
+    testSolveIncrementThrowsWhenIterationsExhausted,
+    testPrintHistoryDoesNotThrow,
+    testExportHistoryToCSVWritesExpectedContentWithNoStateVars,
+    testExportHistoryToCSVWritesStateVarColumnsForAMaterialWithStateVars,
+    testExportHistoryToCSVThrowsForInvalidPath,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotMechanicsCore/src/MarmotMaterialPointSolverHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/src/MarmotMaterialPointSolverHypoElastic.cpp
@@ -240,7 +240,8 @@ void MarmotMaterialPointSolverHypoElastic::exportHistoryToCSV( const std::string
 
   for ( int i = 0; i < nStateVars; i++ )
     file << std::setw( w - ( i < nStateVars - 1 ? 1 : 2 ) ) << "StateVar_" << i + 1
-         << ( i < nStateVars - 1 ? "," : "\n" );
+         << ( i < nStateVars - 1 ? "," : "" );
+  file << "\n";
 
   // write data with fixed-width formatting
   for ( const auto& entry : history ) {
@@ -253,7 +254,8 @@ void MarmotMaterialPointSolverHypoElastic::exportHistoryToCSV( const std::string
       file << std::setw( w - 1 ) << entry.strain[i] << ( i < 5 ? "," : "," );
 
     for ( int i = 0; i < nStateVars; i++ )
-      file << std::setw( w - 1 ) << entry.stateVars[i] << ( i < nStateVars - 1 ? "," : "\n" );
+      file << std::setw( w - 1 ) << entry.stateVars[i] << ( i < nStateVars - 1 ? "," : "" );
+    file << "\n";
   }
 
   file.close();

--- a/modules/core/MarmotMechanicsCore/test.cmake
+++ b/modules/core/MarmotMechanicsCore/test.cmake
@@ -42,3 +42,6 @@ add_marmot_test("TestNewmarkBetaIntegrator" "${CURR_TEST_SOURCE_DIR}/TestNewmark
 
 # Tests for MarmotGeostaticStress
 add_marmot_test("TestMarmotGeostaticStress" "${CURR_TEST_SOURCE_DIR}/TestMarmotGeostaticStress.cpp")
+
+# Tests for MarmotMaterialPointSolverHypoElastic
+add_marmot_test("TestMarmotMaterialPointSolverHypoElastic" "${CURR_TEST_SOURCE_DIR}/TestMarmotMaterialPointSolverHypoElastic.cpp")

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotMaterialPointSolverHypoElastic.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotMaterialPointSolverHypoElastic.cpp
@@ -1,0 +1,437 @@
+#include "Marmot/LinearElastic.h"
+#include "Marmot/MarmotExceptions.h"
+#include "Marmot/MarmotMaterialHypoElasticFactory.h"
+#include "Marmot/MarmotMaterialPointSolverHypoElastic.h"
+#include "Marmot/MarmotTesting.h"
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+using namespace Marmot::Solvers;
+
+namespace {
+
+  // A material that always fails to update its stress, used to exercise solveStep()'s
+  // cutback-retry-then-give-up logic deterministically (no real material fails unconditionally).
+  class AlwaysFailingHypoElasticMaterial : public MarmotMaterialHypoElastic {
+  public:
+    using MarmotMaterialHypoElastic::MarmotMaterialHypoElastic;
+
+    void computeStress( state3D&, Marmot::Matrix6d&, const Marmot::Vector6d&, const timeInfo& ) const override
+    {
+      throw Marmot::StressUpdateFailed( "test-only material always fails" );
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  // A material whose stress output is a strain-independent constant with a zero tangent, used to
+  // exercise solveIncrement()'s own Newton-loop non-convergence throw: for a stress-controlled
+  // component, the residual can then never be driven to zero, regardless of how many correction
+  // steps are attempted.
+  class NeverConvergingSolverMaterial : public MarmotMaterialHypoElastic {
+  public:
+    using MarmotMaterialHypoElastic::MarmotMaterialHypoElastic;
+
+    void computeStress( state3D&          state,
+                        Marmot::Matrix6d& dStress_dStrain,
+                        const Marmot::Vector6d&,
+                        const timeInfo& ) const override
+    {
+      state.stress      = Marmot::Vector6d::Zero();
+      state.stress( 0 ) = 5.0; // never equal to any nonzero target, and independent of dStrain
+      dStress_dStrain.setZero();
+    }
+
+    double getDensity( const double* ) const override { return 1.0; }
+  };
+
+  const bool alwaysFailingRegistered = MarmotLibrary::MarmotMaterialHypoElasticFactory::registerMaterial<
+    AlwaysFailingHypoElasticMaterial >( "TESTALWAYSFAILINGHYPOELASTIC" );
+  const bool neverConvergingRegistered = MarmotLibrary::MarmotMaterialHypoElasticFactory::registerMaterial<
+    NeverConvergingSolverMaterial >( "TESTNEVERCONVERGINGHYPOELASTICSOLVER" );
+
+} // namespace
+
+// ---------------------------------------------------------------------------------------------
+// setInitialState() / resetToInitialState()
+// ---------------------------------------------------------------------------------------------
+void testSetInitialStateAndResetToInitialState()
+{
+  std::vector< double > materialProperties = { 20000., 0.25 };
+  std::string           matName            = "LINEARELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  Marmot::Vector6d initialStress = Marmot::Vector6d::Zero();
+  initialStress( 0 )             = 42.0;
+  Eigen::VectorXd initialStateVars( solver.getNumberOfStateVariables() );
+  initialStateVars.setZero();
+
+  solver.setInitialState( initialStress, initialStateVars );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero(); // zero strain increment: stress must stay at 42
+
+  solver.addStep( step );
+  solver.solve();
+
+  throwExceptionOnFailure( checkIfEqual( solver.getHistory().back().stress( 0 ), 42.0, 1e-10 ),
+                           "setInitialState() did not seed the solver's starting stress in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  solver.resetToInitialState();
+  throwExceptionOnFailure( solver.getHistory().empty(),
+                           "resetToInitialState() must clear the recorded history in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // After resetting, solving the same step again must reproduce the same starting stress.
+  // resetToInitialState() does not clear queued steps, so avoid re-solving the (already-queued)
+  // first step on top of itself.
+  solver.clearSteps();
+  solver.addStep( step );
+  solver.solve();
+  throwExceptionOnFailure( checkIfEqual( solver.getHistory().back().stress( 0 ), 42.0, 1e-10 ),
+                           "resetToInitialState() did not restore the initial stress in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveStep(): retries with a halved time step on StressUpdateFailed, then gives up with
+// SolverTimestepExhausted once the time step can no longer be halved below dTMin.
+// ---------------------------------------------------------------------------------------------
+void testSolveStepRetriesThenThrowsSolverTimestepExhausted()
+{
+  std::vector< double > materialProperties = { 0.0 };
+  std::string           matName            = "TESTALWAYSFAILINGHYPOELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-3;
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+  step.dTStart                     = 0.1;
+  step.dTMin                       = 0.05;
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverTimestepExhausted& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveStep() must throw SolverTimestepExhausted once the time step cannot be halved "
+                           "below dTMin in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveStep(): throws SolverIncrementsExhausted when maxIncrements is reached before timeEnd.
+// ---------------------------------------------------------------------------------------------
+void testSolveStepThrowsSolverIncrementsExhausted()
+{
+  std::vector< double > materialProperties = { 20000., 0.25 };
+  std::string           matName            = "LINEARELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-3;
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+  step.timeStart                   = 0.0;
+  step.timeEnd                     = 1.0;
+  step.dTStart                     = 0.1; // 10 increments needed to reach timeEnd
+  step.maxIncrements               = 2;   // but only 3 are allowed (counter <= maxIncrements)
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverIncrementsExhausted& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveStep() must throw SolverIncrementsExhausted when maxIncrements is reached "
+                           "before timeEnd in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveIncrement(): a mixed strain/stress-controlled increment that is not already exactly
+// satisfied by the initial guess needs at least one Newton correction step -- unlike every
+// fully-strain-controlled LinearElastic test elsewhere, which converges in "0 iterations" because
+// the initial guess already is the exact answer.
+// ---------------------------------------------------------------------------------------------
+void testSolveIncrementMixedControlNeedsNewtonCorrection()
+{
+  std::vector< double > materialProperties = { 20000., 0.25 };
+  std::string           matName            = "LINEARELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { false, true, true, true, true, true };
+  step.isStressComponentControlled = { true, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+  step.stressIncrementTarget( 0 )  = 240.0;
+
+  solver.addStep( step );
+  solver.solve();
+
+  const auto  history = solver.getHistory();
+  const auto& last    = history.back();
+
+  throwExceptionOnFailure( checkIfEqual( last.stress( 0 ), 240.0, 1e-6 ),
+                           "solveIncrement() did not converge to the target stress in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // Cross-check against a freshly constructed material evaluated directly at the converged
+  // strain, rather than re-deriving the expected stress analytically.
+  Marmot::Materials::LinearElastic    mat( materialProperties.data(), materialProperties.size(), 1 );
+  MarmotMaterialHypoElastic&          matBase = mat;
+  MarmotMaterialHypoElastic::state3D  state( Marmot::Vector6d::Zero(), 0.0, 0.0, nullptr );
+  Marmot::Matrix6d                    tangent;
+  MarmotMaterialHypoElastic::timeInfo timeInfo{ 0.0, 1.0 };
+  matBase.computeStress( state, tangent, last.strain, timeInfo );
+
+  throwExceptionOnFailure( checkIfEqual< double >( state.stress, last.stress, 1e-6 ),
+                           "The solver's converged (stress, strain) pair is not self-consistent with a direct "
+                           "material evaluation in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// solveIncrement(): throws SolverConvergenceFailed when the Newton loop cannot drive the residual
+// below tolerance within maxIterations.
+// ---------------------------------------------------------------------------------------------
+void testSolveIncrementThrowsSolverConvergenceFailed()
+{
+  std::vector< double > materialProperties = { 0.0 };
+  std::string           matName            = "TESTNEVERCONVERGINGHYPOELASTICSOLVER";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  solveropts.maxIterations                 = 3; // keep the test fast
+  auto solver                              = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { false, true, true, true, true, true };
+  step.isStressComponentControlled = { true, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+  step.stressIncrementTarget( 0 )  = 100.0; // the material always reports stress(0) == 5.0
+
+  solver.addStep( step );
+
+  bool threw = false;
+  try {
+    solver.solve();
+  }
+  catch ( const Marmot::SolverConvergenceFailed& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "solveIncrement() must throw SolverConvergenceFailed when the residual can never be "
+                           "driven to zero in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// printHistory() / exportHistoryToCSV()
+// ---------------------------------------------------------------------------------------------
+void testPrintHistoryDoesNotThrow()
+{
+  std::vector< double > materialProperties = { 20000., 0.25 };
+  std::string           matName            = "LINEARELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-3;
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+
+  solver.addStep( step );
+  solver.solve();
+
+  solver.printHistory(); // purely a coverage/smoke check: must not throw
+}
+
+void testExportHistoryToCSVWritesExpectedContent()
+{
+  std::vector< double > materialProperties = { 20000., 0.25 };
+  std::string           matName            = "LINEARELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-3;
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+  step.dTStart                     = 0.5; // 2 increments
+
+  solver.addStep( step );
+  solver.solve();
+
+  const std::string filename = "test_export_history_hypoelastic.csv";
+  solver.exportHistoryToCSV( filename );
+
+  std::ifstream file( filename );
+  throwExceptionOnFailure( file.is_open(),
+                           "exportHistoryToCSV() did not create the expected file in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  std::string headerLine;
+  std::getline( file, headerLine );
+  throwExceptionOnFailure( headerLine.find( "Time" ) != std::string::npos &&
+                             headerLine.find( "Stress_11" ) != std::string::npos &&
+                             headerLine.find( "StateVar_1" ) == std::string::npos, // LinearElastic has none
+                           "exportHistoryToCSV() header does not match the expected columns in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  int         dataLines = 0;
+  std::string line;
+  while ( std::getline( file, line ) )
+    if ( !line.empty() )
+      dataLines++;
+
+  throwExceptionOnFailure( dataLines == static_cast< int >( solver.getHistory().size() ),
+                           "exportHistoryToCSV() did not write one line per history entry in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  file.close();
+  std::remove( filename.c_str() );
+}
+
+void testExportHistoryToCSVThrowsForInvalidPath()
+{
+  std::vector< double > materialProperties = { 20000., 0.25 };
+  std::string           matName            = "LINEARELASTIC";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  bool threw = false;
+  try {
+    solver.exportHistoryToCSV( "/nonexistent_directory_xyz/out.csv" );
+  }
+  catch ( const std::runtime_error& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "exportHistoryToCSV() must throw for a path that cannot be opened for writing in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// exportHistoryToCSV(): the state-variable columns (both header and per-row) are only written for
+// a material that actually has state variables -- LinearElastic (used above) has none.
+// ---------------------------------------------------------------------------------------------
+void testExportHistoryToCSVWritesStateVarColumnsForAMaterialWithStateVars()
+{
+  std::vector< double > materialProperties = { 210000., 0.3, 200., 2100., 20., 20. }; // VonMises, purely elastic
+  std::string           matName            = "VONMISES";
+  auto                  solveropts         = MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                  solver             = MarmotMaterialPointSolverHypoElastic( matName,
+                                                      materialProperties.data(),
+                                                      materialProperties.size(),
+                                                      solveropts );
+
+  MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-4; // small: stays elastic, well below the yield stress
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+
+  solver.addStep( step );
+  solver.solve();
+
+  throwExceptionOnFailure( solver.getNumberOfStateVariables() > 0,
+                           "VonMises must require at least one state variable in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  const std::string filename = "test_export_history_vonmises.csv";
+  solver.exportHistoryToCSV( filename );
+
+  std::ifstream file( filename );
+  throwExceptionOnFailure( file.is_open(),
+                           "exportHistoryToCSV() did not create the expected file in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  std::string headerLine;
+  std::getline( file, headerLine );
+  throwExceptionOnFailure( headerLine.find( "StateVar_1" ) != std::string::npos,
+                           "exportHistoryToCSV() header is missing the state-variable columns in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  std::string dataLine;
+  std::getline( file, dataLine );
+  throwExceptionOnFailure( !dataLine.empty(),
+                           "exportHistoryToCSV() did not write a data row in " + std::string( __PRETTY_FUNCTION__ ) );
+
+  file.close();
+  std::remove( filename.c_str() );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testSetInitialStateAndResetToInitialState,
+    testSolveStepRetriesThenThrowsSolverTimestepExhausted,
+    testSolveStepThrowsSolverIncrementsExhausted,
+    testSolveIncrementMixedControlNeedsNewtonCorrection,
+    testSolveIncrementThrowsSolverConvergenceFailed,
+    testPrintHistoryDoesNotThrow,
+    testExportHistoryToCSVWritesExpectedContent,
+    testExportHistoryToCSVWritesStateVarColumnsForAMaterialWithStateVars,
+    testExportHistoryToCSVThrowsForInvalidPath,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- **Bug fix**: `MarmotMaterialPointSolverHypoElastic::exportHistoryToCSV()` only wrote a row's trailing newline from inside the state-variable loop, so a material with zero state variables (e.g. `LinearElastic`) got a header with no line break after it and every data row concatenated onto a single line — malformed CSV. Found while adding coverage. Fixed by emitting the newline unconditionally after each row.
- Both material-point solvers' retry/cutback logic, Newton-failure paths, history introspection and CSV export were largely untested (70.22%/67.94% patch coverage) — `LinearElastic`'s and `CompressibleNeoHooke`'s own tests only ever exercise the trivial, always-converges-in-"0 iterations", fully-strain-controlled, never-fails path.

For each solver, added a dedicated test file covering:
- `setInitialState()`/`resetToInitialState()` — verified against each solver's *actual* persistence semantics: stress persists for the path-dependent hypoelastic law, but is recomputed fresh from `F` for the path-independent finite-strain one, where only state variables genuinely persist. (Getting this distinction right is itself the main finding here — my first draft of the finite-strain test assumed stress persistence and was simply wrong.)
- `solveStep()`'s `StressUpdateFailed`-triggered dT cutback-then-retry, and its give-up throws (`SolverTimestepExhausted`, `SolverIncrementsExhausted`), including the finite-strain solver's dTStart-overshoot-capping branch
- `solveIncrement()`'s Newton-loop-failure throw (`SolverConvergenceFailed`), including the finite-strain solver's separate NaN-encountered vs. iterations-exhausted branches
- a mixed strain/stress-controlled increment needing an actual Newton correction step, unlike every existing fully-controlled test which converges in "0 iterations" because the initial guess is already exact
- `printHistory()` and `exportHistoryToCSV()`, including the fix above and the state-variable columns (via `VonMises` / `FiniteStrainJ2Plasticity`, since `LinearElastic`/`CompressibleNeoHooke` have none)

None of these failure modes have a natural trigger through any currently registered material's well-posed response, so each test file registers a small number of minimal test-only materials (always-failing, singular- or constant-tangent, conditionally-failing) via the public factory registration API — the same technique used for base-class robustness branches in earlier PRs.

## Test plan
- [x] `ctest` — 50/50 tests pass locally (Debug build)
- [x] Local `gcovr`: `MarmotMaterialPointSolverHypoElastic.cpp` 70.22% → 100%; `MarmotMaterialPointSolverFiniteStrain.cpp` 67.94% → 99.4% (the one remaining line — an unconditional statement inside a branch every test in the file executes — looks like a gcov/Fastor-template line-attribution artifact rather than a real gap, matching quirks already documented in earlier PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA