### PR TITLE
fix(core): spinTurbokreisel segfault + wrong control-type guard, cover MarmotUtilitiesCore

### DIFF
--- a/modules/core/MarmotUtilitiesCore/src/MarmotTesting.cpp
+++ b/modules/core/MarmotUtilitiesCore/src/MarmotTesting.cpp
@@ -107,17 +107,6 @@ namespace Marmot::Testing {
     using namespace Eigen;
     using namespace ContinuumMechanics::VoigtNotation;
 
-    solver.solve();
-    auto           history = solver.getHistory();
-    const Vector6d refStress( history.back().stress );
-    const Matrix6d refStiffness( history.back().dStressdStrain );
-
-    const int                     N   = 100;
-    Eigen::Matrix< double, N, 2 > pts = fibonacciLatticeHemisphere< N >();
-
-    Eigen::Vector2d pt;
-    double          phi, theta;
-
     // modify steps to account for rotation
     const auto steps = solver.getSteps();
     // check if at least one step exists
@@ -128,11 +117,22 @@ namespace Marmot::Testing {
 
     for ( auto& step : steps ) {
       // must be pure strain control, i.e. all strain increment components are controlled
-      if ( step.isStrainComponentControlled.any() == false ) {
+      if ( step.isStrainComponentControlled.all() == false ) {
         std::cout << "TURBOKREISEL TEST REQUIRES PURE STRAIN CONTROLLED STEPS." << std::endl;
         return false;
       };
     }
+
+    solver.solve();
+    auto           history = solver.getHistory();
+    const Vector6d refStress( history.back().stress );
+    const Matrix6d refStiffness( history.back().dStressdStrain );
+
+    const int                     N   = 100;
+    Eigen::Matrix< double, N, 2 > pts = fibonacciLatticeHemisphere< N >();
+
+    Eigen::Vector2d pt;
+    double          phi, theta;
 
     for ( int i1 = 0; i1 < N; i1++ ) {
       pt    = pts.row( i1 );

--- a/modules/core/MarmotUtilitiesCore/test.cmake
+++ b/modules/core/MarmotUtilitiesCore/test.cmake
@@ -1,0 +1,8 @@
+# add current directory to the source for the tests
+SET(CURR_TEST_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test")
+
+# Tests for MarmotJournal
+add_marmot_test("TestMarmotJournal" "${CURR_TEST_SOURCE_DIR}/TestMarmotJournal.cpp")
+
+# Tests for MarmotTesting
+add_marmot_test("TestMarmotTesting" "${CURR_TEST_SOURCE_DIR}/TestMarmotTesting.cpp")

--- a/modules/core/MarmotUtilitiesCore/test/TestMarmotJournal.cpp
+++ b/modules/core/MarmotUtilitiesCore/test/TestMarmotJournal.cpp
@@ -1,0 +1,72 @@
+#include "Marmot/MarmotJournal.h"
+#include "Marmot/MarmotTesting.h"
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace Marmot::Testing;
+
+// ---------------------------------------------------------------------------------------------
+// MarmotJournal is a singleton, so setMSGOutputDirection()'s effect on warningToMSG()/
+// notificationToMSG() persists across tests within this process -- each test below redirects to
+// its own fresh stream first, so it is unaffected by whichever stream a previous test last set.
+// ---------------------------------------------------------------------------------------------
+
+void testWarningToMSGWritesToTheRedirectedStreamAndReturnsFalse()
+{
+  std::ostringstream captured;
+  MarmotJournal::setMSGOutputDirection( captured );
+
+  const bool result = MarmotJournal::warningToMSG( "a test warning message" );
+
+  throwExceptionOnFailure( result == false,
+                           "warningToMSG() must return false in " + std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( captured.str().find( "a test warning message" ) != std::string::npos,
+                           "warningToMSG() did not write its message to the redirected stream in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testNotificationToMSGWritesToTheRedirectedStreamAndReturnsTrue()
+{
+  std::ostringstream captured;
+  MarmotJournal::setMSGOutputDirection( captured );
+
+  const bool result = MarmotJournal::notificationToMSG( "a test notification message" );
+
+  throwExceptionOnFailure( result == true,
+                           "notificationToMSG() must return true in " + std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( captured.str().find( "a test notification message" ) != std::string::npos,
+                           "notificationToMSG() did not write its message to the redirected stream in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSetMSGOutputDirectionRedirectsAwayFromAPreviousStream()
+{
+  std::ostringstream first, second;
+
+  MarmotJournal::setMSGOutputDirection( first );
+  MarmotJournal::warningToMSG( "goes to first" );
+
+  MarmotJournal::setMSGOutputDirection( second );
+  MarmotJournal::warningToMSG( "goes to second" );
+
+  throwExceptionOnFailure( first.str().find( "goes to second" ) == std::string::npos,
+                           "setMSGOutputDirection() must redirect away from the previous stream in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( second.str().find( "goes to second" ) != std::string::npos,
+                           "setMSGOutputDirection() did not redirect to the new stream in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testWarningToMSGWritesToTheRedirectedStreamAndReturnsFalse,
+    testNotificationToMSGWritesToTheRedirectedStreamAndReturnsTrue,
+    testSetMSGOutputDirectionRedirectsAwayFromAPreviousStream,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotUtilitiesCore/test/TestMarmotTesting.cpp
+++ b/modules/core/MarmotUtilitiesCore/test/TestMarmotTesting.cpp
@@ -1,0 +1,250 @@
+#include "Marmot/MarmotMaterialPointSolverHypoElastic.h"
+#include "Marmot/MarmotTesting.h"
+#include "Marmot/MarmotTypedefs.h"
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace Marmot;
+using namespace Marmot::Testing;
+
+// ---------------------------------------------------------------------------------------------
+// Most of Marmot::Testing's own source lines are only reached when an equality check actually
+// *fails* -- which, correctly, never happens in a clean, all-passing suite. Testing them means
+// deliberately triggering a "failure" and checking the framework reports/returns it correctly,
+// without letting that propagate as a real failure of this test suite.
+// ---------------------------------------------------------------------------------------------
+
+void testGetStringFormatsDoubleAndDual()
+{
+  throwExceptionOnFailure( getString( 1.5 ) == std::to_string( 1.5 ),
+                           "getString(double) failed in " + std::string( __PRETTY_FUNCTION__ ) );
+
+  autodiff::dual d    = 2.0;
+  d.grad              = 3.0;
+  const std::string s = getString( d );
+  throwExceptionOnFailure( s.find( std::to_string( 2.0 ) ) != std::string::npos &&
+                             s.find( std::to_string( 3.0 ) ) != std::string::npos,
+                           "getString(autodiff::dual) failed in " + std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCheckIfEqualReturnsFalseForNaNAndInf()
+{
+  const double nan = std::numeric_limits< double >::quiet_NaN();
+  const double inf = std::numeric_limits< double >::infinity();
+
+  throwExceptionOnFailure( checkIfEqual( nan, 1.0 ) == false,
+                           "checkIfEqual() must return false when the first argument is NaN in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( 1.0, nan ) == false,
+                           "checkIfEqual() must return false when the second argument is NaN in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( inf, 1.0 ) == false,
+                           "checkIfEqual() must return false when the first argument is inf in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( 1.0, inf ) == false,
+                           "checkIfEqual() must return false when the second argument is inf in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCheckIfEqualReturnsFalseForMismatchedScalars()
+{
+  throwExceptionOnFailure( checkIfEqual( 1.0, 2.0, 1e-10 ) == false,
+                           "checkIfEqual(double) must return false for clearly different values in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  const autodiff::dual a = 1.0, b = 2.0;
+  throwExceptionOnFailure( checkIfEqual( a, b, 1e-10 ) == false,
+                           "checkIfEqual(autodiff::dual) must return false for different values in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( a, a, 1e-10 ) == true,
+                           "checkIfEqual(autodiff::dual) must return true for identical values in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  const std::complex< double > c1( 1.0, 0.0 ), c2( 1.0, 1.0 );
+  throwExceptionOnFailure( checkIfEqual( c1, c2, 1e-10 ) == false,
+                           "checkIfEqual(complex<double>) must return false for different imaginary parts in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+  throwExceptionOnFailure( checkIfEqual( c1, c1, 1e-10 ) == true,
+                           "checkIfEqual(complex<double>) must return true for identical values in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testCheckIfEqualMatrixHintPathForMismatch()
+{
+  // Exercises the "-> HINT: a(i,j) = ... != b(i,j) = ..." diagnostic path (and, through it,
+  // getString()), which is only reached inside a *failing* matrix comparison.
+  Eigen::MatrixXd a( 1, 1 ), b( 1, 1 );
+  a( 0, 0 ) = 1.0;
+  b( 0, 0 ) = 2.0;
+
+  throwExceptionOnFailure( checkIfEqual< double >( a, b, 1e-10 ) == false,
+                           "checkIfEqual() for mismatched matrices must return false in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testThrowExceptionOnFailureThrowsForFalseCondition()
+{
+  bool threw = false;
+  try {
+    throwExceptionOnFailure( false, "deliberate test failure message" );
+  }
+  catch ( const std::runtime_error& e ) {
+    threw = std::string( e.what() ) == "deliberate test failure message";
+  }
+  throwExceptionOnFailure( threw,
+                           "throwExceptionOnFailure(false, ...) must throw std::runtime_error with the given "
+                           "message in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // Must not throw for a true condition.
+  throwExceptionOnFailure( true, "must not be thrown" );
+}
+
+void testExecuteTestsAndCollectExceptionsAggregatesFailures()
+{
+  bool passed = false;
+
+  const std::vector< std::function< void() > > innerTests = {
+    []() { /* passes */ },
+    []() { throw std::runtime_error( "deliberate inner failure" ); },
+  };
+
+  bool threw = false;
+  try {
+    executeTestsAndCollectExceptions( innerTests );
+  }
+  catch ( const std::runtime_error& e ) {
+    threw = std::string( e.what() ) == "some tests failed";
+  }
+  throwExceptionOnFailure( threw,
+                           "executeTestsAndCollectExceptions() must throw \"some tests failed\" when a test "
+                           "throws in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // A fully passing set must not throw.
+  const std::vector< std::function< void() > > passingTests = { []() {}, [&passed]() { passed = true; } };
+  executeTestsAndCollectExceptions( passingTests );
+  throwExceptionOnFailure( passed,
+                           "executeTestsAndCollectExceptions() did not run a passing test in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+namespace {
+
+  Marmot::Solvers::MarmotMaterialPointSolverHypoElastic makeIsotropicSolver()
+  {
+    static std::vector< double > materialProperties = { 20000., 0.25 };
+    static std::string           matName            = "LINEARELASTIC";
+    auto                         solveropts = Marmot::Solvers::MarmotMaterialPointSolverHypoElastic::SolverOptions();
+    return Marmot::Solvers::MarmotMaterialPointSolverHypoElastic( matName,
+                                                                  materialProperties.data(),
+                                                                  materialProperties.size(),
+                                                                  solveropts );
+  }
+
+} // namespace
+
+void testSpinTurbokreiselReturnsFalseForNoSteps()
+{
+  auto solver = makeIsotropicSolver();
+  throwExceptionOnFailure( spinTurbokreisel( solver, 1e-8, 1e-8 ) == false,
+                           "spinTurbokreisel() must return false when no steps were added in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSpinTurbokreiselReturnsFalseForAStressControlledStep()
+{
+  auto solver = makeIsotropicSolver();
+
+  Marmot::Solvers::MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, false };
+  step.isStressComponentControlled = { false, false, false, false, false, true }; // not pure strain control
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+
+  solver.addStep( step );
+
+  throwExceptionOnFailure( spinTurbokreisel( solver, 1e-8, 1e-8 ) == false,
+                           "spinTurbokreisel() must return false for a step that is not purely strain-controlled "
+                           "in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSpinTurbokreiselDetectsAnAnisotropicMaterial()
+{
+  // A transversely isotropic (i.e. genuinely NOT isotropic) LinearElastic material: E1, E2, nu12,
+  // nu23, G12, and the two direction vectors defining the local coordinate system.
+  static std::vector< double > materialProperties = { 20000, 10000, 0.25, 0.3, 4000, 1, 0, 0, 0, 0, 1 };
+  static std::string           matName            = "LINEARELASTIC";
+  auto                         solveropts = Marmot::Solvers::MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                         solver     = Marmot::Solvers::MarmotMaterialPointSolverHypoElastic( matName,
+                                                                       materialProperties.data(),
+                                                                       materialProperties.size(),
+                                                                       solveropts );
+
+  Marmot::Solvers::MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-3;
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+
+  solver.addStep( step );
+
+  // A transversely isotropic material's response depends on orientation relative to its material
+  // axes, so rotating the loading direction (as spinTurbokreisel does) must be detected as a
+  // stress and/or tangent mismatch against the un-rotated reference response.
+  throwExceptionOnFailure( spinTurbokreisel( solver, 1e-6, 1e-6 ) == false,
+                           "spinTurbokreisel() must detect a transversely isotropic (non-isotropic) material as "
+                           "failing the isotropy check in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+void testSpinTurbokreiselDetectsATangentOnlyMismatch()
+{
+  // Same anisotropic setup as above, but with a deliberately loose stress tolerance: exercises the
+  // separate tangent-mismatch failure branch (reached only once the stress check has already
+  // passed), rather than the stress-mismatch branch above.
+  static std::vector< double > materialProperties = { 20000, 10000, 0.25, 0.3, 4000, 1, 0, 0, 0, 0, 1 };
+  static std::string           matName            = "LINEARELASTIC";
+  auto                         solveropts = Marmot::Solvers::MarmotMaterialPointSolverHypoElastic::SolverOptions();
+  auto                         solver     = Marmot::Solvers::MarmotMaterialPointSolverHypoElastic( matName,
+                                                                       materialProperties.data(),
+                                                                       materialProperties.size(),
+                                                                       solveropts );
+
+  Marmot::Solvers::MarmotMaterialPointSolverHypoElastic::Step step;
+  step.isStrainComponentControlled = { true, true, true, true, true, true };
+  step.isStressComponentControlled = { false, false, false, false, false, false };
+  step.strainIncrementTarget       = Marmot::Vector6d::Zero();
+  step.strainIncrementTarget( 0 )  = 1e-3;
+  step.stressIncrementTarget       = Marmot::Vector6d::Zero();
+
+  solver.addStep( step );
+
+  throwExceptionOnFailure( spinTurbokreisel( solver, 1e2, 1e-6 ) == false,
+                           "spinTurbokreisel() must detect a tangent-only mismatch under a loose stress "
+                           "tolerance in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
+int main()
+{
+  const std::vector< std::function< void() > > tests = {
+    testGetStringFormatsDoubleAndDual,
+    testCheckIfEqualReturnsFalseForNaNAndInf,
+    testCheckIfEqualReturnsFalseForMismatchedScalars,
+    testCheckIfEqualMatrixHintPathForMismatch,
+    testThrowExceptionOnFailureThrowsForFalseCondition,
+    testExecuteTestsAndCollectExceptionsAggregatesFailures,
+    testSpinTurbokreiselReturnsFalseForNoSteps,
+    testSpinTurbokreiselReturnsFalseForAStressControlledStep,
+    testSpinTurbokreiselDetectsAnAnisotropicMaterial,
+    testSpinTurbokreiselDetectsATangentOnlyMismatch,
+  };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
`MarmotUtilitiesCore` (MarmotJournal, MarmotTesting) had no `test.cmake`/`test/` directory at all — reaudited the core modules and found this was the largest remaining untouched gap.

- **Bug fix**: `spinTurbokreisel()` (the isotropy-check test helper used by several material tests) called `solver.solve()` and `.getHistory().back()` *before* checking `solver.getSteps().size() == 0` — so a solver with no added steps segfaults on the empty-history `.back()` instead of hitting the "No steps found" guard sitting right below it. Reordered the guard checks to run first. Found this by literally triggering the segfault while writing the "no steps" test case.
- **Bug fix**: the same function's "must be pure strain control" guard checked `.any()` (at least one component controlled) instead of `.all()` (every component controlled), as the comment directly above it says is required — so a step with e.g. one stress-controlled component silently passed the guard instead of being rejected.
- Added `test.cmake` + `test/` for the module, with dedicated tests for `MarmotJournal` (output redirection, warning/notification return values) and `MarmotTesting` (this repo's own assertion framework: `checkIfEqual`, `getString`, `throwExceptionOnFailure`, `executeTestsAndCollectExceptions`, `spinTurbokreisel`). Most of `MarmotTesting.cpp`'s source is only reached when an equality check actually *fails* — which correctly never happens in a clean suite — so covering it means deliberately triggering failures (mismatched values, a throwing sub-test, a genuinely non-isotropic material) and checking they're reported/returned correctly, including isolating the tangent-only-mismatch branch by loosening the stress tolerance so the stress-mismatch branch doesn't return first.

## Test plan
- [x] `ctest` — 50/50 tests pass locally (Debug build)
- [x] Confirmed the segfault reproduces on the old code (via the "no steps" test) and is gone after reordering; confirmed the `.any()`→`.all()` fix correctly rejects a mixed-control step
- [x] Local `gcovr`: `MarmotJournal.cpp` 0% → 100%; `MarmotTesting.cpp` 65% → 99% (the one remaining line is exercised by existing material tests that already call `spinTurbokreisel` expecting `true`, just not by this new file in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA