### PR TITLE
fix(core): reaudit MarmotMathCore/MarmotMechanicsCore for coverage gaps

### DIFF
--- a/modules/core/MarmotMathCore/include/Marmot/MarmotFastorTensorBasics.h
+++ b/modules/core/MarmotMathCore/include/Marmot/MarmotFastorTensorBasics.h
@@ -91,7 +91,7 @@ namespace Marmot {
 
       inline const Tensor3333d Deviatoric = I4 - 1. / 3 * IHyd;
 
-      inline const Tensor3333d DeviatoricTranspose = Fastor::transpose( DeviatoricTranspose );
+      inline const Tensor3333d DeviatoricTranspose = Fastor::transpose( Deviatoric );
 
       inline const Tensor3333d DeviatoricSymmetric = ISymm - 1. / 3 * IHyd;
 

--- a/modules/core/MarmotMathCore/src/MarmotAutomaticDifferentiation.cpp
+++ b/modules/core/MarmotMathCore/src/MarmotAutomaticDifferentiation.cpp
@@ -19,8 +19,8 @@ namespace Marmot {
 
     VectorXdual2nd shiftTo2ndOrderDual( const VectorXdual& X )
     {
-      VectorXdual2nd X_;
       const size_t   sizeX = X.size();
+      VectorXdual2nd X_( sizeX );
 
       for ( size_t j = 0; j < sizeX; j++ ) {
         X_( j ) = shiftTo2ndOrderDual( X( j ) );

--- a/modules/core/MarmotMathCore/src/MarmotMath.cpp
+++ b/modules/core/MarmotMathCore/src/MarmotMath.cpp
@@ -36,10 +36,6 @@ namespace Marmot {
     {
       return double( value );
     }
-    double makeReal( const autodiff::dual& value )
-    {
-      return double( value );
-    }
 
     double makeReal( const double& value )
     {
@@ -49,12 +45,13 @@ namespace Marmot {
     // return the exponent to the power of ten of an expression like 5*10^5 --> return 5
     int getExponentPowerTen( const double x )
     {
-      if ( x >= 1e-16 )      // positive number
-        return floor( log10( x ) );
-      else if ( x <= 1e-16 ) // negative number
-        return floor( log10( abs( x ) ) );
-      else                   // number close to 0
+      // "x >= 1e-16" and "x <= 1e-16" are collectively exhaustive over all reals, so a
+      // three-way branch on those two conditions can never reach a "close to 0" case;
+      // in particular x == 0 fell through to log10(0) == -inf, which is UB once floor()'d
+      // into the int return type. Guard on |x| explicitly instead.
+      if ( std::abs( x ) < 1e-16 )
         return 0;
+      return floor( log10( std::abs( x ) ) );
     }
 
     Matrix3d orthonormalCoordinateSystem( Vector3d& normalVector )

--- a/modules/core/MarmotMathCore/test.cmake
+++ b/modules/core/MarmotMathCore/test.cmake
@@ -30,3 +30,6 @@ add_marmot_test("TestMarmotTensorExponential" "${CURR_TEST_SOURCE_DIR}/TestMarmo
 
 # Tests for MarmotEigenSystems
 add_marmot_test("TestMarmotEigenSystems" "${CURR_TEST_SOURCE_DIR}/TestMarmotEigenSystems.cpp")
+
+# Tests for MarmotFastorTensorBasics
+add_marmot_test("TestMarmotFastorTensorBasics" "${CURR_TEST_SOURCE_DIR}/TestMarmotFastorTensorBasics.cpp")

--- a/modules/core/MarmotMathCore/test/TestMarmotAutomaticDifferentiation.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotAutomaticDifferentiation.cpp
@@ -76,11 +76,35 @@ void testADForVectorValuedFunctions()
                            "Error in vector function jacobian with autodiff::dual2nd" );
 }
 
+void testShiftTo2ndOrderDualForVectors()
+{
+  using namespace Marmot::AutomaticDifferentiation;
+
+  autodiff::VectorXdual X( 3 );
+  X( 0 ) = 1.5;
+  X( 1 ) = -2.5;
+  X( 2 ) = 3.5;
+
+  const autodiff::VectorXdual2nd X2nd = shiftTo2ndOrderDual( X );
+
+  throwExceptionOnFailure( static_cast< int >( X2nd.size() ) == 3,
+                           "shiftTo2ndOrderDual(VectorXdual) returned the wrong size in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  for ( int i = 0; i < 3; i++ ) {
+    const autodiff::dual2nd expected = shiftTo2ndOrderDual( X( i ) );
+    throwExceptionOnFailure( checkIfEqual( X2nd( i ).val, expected.val ),
+                             "shiftTo2ndOrderDual(VectorXdual) does not match the scalar overload at index " +
+                               std::to_string( i ) + " in " + std::string( __PRETTY_FUNCTION__ ) );
+  }
+}
+
 int main()
 {
 
   auto tests = std::vector< std::function< void() > >{ testAutomaticDifferentiationForScalars,
-                                                       testADForVectorValuedFunctions };
+                                                       testADForVectorValuedFunctions,
+                                                       testShiftTo2ndOrderDualForVectors };
 
   executeTestsAndCollectExceptions( tests );
 

--- a/modules/core/MarmotMathCore/test/TestMarmotFastorTensorBasics.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotFastorTensorBasics.cpp
@@ -1,0 +1,71 @@
+#include "Marmot/MarmotFastorTensorBasics.h"
+#include "Marmot/MarmotTesting.h"
+
+using namespace Marmot::Testing;
+using namespace Marmot::FastorStandardTensors;
+using namespace Marmot::FastorStandardTensors::Spatial3D;
+
+void testInvertMinorSymmetricFourthOrderTensorMatchesIsotropicCompliance()
+{
+  // isotropic elasticity tensor C = lambda * I2xI2 + 2*mu*Isym
+  const double lambda = 1.0;
+  const double mu     = 0.5;
+
+  const Tensor3333d C = lambda * IHyd + 2. * mu * ISymm;
+
+  const Tensor3333d Cinv = Marmot::invertMinorSymmetricFourthOrderTensor( C );
+
+  // analytical isotropic compliance tensor: S = 1/(2*mu) * Isym - lambda / ( 2*mu*(3*lambda + 2*mu) ) * I2xI2
+  const double      nuOverE   = lambda / ( 2. * mu * ( 3. * lambda + 2. * mu ) );
+  const Tensor3333d Sexpected = 1. / ( 2. * mu ) * ISymm - nuOverE * IHyd;
+
+  throwExceptionOnFailure( checkIfEqual( Cinv, Sexpected, 1e-10 ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " invertMinorSymmetricFourthOrderTensor does not match the analytical "
+                                           "isotropic compliance tensor" );
+}
+
+void testInvertMinorSymmetricFourthOrderTensorIsInvolutive()
+{
+  // for a different set of isotropic parameters, inverting twice must recover the original tensor
+  const double lambda = 2.3;
+  const double mu     = 0.7;
+
+  const Tensor3333d C       = lambda * IHyd + 2. * mu * ISymm;
+  const Tensor3333d Cinv    = Marmot::invertMinorSymmetricFourthOrderTensor( C );
+  const Tensor3333d CinvInv = Marmot::invertMinorSymmetricFourthOrderTensor( Cinv );
+
+  throwExceptionOnFailure( checkIfEqual( CinvInv, C, 1e-8 ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " inverting the inverse of a minor-symmetric fourth order tensor must "
+                                           "recover the original tensor" );
+}
+
+void testDeviatoricTransposeIsTransposeOfDeviatoric()
+{
+  // DeviatoricTranspose used to self-referentially read its own (uninitialized) value in its
+  // initializer instead of transposing Deviatoric; guard against a regression to that bug.
+  const Tensor3333d expected = Fastor::transpose( Deviatoric );
+
+  throwExceptionOnFailure( checkIfEqual( DeviatoricTranspose, expected ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " DeviatoricTranspose must equal transpose(Deviatoric)" );
+
+  const Tensor3333d zero( 0.0 );
+  throwExceptionOnFailure( !checkIfEqual( DeviatoricTranspose, zero, 1e-12 ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " DeviatoricTranspose must not degenerate to the all-zero tensor "
+                                           "produced by the old self-referential initialization bug" );
+}
+
+int main()
+{
+  auto
+    tests = std::vector< std::function< void() > >{ testInvertMinorSymmetricFourthOrderTensorMatchesIsotropicCompliance,
+                                                    testInvertMinorSymmetricFourthOrderTensorIsInvolutive,
+                                                    testDeviatoricTransposeIsTransposeOfDeviatoric };
+
+  executeTestsAndCollectExceptions( tests );
+
+  return 0;
+}

--- a/modules/core/MarmotMathCore/test/TestMarmotMath.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotMath.cpp
@@ -254,6 +254,39 @@ void test_getExponentPowerTen()
     throwExceptionOnFailure( checkIfEqual( computed, expected ),
                              MakeString() << __PRETTY_FUNCTION__ << " failed for Testcase 2" );
   }
+
+  // Testcase 3: value exactly zero must return 0, not floor(log10(0)) == -inf
+  {
+    double computed = getExponentPowerTen( 0.0 );
+    double expected = 0;
+    throwExceptionOnFailure( checkIfEqual( computed, expected ),
+                             MakeString() << __PRETTY_FUNCTION__ << " failed for Testcase 3 (x == 0)" );
+  }
+
+  // Testcase 4: value close to (but not exactly) zero, on both sides
+  {
+    double computed = getExponentPowerTen( 5e-17 );
+    double expected = 0;
+    throwExceptionOnFailure( checkIfEqual( computed, expected ),
+                             MakeString() << __PRETTY_FUNCTION__ << " failed for Testcase 4 (positive, close to 0)" );
+  }
+  {
+    double computed = getExponentPowerTen( -5e-17 );
+    double expected = 0;
+    throwExceptionOnFailure( checkIfEqual( computed, expected ),
+                             MakeString() << __PRETTY_FUNCTION__ << " failed for Testcase 4 (negative, close to 0)" );
+  }
+}
+
+void test_factorial()
+{
+  throwExceptionOnFailure( checkIfEqual( static_cast< double >( factorial( 0 ) ), 1.0 ),
+                           MakeString() << __PRETTY_FUNCTION__ << " failed for n = 0" );
+  throwExceptionOnFailure( checkIfEqual( static_cast< double >( factorial( 1 ) ), 1.0 ),
+                           MakeString() << __PRETTY_FUNCTION__ << " failed for n = 1" );
+  // n = 5 exercises the recursive branch: 5! = 120
+  throwExceptionOnFailure( checkIfEqual( static_cast< double >( factorial( 5 ) ), 120.0 ),
+                           MakeString() << __PRETTY_FUNCTION__ << " failed for n = 5" );
 }
 
 void test_orthonormalCoordinateSystem()
@@ -290,6 +323,44 @@ void test_orthonormalCoordinateSystem()
 
     throwExceptionOnFailure( checkIfEqual< double >( computed, expected ),
                              MakeString() << __PRETTY_FUNCTION__ << " failed for Testcase 2" );
+  }
+
+  {
+    // Test 3: normal vector along the z-axis, i.e. its x and y components are exactly
+    // zero -- exercises the dedicated branch that special-cases this to avoid degenerating
+    // the arbitrary-perpendicular-vector construction.
+    Marmot::Vector3d normalVector( 0.0, 0.0, 1.0 );
+    Marmot::Matrix3d computed = orthonormalCoordinateSystem( normalVector );
+
+    // columns: normal vector (0,0,1); hard-coded orthogonal vector (0,1,0);
+    // cross product of the two, (0,0,1) x (0,1,0) = (-1,0,0)
+    Marmot::Matrix3d expected;
+    // clang-format off
+    expected <<  0.0, 0.0, -1.0,
+                 0.0, 1.0,  0.0,
+                 1.0, 0.0,  0.0;
+    // clang-format on
+
+    throwExceptionOnFailure( checkIfEqual< double >( computed, expected ),
+                             MakeString() << __PRETTY_FUNCTION__ << " failed for Testcase 3 (normal along z-axis)" );
+  }
+
+  {
+    // Test 4: non-orthogonal n1, n2 must throw
+    Marmot::Vector3d n1( 1.0, 0.0, 0.0 );
+    Marmot::Vector3d n2( 1.0, 1.0, 0.0 );
+
+    bool threw = false;
+    try {
+      orthonormalCoordinateSystem( n1, n2 );
+    }
+    catch ( const std::invalid_argument& ) {
+      threw = true;
+    }
+
+    throwExceptionOnFailure( threw,
+                             MakeString()
+                               << __PRETTY_FUNCTION__ << " failed to throw for non-orthogonal n1, n2 (Testcase 4)" );
   }
 }
 
@@ -721,6 +792,7 @@ int main()
                                                        test_exp,
                                                        test_makeReal,
                                                        test_getExponentPowerTen,
+                                                       test_factorial,
                                                        test_orthonormalCoordinateSystem,
                                                        test_directionCosines,
                                                        test_isNaN,

--- a/modules/core/MarmotMathCore/test/TestMarmotNumericalIntegration.cpp
+++ b/modules/core/MarmotMathCore/test/TestMarmotNumericalIntegration.cpp
@@ -42,9 +42,35 @@ void testIntegrateScalarFunction()
                            "Simpson's rule integration failed." );
 }
 
+void testIntegrateScalarFunctionThrowsForInvalidRule()
+{
+  auto testFunction = []( const double x ) { return std::pow( x, 2 ); };
+
+  std::tuple< double, double > limits = { 0.0, 1.0 };
+  int                          nSteps = 10;
+
+  // any enumerator value outside {midpoint, trapezodial, simpson} must hit the default: throw branch
+  const auto invalidRule = static_cast< integrationRule >( 99 );
+
+  bool threw = false;
+  try {
+    integrateScalarFunction( testFunction, limits, nSteps, invalidRule );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+
+  throwExceptionOnFailure( threw,
+                           "integrateScalarFunction() must throw std::invalid_argument for an unknown "
+                           "integration rule" );
+}
+
 int main()
 {
-  testIntegrateScalarFunction();
+  auto tests = std::vector< std::function< void() > >{ testIntegrateScalarFunction,
+                                                       testIntegrateScalarFunctionThrowsForInvalidRule };
+
+  executeTestsAndCollectExceptions( tests );
 
   return 0;
 }

--- a/modules/core/MarmotMathCore/test/TestNewtonConvergenceChecker.cpp
+++ b/modules/core/MarmotMathCore/test/TestNewtonConvergenceChecker.cpp
@@ -68,5 +68,26 @@ int main()
   throwExceptionOnFailure( checker.isConverged( residual, X, increment, 15 ) == true,
                            "checker.isConverged( residual, X, increment, 15 ) != true" );
 
+  // convergence within nMaxNewtonCycles using the *normal* (non-alt) tolerances
+  residual << 1e-9;
+  increment << 1e-9;
+  throwExceptionOnFailure( checker.isConverged( residual, X, increment, 5 ) == true,
+                           "checker.isConverged() must be true for a residual/increment satisfying the normal "
+                           "tolerances within nMaxNewtonCycles" );
+  throwExceptionOnFailure( checker.iterationFinished( residual, X, increment, 5 ) == true,
+                           "checker.iterationFinished() must be true once isConverged() is true" );
+
+  // relativeNorm: increment norm below 1e-14 must short-circuit to incNorm itself
+  Eigen::VectorXd tinyIncrement( 1 );
+  tinyIncrement << 1e-15;
+  throwExceptionOnFailure( checkIfEqual( checker.relativeNorm( tinyIncrement, X ), tinyIncrement.norm() ),
+                           "relativeNorm() must return incNorm unchanged when incNorm < 1e-14" );
+
+  // relativeNorm: reference norm below 1e-12 must yield 0.0 (undefined relative norm)
+  Eigen::VectorXd tinyX( 1 );
+  tinyX << 1e-13;
+  throwExceptionOnFailure( checkIfEqual( checker.relativeNorm( increment, tinyX ), 0.0 ),
+                           "relativeNorm() must return 0.0 when the reference norm < 1e-12" );
+
   return 0;
 }

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotKelvinChain.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotKelvinChain.cpp
@@ -190,6 +190,27 @@ void approximateZerothComplianceTestFunction()
                            MakeString() << __PRETTY_FUNCTION__ << " error in zeroth compliance" );
 }
 
+void updateStateVarMatrixIsANoOpForZeroTimeIncrementTestFunction()
+{
+  const int  n = 2;
+  Properties elasticModuli( n ), retardationTimes( n );
+  elasticModuli << 3., 30.;
+  retardationTimes << 10., 50.;
+
+  StateVarMatrix stateVars( 6, n );
+  stateVars << 0.01, 0.1, 0.02, 0.2, 0.03, 0.3, 0.04, 0.4, 0.05, 0.5, 0.06, 0.6;
+  const StateVarMatrix stateVarsBefore = stateVars;
+
+  Vector6d dStress              = { 0.1, 0.2, 0.3, 0.06, 0.04, 0.02 };
+  Matrix6d unitComplianceMatrix = ContinuumMechanics::Elasticity::Isotropic::complianceTensor( 1.0, 0.2 );
+
+  updateStateVarMatrix( 0.0, elasticModuli, retardationTimes, stateVars, dStress, unitComplianceMatrix );
+
+  throwExceptionOnFailure( checkIfEqual< double >( stateVars, stateVarsBefore ),
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << " updateStateVarMatrix() must be a no-op for dT <= 1e-14" );
+}
+
 int main()
 {
 
@@ -197,7 +218,8 @@ int main()
                                                        computeLambdaAndBetaTestFunction,
                                                        computeElasticModuliTestFunction,
                                                        approximateZerothComplianceTestFunction,
-                                                       evaluatePostWidderFormulaTestFunction };
+                                                       evaluatePostWidderFormulaTestFunction,
+                                                       updateStateVarMatrixIsANoOpForZeroTimeIncrementTestFunction };
 
   executeTestsAndCollectExceptions( tests );
 

--- a/modules/core/MarmotMechanicsCore/test/TestMarmotLocalization.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMarmotLocalization.cpp
@@ -65,9 +65,31 @@ void testMarmotLocalization()
                            "test minimumDeterminantAcousticTensor" );
 }
 
+void testLocalizationChecker()
+{
+  using namespace Marmot::ContinuumMechanics::LocalizationAnalysis;
+
+  // A well-conditioned (positive-definite, non-singular) acoustic tensor: no localization.
+  Marmot::Matrix3d wellConditioned = Marmot::Matrix3d::Identity() * 1000.;
+  throwExceptionOnFailure( localizationChecker( wellConditioned ) == false,
+                           "localizationChecker() must return false for a well-conditioned acoustic tensor in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+
+  // A singular (zero-determinant) acoustic tensor: localization detected.
+  Marmot::Matrix3d singular = Marmot::Matrix3d::Zero();
+  singular( 0, 0 )          = 1000.;
+  singular( 1, 1 )          = 1000.;
+  // row/col 2 left as zero -> determinant exactly 0
+  throwExceptionOnFailure( localizationChecker( singular ) == true,
+                           "localizationChecker() must return true for a singular acoustic tensor in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
 int main()
 {
-  testMarmotLocalization();
+  auto tests = std::vector< std::function< void() > >{ testMarmotLocalization, testLocalizationChecker };
+
+  executeTestsAndCollectExceptions( tests );
 
   return 0;
 }

--- a/modules/core/MarmotMechanicsCore/test/TestMenetreyWillam.cpp
+++ b/modules/core/MarmotMechanicsCore/test/TestMenetreyWillam.cpp
@@ -213,6 +213,20 @@ void testd2PolarRadius_dTheta2()
                                         << " failed: 2nd derivative of polar radius for shear meridian is wrong" );
 }
 
+void testSetParametersThrowsForUnknownType()
+{
+  bool threw = false;
+  try {
+    MenetreyWillam( 2.1, static_cast< MenetreyWillam::MenetreyWillamType >( 99 ) );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           "MenetreyWillam::setParameters() must throw for an unknown MenetreyWillamType in " +
+                             std::string( __PRETTY_FUNCTION__ ) );
+}
+
 int main()
 {
   auto tests = std::vector< std::function< void() > >{ testYieldFunctions,
@@ -220,7 +234,8 @@ int main()
                                                        testInlineFunctions,
                                                        testDerivatives,
                                                        testdPolarRadius_dTheta,
-                                                       testd2PolarRadius_dTheta2 };
+                                                       testd2PolarRadius_dTheta2,
+                                                       testSetParametersThrowsForUnknownType };
 
   executeTestsAndCollectExceptions( tests );
 


### PR DESCRIPTION
## Summary

Continues the coverage-driven reaudit of `modules/core`. Adds targeted tests for previously-uncovered branches, and — per the pattern established across this series of PRs — treats every bug uncovered while writing them as a first-class fix rather than just documenting the gap.

### Bugs found and fixed

- **`MarmotMath.cpp`: `getExponentPowerTen()`'s "close to 0" branch was dead code.** Its two guard conditions (`x >= 1e-16`, `x <= 1e-16`) are collectively exhaustive over all reals, so the `else` branch could never execute. In particular `x == 0` fell into the "negative number" branch, computing `floor(log10(0)) == -inf` and converting that to `int` (UB). Replaced the three-way branch with a single `|x| < 1e-16` guard.
- **`MarmotMath.cpp`: removed `makeReal(const autodiff::dual&)`**, a non-template overload with no declaration anywhere outside its own `.cpp`, made permanently unreachable by `MarmotMath.h`'s templated `makeReal(const autodiff::detail::Dual<T,G>&)` overload — genuine dead code.
- **`MarmotFastorTensorBasics.h`: `Spatial3D::DeviatoricTranspose` read itself (uninitialized) in its own initializer** instead of transposing `Deviatoric` — undefined behavior at static-init time, silently degenerating to an all-zero tensor. No current caller depends on it, but fixed now that a regression test exists.
- **`MarmotAutomaticDifferentiation.cpp`: `shiftTo2ndOrderDual(const VectorXdual&)`** wrote into a default-constructed (size-0) `VectorXdual2nd` without resizing it first — an out-of-bounds write, caught by an Eigen assertion crash the first time a test exercised this previously zero-caller function. Fixed by sizing the vector before writing.

### Test coverage added

- `TestMarmotMath.cpp`: `factorial`'s recursive branch, `orthonormalCoordinateSystem`'s z-axis-normal branch and its non-orthogonal-input throw, `getExponentPowerTen`'s near-zero cases.
- `TestMarmotNumericalIntegration.cpp`: the unknown-integration-rule throw path.
- `TestNewtonConvergenceChecker.cpp`: the within-`nMaxNewtonCycles` convergence branch, and both `relativeNorm()` short-circuit branches (tiny increment, tiny reference).
- `TestMarmotFastorTensorBasics.cpp` (new): first-ever test coverage for `invertMinorSymmetricFourthOrderTensor` (verified against the closed-form isotropic compliance tensor, plus an invert-twice round trip) and for the `DeviatoricTranspose` fix.
- `TestMarmotAutomaticDifferentiation.cpp`: vector-valued `shiftTo2ndOrderDual` test (the one that caught the bug above).
- `MarmotMechanicsCore`: small residual gaps in `TestMenetreyWillam.cpp` (unknown `MenetreyWillamType` throw), `TestMarmotLocalization.cpp` (`localizationChecker` well-conditioned/singular branches), `TestMarmotKelvinChain.cpp` (`updateStateVarMatrix`'s `dT<=1e-14` no-op branch).

### Deliberately left as-is (not real gaps)

- `MarmotMath.cpp`'s `transformToLocalSystem`/`transformToGlobalSystem` — already covered by the open, unmerged #90 branch.
- Three lines in `MarmotNumericalDifferentiation.cpp` — a gcov line-attribution artifact where a division operator sits alone on a `clang-format-off` comment line; confirmed via annotated gcov output that the surrounding lines of the same statement are hit.

## Test plan

- [x] All 49 local `ctest` targets pass (`ctest --output-on-failure`)
- [x] Verified `DeviatoricTranspose` fix and `invertMinorSymmetricFourthOrderTensor` against closed-form isotropic elasticity/compliance tensors
- [x] Verified the `shiftTo2ndOrderDual` fix by reproducing the pre-fix Eigen assertion crash, then confirming the test passes after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA