### PR TITLE
test(core): reaudit MarmotFiniteStrainMechanicsCore for coverage gaps

### DIFF
--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotEnergyDensityFunctions.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotEnergyDensityFunctions.cpp
@@ -162,13 +162,164 @@ auto testSecondOrderDerivedB()
     }
 }
 
+auto testStandardNeoHookeEnergyMatchesClosedForm()
+{
+  using namespace Marmot::ContinuumMechanics::EnergyDensityFunctions::ThirdOrderDerived;
+  std::tuple< Tensor33d, Tensor33d, double, double, double, double > params = computationParameters();
+  Tensor33d                                                          C      = get< 0 >( params );
+  const double                                                       K      = get< 2 >( params );
+  const double                                                       G      = get< 3 >( params );
+
+  const double lambda   = K - 2.0 / 3.0 * G;
+  const double trC      = Fastor::trace( C );
+  const double detC     = Fastor::determinant( C );
+  const double expected = G / 2. * ( trC - 3.0 - log( detC ) ) + lambda / 4. * ( detC - 1.0 - log( detC ) );
+
+  auto [psi, dPsi_dC, d2Psi_dC2, d3Psi_dC3] = standardNeoHooke( C, K, G );
+
+  throwExceptionOnFailure( checkIfEqual( psi, expected, 1e-10 ),
+                           MakeString() << __PRETTY_FUNCTION__ << " energy density does not match the closed form" );
+}
+
+auto testStandardNeoHookeFirstDerivativeMatchesNumericalDifferentiation()
+{
+  using namespace Marmot::ContinuumMechanics::EnergyDensityFunctions::ThirdOrderDerived;
+  std::tuple< Tensor33d, Tensor33d, double, double, double, double > params = computationParameters();
+  Tensor33d                                                          C      = get< 0 >( params );
+  const double                                                       K      = get< 2 >( params );
+  const double                                                       G      = get< 3 >( params );
+
+  auto [psi0, dPsi_dC, d2Psi_dC2, d3Psi_dC3] = standardNeoHooke( C, K, G );
+
+  const double h = 1e-6;
+  for ( int i = 0; i < 3; i++ )
+    for ( int j = 0; j < 3; j++ ) {
+      Tensor33d Cp = C;
+      Tensor33d Cm = C;
+      Cp( i, j ) += h;
+      Cm( i, j ) -= h;
+      const double psiPlus  = std::get< 0 >( standardNeoHooke( Cp, K, G ) );
+      const double psiMinus = std::get< 0 >( standardNeoHooke( Cm, K, G ) );
+      const double numDeriv = ( psiPlus - psiMinus ) / ( 2. * h );
+      throwExceptionOnFailure( checkIfEqual( dPsi_dC( i, j ), numDeriv, 1e-6 ),
+                               MakeString() << __PRETTY_FUNCTION__ << " dPsi_dC(" << i << "," << j
+                                            << ") does not match central-difference numerical differentiation" );
+    }
+}
+
+// The 6 independent symmetric "unit" directions of a symmetric 3x3 tensor (00, 11, 22, and the
+// 3 off-diagonal directions with both (a,b) and (b,a) set to 1). d2Psi_dC2/d3Psi_dC3 are only
+// meaningful when contracted against directions like these -- C is always the (symmetric) right
+// Cauchy-Green tensor, and the returned tensors internally symmetrize over each differentiated
+// index pair to match that (e.g. d2Psi_dC2(i,j,k,l) == d2Psi_dC2(i,j,l,k) by construction), so
+// isolating a single (k,l) component via an asymmetric single-entry perturbation does not recover
+// it. Verifying directional bilinear/trilinear forms instead sidesteps that convention entirely.
+std::vector< Tensor33d > symmetricUnitDirections()
+{
+  std::vector< Tensor33d > directions;
+  for ( int a = 0; a < 3; a++ )
+    for ( int b = a; b < 3; b++ ) {
+      Tensor33d dC( 0.0 );
+      dC( a, b ) = 1.0;
+      dC( b, a ) = 1.0;
+      directions.push_back( dC );
+    }
+  return directions;
+}
+
+auto testStandardNeoHookeSecondDerivativeMatchesNumericalDifferentiation()
+{
+  using namespace Marmot::ContinuumMechanics::EnergyDensityFunctions::ThirdOrderDerived;
+  std::tuple< Tensor33d, Tensor33d, double, double, double, double > params = computationParameters();
+  Tensor33d                                                          C      = get< 0 >( params );
+  const double                                                       K      = get< 2 >( params );
+  const double                                                       G      = get< 3 >( params );
+
+  auto [psi0, dPsi_dC0, d2Psi_dC2, d3Psi_dC3] = standardNeoHooke( C, K, G );
+
+  const double h = 1e-5;
+  for ( const Tensor33d& dC : symmetricUnitDirections() ) {
+    Tensor33d Cp = C + h * dC;
+    Tensor33d Cm = C - h * dC;
+
+    const Tensor33d dPsi_dC_plus  = std::get< 1 >( standardNeoHooke( Cp, K, G ) );
+    const Tensor33d dPsi_dC_minus = std::get< 1 >( standardNeoHooke( Cm, K, G ) );
+
+    for ( int i = 0; i < 3; i++ )
+      for ( int j = 0; j < 3; j++ ) {
+        const double numDirectional = ( dPsi_dC_plus( i, j ) - dPsi_dC_minus( i, j ) ) / ( 2. * h );
+
+        double analyticalDirectional = 0.0;
+        for ( int k = 0; k < 3; k++ )
+          for ( int l = 0; l < 3; l++ )
+            analyticalDirectional += d2Psi_dC2( i, j, k, l ) * dC( k, l );
+
+        throwExceptionOnFailure( checkIfEqual( analyticalDirectional, numDirectional, 1e-4 ),
+                                 MakeString() << __PRETTY_FUNCTION__ << " d2Psi_dC2 contracted with a symmetric "
+                                              << "direction does not match numerical differentiation at (" << i << ","
+                                              << j << ")" );
+      }
+  }
+}
+
+auto testStandardNeoHookeThirdDerivativeMatchesNumericalDifferentiation()
+{
+  using namespace Marmot::ContinuumMechanics::EnergyDensityFunctions::ThirdOrderDerived;
+  std::tuple< Tensor33d, Tensor33d, double, double, double, double > params = computationParameters();
+  Tensor33d                                                          C      = get< 0 >( params );
+  const double                                                       K      = get< 2 >( params );
+  const double                                                       G      = get< 3 >( params );
+
+  auto [psi0, dPsi_dC0, d2Psi_dC2_0, d3Psi_dC3] = standardNeoHooke( C, K, G );
+
+  const std::vector< Tensor33d > directions = symmetricUnitDirections();
+
+  const double h = 1e-4;
+  for ( const Tensor33d& dCOuter : directions ) {
+    Tensor33d Cp = C + h * dCOuter;
+    Tensor33d Cm = C - h * dCOuter;
+
+    const Tensor3333d d2Psi_dC2_plus  = std::get< 2 >( standardNeoHooke( Cp, K, G ) );
+    const Tensor3333d d2Psi_dC2_minus = std::get< 2 >( standardNeoHooke( Cm, K, G ) );
+
+    for ( const Tensor33d& dCInner : directions )
+      for ( int i = 0; i < 3; i++ )
+        for ( int j = 0; j < 3; j++ ) {
+          double d2Plus = 0.0, d2Minus = 0.0;
+          for ( int k = 0; k < 3; k++ )
+            for ( int l = 0; l < 3; l++ ) {
+              d2Plus += d2Psi_dC2_plus( i, j, k, l ) * dCInner( k, l );
+              d2Minus += d2Psi_dC2_minus( i, j, k, l ) * dCInner( k, l );
+            }
+          const double numDirectional = ( d2Plus - d2Minus ) / ( 2. * h );
+
+          double analyticalDirectional = 0.0;
+          for ( int k = 0; k < 3; k++ )
+            for ( int l = 0; l < 3; l++ )
+              for ( int m = 0; m < 3; m++ )
+                for ( int n = 0; n < 3; n++ )
+                  analyticalDirectional += d3Psi_dC3( i, j, k, l, m, n ) * dCInner( k, l ) * dCOuter( m, n );
+
+          throwExceptionOnFailure( checkIfEqual( analyticalDirectional, numDirectional, 1e-2 ),
+                                   MakeString() << __PRETTY_FUNCTION__ << " d3Psi_dC3 contracted with two symmetric "
+                                                << "directions does not match numerical differentiation at (" << i
+                                                << "," << j << ")" );
+        }
+  }
+}
+
 int main()
 {
-  auto tests = std::vector< std::function< void() > >{ testPenceGouPotentialA,
-                                                       testPenceGouPotentialB,
-                                                       testPenceGouPotentialC,
-                                                       testFirstOrderDerivedB,
-                                                       testSecondOrderDerivedB };
+  auto tests = std::vector<
+    std::function< void() > >{ testPenceGouPotentialA,
+                               testPenceGouPotentialB,
+                               testPenceGouPotentialC,
+                               testFirstOrderDerivedB,
+                               testSecondOrderDerivedB,
+                               testStandardNeoHookeEnergyMatchesClosedForm,
+                               testStandardNeoHookeFirstDerivativeMatchesNumericalDifferentiation,
+                               testStandardNeoHookeSecondDerivativeMatchesNumericalDifferentiation,
+                               testStandardNeoHookeThirdDerivativeMatchesNumericalDifferentiation };
 
   executeTestsAndCollectExceptions( tests );
   return 0;

--- a/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainViscoelasticity.cpp
+++ b/modules/core/MarmotFiniteStrainMechanicsCore/test/TestMarmotFiniteStrainViscoelasticity.cpp
@@ -62,6 +62,48 @@ void testCreateMaxwellPropertiesTwo()
                            MakeString() << __PRETTY_FUNCTION__ << ": sumGamma should be 0.5" );
 }
 
+// createMaxwellProperties must reject a negative element count
+void testCreateMaxwellPropertiesThrowsForNegativeCount()
+{
+  bool threw = false;
+  try {
+    createMaxwellProperties( -1, nullptr );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, MakeString() << __PRETTY_FUNCTION__ << ": negative nMaxwell must throw" );
+}
+
+// createMaxwellProperties must reject a null pairVector when nMaxwell > 0
+void testCreateMaxwellPropertiesThrowsForNullPairVectorWithPositiveCount()
+{
+  bool threw = false;
+  try {
+    createMaxwellProperties( 1, nullptr );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw,
+                           MakeString() << __PRETTY_FUNCTION__
+                                        << ": null gammaTauPairVector with nMaxwell > 0 must throw" );
+}
+
+// createMaxwellProperties must reject a negative relaxation time
+void testCreateMaxwellPropertiesThrowsForNegativeTau()
+{
+  const double pairs[2] = { 0.3, -1.0 };
+  bool         threw    = false;
+  try {
+    createMaxwellProperties( 1, pairs );
+  }
+  catch ( const std::invalid_argument& ) {
+    threw = true;
+  }
+  throwExceptionOnFailure( threw, MakeString() << __PRETTY_FUNCTION__ << ": negative tau must throw" );
+}
+
 // ---------------------------------------------------------------------------
 // Helper: compute Maxwell alpha and beta analytically
 // ---------------------------------------------------------------------------
@@ -408,6 +450,64 @@ void testSimoOverloadTwoElements()
                            MakeString() << __PRETTY_FUNCTION__ << ": tangent(0,0,0,0) with two elements failed" );
 }
 
+// Element with a near-zero relaxation time must be skipped entirely (continue branch)
+void testSimoOverloadSkipsNearZeroTau()
+{
+  const double      pairs[4] = { 0.3, 1e-13, 0.2, 5.0 }; // element 1: tau ~ 0 -> must be skipped
+  MaxwellProperties props    = createMaxwellProperties( 2, pairs );
+
+  const double dT = 1.0;
+  double       alpha2, beta2;
+  computeAlphaBeta( 0.2, 5.0, dT, alpha2, beta2 );
+
+  Tensor33d   stress = Spatial3D::I;
+  Tensor3333d tangent( 1.0 );
+  Tensor33d   dStress = Spatial3D::I;
+
+  std::array< double, 18 > stateVars{};
+
+  evaluateGeneralizedMaxwellModel( stress, tangent, dStress, dT, props, stateVars.data() );
+
+  // the skipped element's state vars must never be written
+  for ( int i = 0; i < 9; ++i )
+    throwExceptionOnFailure( checkIfEqual( stateVars[i], 0.0 ),
+                             MakeString() << __PRETTY_FUNCTION__ << ": skipped element's state var[" << i
+                                          << "] must remain untouched" );
+
+  const double sumGamma       = 0.3 + 0.2;
+  const double expectedStress = ( 1.0 - sumGamma ) + beta2;
+  throwExceptionOnFailure( checkIfEqual( stress( 0, 0 ), expectedStress, 1e-12 ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": stress(0,0) with a skipped element failed" );
+
+  const double expectedTangent = ( 1.0 - sumGamma + beta2 ); // tangent_in = 1.0 everywhere
+  throwExceptionOnFailure( checkIfEqual( tangent( 0, 0, 0, 0 ), expectedTangent, 1e-12 ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": tangent(0,0,0,0) with a skipped element failed" );
+}
+
+// dT/tau below 1e-6 must use the Taylor-expansion branch for alpha/beta
+void testSimoOverloadTaylorApproximation()
+{
+  const double      pairs[2] = { 0.3, 1.0 };
+  MaxwellProperties props    = createMaxwellProperties( 1, pairs );
+
+  const double dT_small = 1e-8; // dT/tau = 1e-8 << 1e-6 -> Taylor branch
+
+  Tensor33d   stress = Spatial3D::I;
+  Tensor3333d tangent( 1.0 );
+  Tensor33d   dStress = Spatial3D::I;
+
+  std::array< double, 9 > stateVars{};
+
+  evaluateGeneralizedMaxwellModel( stress, tangent, dStress, dT_small, props, stateVars.data() );
+
+  double alpha_ref, beta_ref;
+  computeAlphaBeta( 0.3, 1.0, dT_small, alpha_ref, beta_ref );
+
+  const double expectedFactor = ( 1.0 - 0.3 ) + beta_ref;
+  throwExceptionOnFailure( checkIfEqual( stress( 0, 0 ), expectedFactor, 1e-10 ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": Taylor branch stress(0,0) failed" );
+}
+
 // Verify that the Simo overload and template overload give the same stress result
 void testSimoAndTemplateOverloadConsistency()
 {
@@ -610,6 +710,112 @@ void testLiuOverloadNonZeroDTangentDDeformation()
                            MakeString() << __PRETTY_FUNCTION__ << ": tangent(0,0,0,0) with dStress=0 failed" );
 }
 
+// nMaxwell=0: no change to stress or tangent
+void testLiuOverloadNoOp()
+{
+  MaxwellProperties props = createMaxwellProperties( 0, nullptr );
+
+  Tensor33d stress( 0.0 );
+  stress( 0, 0 ) = 5.0;
+  stress( 1, 1 ) = 3.0;
+
+  Tensor3333d tangent( 1.0 );
+  Tensor3333d initialCompliance( 2.0 );
+
+  Tensor33d     dStress( 0.0 );
+  Tensor333333d dTangent_dDeformation( 1.0 );
+
+  Tensor33d   stressOrig  = stress;
+  Tensor3333d tangentOrig = tangent;
+
+  evaluateGeneralizedMaxwellModel( stress,
+                                   tangent,
+                                   dTangent_dDeformation,
+                                   initialCompliance,
+                                   dStress,
+                                   1.0,
+                                   props,
+                                   nullptr );
+
+  throwExceptionOnFailure( checkIfEqual( stress, stressOrig ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": nMaxwell=0 should leave stress unchanged" );
+  throwExceptionOnFailure( checkIfEqual( tangent, tangentOrig ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": nMaxwell=0 should leave tangent unchanged" );
+}
+
+// Element with a near-zero relaxation time must be skipped entirely (continue branch)
+void testLiuOverloadSkipsNearZeroTau()
+{
+  const double      pairs[4] = { 0.3, 1e-13, 0.2, 5.0 }; // element 1: tau ~ 0 -> must be skipped
+  MaxwellProperties props    = createMaxwellProperties( 2, pairs );
+
+  const double dT = 1.0;
+  double       alpha2, beta2;
+  computeAlphaBeta( 0.2, 5.0, dT, alpha2, beta2 );
+
+  const double K = 10000.0, G = 5000.0;
+  Tensor3333d  C    = makeIsotropicTangent( K, G );
+  Tensor3333d  Cinv = makeIsotropicCompliance( K, G );
+
+  Tensor33d     stress  = Spatial3D::I;
+  Tensor33d     dStress = Spatial3D::I;
+  Tensor3333d   tangent = C;
+  Tensor333333d dTangent_dDeformation( 0.0 );
+
+  std::array< double, 18 > stateVars{};
+
+  evaluateGeneralizedMaxwellModel( stress, tangent, dTangent_dDeformation, Cinv, dStress, dT, props, stateVars.data() );
+
+  for ( int i = 0; i < 9; ++i )
+    throwExceptionOnFailure( checkIfEqual( stateVars[i], 0.0 ),
+                             MakeString() << __PRETTY_FUNCTION__ << ": skipped element's state var[" << i
+                                          << "] must remain untouched" );
+
+  // Q_n2 = 0 -> Q_np2 = beta2 * dStress = beta2 * I; since C:Cinv = ISymm (identity on symmetric
+  // tensors, see testIsotropicInverseConsistency), H_np2 : C = Q_np2, so stress gets exactly
+  // beta2*I on top of the elastic scaling.
+  const double sumGamma       = 0.3 + 0.2;
+  const double expectedStress = ( 1.0 - sumGamma ) + beta2;
+  throwExceptionOnFailure( checkIfEqual( stress( 0, 0 ), expectedStress, 1e-8 ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": stress(0,0) with a skipped element failed" );
+}
+
+// dT/tau below 1e-6 must use the Taylor-expansion branch for alpha/beta
+void testLiuOverloadTaylorApproximation()
+{
+  const double      pairs[2] = { 0.3, 1.0 };
+  MaxwellProperties props    = createMaxwellProperties( 1, pairs );
+
+  const double dT_small = 1e-8; // dT/tau = 1e-8 << 1e-6 -> Taylor branch
+
+  const double K = 10000.0, G = 5000.0;
+  Tensor3333d  C    = makeIsotropicTangent( K, G );
+  Tensor3333d  Cinv = makeIsotropicCompliance( K, G );
+
+  Tensor33d     stress  = Spatial3D::I;
+  Tensor33d     dStress = Spatial3D::I;
+  Tensor3333d   tangent = C;
+  Tensor333333d dTangent_dDeformation( 0.0 );
+
+  std::array< double, 9 > stateVars{};
+
+  evaluateGeneralizedMaxwellModel( stress,
+                                   tangent,
+                                   dTangent_dDeformation,
+                                   Cinv,
+                                   dStress,
+                                   dT_small,
+                                   props,
+                                   stateVars.data() );
+
+  double alpha_ref, beta_ref;
+  computeAlphaBeta( 0.3, 1.0, dT_small, alpha_ref, beta_ref );
+
+  const double expectedFactor = ( 1.0 - 0.3 ) + beta_ref;
+  throwExceptionOnFailure( checkIfEqual( stress( 0, 0 ), expectedFactor, 1e-8 ),
+                           MakeString() << __PRETTY_FUNCTION__ << ": Taylor branch stress(0,0) failed" );
+}
+
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
@@ -620,6 +826,9 @@ int main()
     testCreateMaxwellPropertiesEmpty,
     testCreateMaxwellPropertiesSingle,
     testCreateMaxwellPropertiesTwo,
+    testCreateMaxwellPropertiesThrowsForNegativeCount,
+    testCreateMaxwellPropertiesThrowsForNullPairVectorWithPositiveCount,
+    testCreateMaxwellPropertiesThrowsForNegativeTau,
 
     // Template overload (no tangent)
     testTemplateOverloadNoOp,
@@ -633,13 +842,18 @@ int main()
     testSimoOverloadNoOp,
     testSimoOverloadSingleElementFromZero,
     testSimoOverloadSingleElementFromNonZeroState,
+    testSimoOverloadSkipsNearZeroTau,
+    testSimoOverloadTaylorApproximation,
     testSimoOverloadTwoElements,
     testSimoAndTemplateOverloadConsistency,
 
     // Liu et al. overload (with compliance and dTangent/dDeformation)
     testIsotropicInverseConsistency,
+    testLiuOverloadNoOp,
     testLiuOverloadMatchesSimo,
     testLiuOverloadNonZeroDTangentDDeformation,
+    testLiuOverloadSkipsNearZeroTau,
+    testLiuOverloadTaylorApproximation,
   };
 
   executeTestsAndCollectExceptions( tests );


### PR DESCRIPTION
## Summary

Continues the coverage reaudit of `modules/core` (see #95 for the `MarmotMathCore`/`MarmotMechanicsCore` half), this time in `MarmotFiniteStrainMechanicsCore`.

### `MarmotEnergyDensityFunctions.cpp`

`ThirdOrderDerived::standardNeoHooke` — the energy density and its 1st/2nd/3rd derivatives w.r.t. C for the `NeoHooke` hyperelastic base used by `CompressibleFiniteStrainLinearViscoelasticity` — had **zero** test coverage (0/25 lines). Added tests verifying:
- the energy value against its closed form
- the first derivative via central-difference numerical differentiation
- the second and third derivatives via **directional** bilinear/trilinear contraction against symmetric perturbation directions, rather than isolating individual `(i,j,k,l)` tensor components

That last point is worth calling out: my first attempt at this test isolated single tensor components with single-entry (and then paired-entry) perturbations of C, and got what looked like real, large discrepancies (up to a clean factor of 2, and worse for the third derivative). Digging in, `d2Psi_dC2`/`d3Psi_dC3` are only physically meaningful when contracted against a *symmetric* C direction — exactly how they're always used in practice, since C is the right Cauchy-Green tensor — and the hand-coded second-derivative term (`dInvCt_dC`) deliberately symmetrizes over the differentiated index pair to match that. Isolating single asymmetric components sidesteps that convention and manufactures a false sense of a bug. Once verified via directional contraction (the same style of check used elsewhere in this codebase for tangent verification), all four returned quantities are mutually consistent — no bug here, just a test-construction lesson worth documenting for whoever touches this function next.

### `MarmotFiniteStrainViscoelasticity.cpp`

Added coverage for:
- `createMaxwellProperties`'s three input-validation throws (negative element count, null pair vector with a positive count, negative relaxation time)
- the Liu-et-al. overload's `nMaxwell==0` no-op (previously only the other two overloads' no-op was tested)
- for both the Simo and Liu overloads: the near-zero relaxation time skip (an element with `tau ~ 0` must be skipped entirely, its state vars left untouched) and the small-`dT/tau` Taylor-expansion branch for alpha/beta

### Confirmed non-issues

`MarmotFiniteStrainPlasticity.cpp`'s one remaining "missed" line, and one line in `MarmotEnergyDensityFunctions.cpp`, are confirmed via annotated `gcov` output to be the same multi-line-statement attribution artifact seen elsewhere in this coverage series: the first line of a multi-line return/assignment shows 0 hits while its continuation line shows the real, non-zero hit count.

## Test plan

- [x] All 48 local `ctest` targets pass
- [x] Verified the directional-contraction methodology against the (initially-suspicious) component-isolation failures, confirming no actual bug in `standardNeoHooke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxcHVAYFXUwSpTodLHrhDA